### PR TITLE
fix: HS-158: TrustPay ApplePay user gesture fix for MWeb

### DIFF
--- a/src/GlobalVars.res
+++ b/src/GlobalVars.res
@@ -2,6 +2,7 @@
 @val external repoVersion: string = "repoVersion"
 @val external repoPublicPath: string = "publicPath"
 @val external backendEndPoint: string = "backendEndPoint"
+@val external confirmEndPoint: string = "confirmEndPoint"
 @val external sdkUrl: string = "sdkUrl"
 @val external logEndpoint: string = "logEndpoint"
 @val external sentryDSN: string = "sentryDSN"

--- a/src/Utilities/ApiEndpoint.res
+++ b/src/Utilities/ApiEndpoint.res
@@ -8,15 +8,16 @@ let setApiEndPoint = str => {
   apiEndPoint := Some(str)
 }
 
-let getApiEndPoint = (~publishableKey="", ()) => {
+let getApiEndPoint = (~publishableKey="", ~isConfirmCall=false, ()) => {
   let testMode = publishableKey->Js.String2.startsWith("pk_snd_")
   switch apiEndPoint.contents {
   | Some(str) => str
   | None =>
+    let backendEndPoint = isConfirmCall ? GlobalVars.confirmEndPoint : GlobalVars.backendEndPoint
     if GlobalVars.isProd {
-      testMode ? "https://sandbox.hyperswitch.io" : {GlobalVars.backendEndPoint}
+      testMode ? "https://sandbox.hyperswitch.io" : backendEndPoint
     } else {
-      {GlobalVars.backendEndPoint}
+      backendEndPoint
     }
   }
 }

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -496,7 +496,11 @@ let usePaymentIntent = (optLogger: option<OrcaLogger.loggerMake>, paymentType: p
           returnUrlArr,
           manual_retry,
         ])
-      let endpoint = ApiEndpoint.getApiEndPoint(~publishableKey=confirmParam.publishableKey, ())
+      let endpoint = ApiEndpoint.getApiEndPoint(
+        ~publishableKey=confirmParam.publishableKey,
+        ~isConfirmCall=true,
+        (),
+      )
       let uri = `${endpoint}/payments/${paymentIntentID}/confirm`
       let fetchMethod = Fetch.Post
       let loggerPayload = body->Js.Dict.fromArray->maskPayload

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,19 +27,28 @@ let sdkUrl =
   sdkEnv === "prod"
     ? "https://checkout.hyperswitch.io"
     : sdkEnv === "sandbox"
-    ? "https://beta.hyperswitch.io"
-    : sdkEnv === "integ"
-    ? "https://dev.hyperswitch.io"
-    : "http://localhost:9050";
+      ? "https://beta.hyperswitch.io"
+      : sdkEnv === "integ"
+        ? "https://dev.hyperswitch.io"
+        : "http://localhost:9050";
 
 let backendEndPoint =
   sdkEnv === "prod"
     ? "https://checkout.hyperswitch.io/api"
     : sdkEnv === "sandbox"
-    ? "https://beta.hyperswitch.io/api"
-    : sdkEnv === "integ"
-    ? "https://integ-api.hyperswitch.io"
-    : "https://beta.hyperswitch.io/api";
+      ? "https://beta.hyperswitch.io/api"
+      : sdkEnv === "integ"
+        ? "https://integ-api.hyperswitch.io"
+        : "https://beta.hyperswitch.io/api";
+
+let confirmEndPoint =
+  sdkEnv === "prod"
+    ? "https://api.hyperswitch.io"
+    : sdkEnv === "sandbox"
+      ? "https://sandbox.hyperswitch.io"
+      : sdkEnv === "integ"
+        ? "https://integ-api.hyperswitch.io"
+        : "https://sandbox.hyperswitch.io";
 
 let logEndpoint =
   sdkEnv === "prod"
@@ -89,6 +98,7 @@ module.exports = (publicPath = "auto") => {
         publicPath: JSON.stringify(repoPublicPath),
         sdkUrl: JSON.stringify(sdkUrl),
         backendEndPoint: JSON.stringify(backendEndPoint),
+        confirmEndPoint: JSON.stringify(confirmEndPoint),
         logEndpoint: JSON.stringify(logEndpoint),
         sentryDSN: JSON.stringify(process.env.SENTRY_DSN),
         sentryScriptUrl: JSON.stringify(process.env.SENTRY_SCRIPT_URL),


### PR DESCRIPTION
**Problem Description -** Apple Pay Via TrustPay Modal was not opening in case of MWeb intermittently due to the increase in latency in /confirm Api call after CDN changes. ApplePay was throwing user gesture handler error

**Solution -** Removed CDN for confirm call