### PR TITLE
fix: HS-174: Removed console warning for using link with document and Batcher error for Recoil

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -9,9 +9,13 @@ let make = () => {
 
   let logger = React.useMemo0(() => {
     let log = OrcaLogger.make()
-    setLoggerState(._ => log)
     log
   })
+
+  React.useEffect1(()=>{
+    setLoggerState(._=>logger)
+    None
+  },[logger])
 
   let renderFullscreen = {
     switch fullscreenMode {

--- a/src/orca-loader/Hyper.res
+++ b/src/orca-loader/Hyper.res
@@ -43,7 +43,6 @@ let preloadFile = (~type_, ~href=``, ()) => {
 }
 
 let preloader = () => {
-  preloadFile(~type_="document", ~href=`${ApiEndpoint.sdkDomainUrl}/`, ())
   preloadFile(~type_="script", ~href=`${ApiEndpoint.sdkDomainUrl}/app.js`, ())
   preloadFile(~type_="style", ~href=`${ApiEndpoint.sdkDomainUrl}/app.css`, ())
   preloadFile(~type_="image", ~href=`${ApiEndpoint.sdkDomainUrl}/icons/orca.svg`, ())


### PR DESCRIPTION
Removed console warning for using link with "as" as  document which wasnt loading up anything  and Batcher error for Recoil occurring inside a useMemo