### PR TITLE
feat: HS-132: Passing Card Holder Name in Saved Cards Flow

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -73,7 +73,7 @@ let make = (
       }}
       <RenderIf condition={list.payment_methods->Js.Array.length !== 0}>
         <DynamicFields
-          paymentType list paymentMethod="card" paymentMethodType="debit" setRequiredFieldsBody isSavedCardFlow=true
+          paymentType list paymentMethod="card" paymentMethodType="debit" setRequiredFieldsBody isSavedCardFlow=true savedCards=savedMethods
         />
       </RenderIf>
       <RenderIf condition={!showFeilds}>

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -222,8 +222,7 @@ let make = (
           ->Js.Json.object_
           ->OrcaUtils.flattenObject(true)
           ->OrcaUtils.mergeTwoFlattenedJsonDicts(requiredFieldsBody)
-          ->OrcaUtils.getArrayOfTupleFromDict
-          ->Js.Array2.filter(((key, _)) => key !== "payment_method_data"),
+          ->OrcaUtils.getArrayOfTupleFromDict,
           ~confirmParam=confirm.confirmParams,
           ~handleUserError=false,
           (),

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -528,14 +528,14 @@ let getRequiredFieldsFromJson = dict => {
 
 let dynamicFieldsEnabledPaymentMethods = ["crypto_currency", "debit", "credit", "blik"]
 
-let getPaymentMethodFields = (paymentMethod, requiredFields, ~isSavedCardFlow=false, ()) => {
+let getPaymentMethodFields = (paymentMethod, requiredFields, ~isSavedCardFlow=false, ~isAllStoredCardsHaveName=false, ()) => {
   let requiredFieldsArr =
     requiredFields
     ->Utils.getDictFromJson
     ->Js.Dict.values
     ->Js.Array2.map(item => {
       let val = item->Utils.getDictFromJson->getRequiredFieldsFromJson
-      if isSavedCardFlow && val.display_name === "card_holder_name" {
+      if isSavedCardFlow && val.display_name === "card_holder_name" && isAllStoredCardsHaveName {
         None
       } else {
         val.field_type

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -856,3 +856,15 @@ let itemToObjMapper = (dict, logger) => {
 }
 
 type loadType = Loading | Loaded(Js.Json.t) | SemiLoaded | LoadError(Js.Json.t)
+
+let getIsAllStoredCardsHaveName = (savedCards: array<customerMethods>) => {
+  savedCards
+  ->Js.Array2.filter(savedCard => {
+    switch savedCard.card.cardHolderName {
+    | None
+    | Some("") => false
+    | _ => true
+    }
+  })
+  ->Belt.Array.length === savedCards->Belt.Array.length
+}


### PR DESCRIPTION
**Problem Description -** Required to pass card holder name in confirm call for saved cards

**Solution -** Backend will check whether the stored card has card_holder_name present in the locker. If it is not there, in that scenario it will check whether it is being passed in the confirm body.

Therefore, added check to render card holder name and pass in the confirm call if the following condition pass -

- [x] Saved Cards Flow
- [x] Card holder name is being passed in the dynamic fields
- [x] Atleast one saved card does not have card_holder_name

Sample Confirm Request -

```
payment_method_data:
  { card_token:
    { card_holder_name: "Arush Kapoor"
    }
  }
```

Backend Pr - https://github.com/juspay/hyperswitch/pull/2982