### PR TITLE
fix: HS-148: Changed Flow for Surcharge

### DIFF
--- a/src/Components/Surcharge.res
+++ b/src/Components/Surcharge.res
@@ -12,38 +12,19 @@ let make = (~list, ~paymentMethod, ~paymentMethodType, ~cardBrand=CardUtils.NOTF
 
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
 
-  let getSurchargeValue = (surchargeDetails: PaymentMethodsRecord.surchargeDetails) => {
-    switch surchargeDetails.surcharge.value {
-    | VAL(val) => val
-    | PERCENTAGE(percent) => percent.percentage
-    }->Js.Float.toString
-  }
-
   let getMessage = (surchargeDetails: PaymentMethodsRecord.surchargeDetails) => {
-    let surchargeType = surchargeDetails.surcharge.surchargeType
-    let surchargeValue = surchargeDetails->getSurchargeValue
+    let surchargeValue = surchargeDetails.displayTotalSurchargeAmount->Js.Float.toString
 
     let getLocaleStrForSurcharge = (cardLocale, altPaymentLocale) => {
       paymentMethod === "card" ? cardLocale(surchargeValue) : altPaymentLocale(surchargeValue)
     }
 
-    switch surchargeType {
-    | FIXED =>
-      Some(
-        getLocaleStrForSurcharge(
-          localeString.surchargeMsgAmountForCard,
-          localeString.surchargeMsgAmount,
-        ),
-      )
-    | RATE =>
-      Some(
-        getLocaleStrForSurcharge(
-          localeString.surchargeMsgPercentageForCard,
-          localeString.surchargeMsgPercentage,
-        ),
-      )
-    | NONE => None
-    }
+    Some(
+      getLocaleStrForSurcharge(
+        localeString.surchargeMsgAmountForCard,
+        localeString.surchargeMsgAmount,
+      ),
+    )
   }
 
   let getCardNetwork = (paymentMethodType: PaymentMethodsRecord.paymentMethodTypes) => {
@@ -65,8 +46,8 @@ let make = (~list, ~paymentMethod, ~paymentMethodType, ~cardBrand=CardUtils.NOTF
 
         switch (debitCardNetwork.surcharge_details, creditCardNetwork.surcharge_details) {
         | (Some(debitSurchargeDetails), Some(creditSurchargeDetails)) =>
-          let creditCardSurcharge = creditSurchargeDetails->getSurchargeValue
-          let debitCardSurcharge = debitSurchargeDetails->getSurchargeValue
+          let creditCardSurcharge = creditSurchargeDetails.displayTotalSurchargeAmount
+          let debitCardSurcharge = debitSurchargeDetails.displayTotalSurchargeAmount
 
           if creditCardSurcharge >= debitCardSurcharge {
             creditSurchargeDetails->getMessage

--- a/src/LocaleString.res
+++ b/src/LocaleString.res
@@ -43,9 +43,7 @@ type localeStrings = {
   enterValidDetailsText: string,
   card: string,
   surchargeMsgAmount: string => string,
-  surchargeMsgPercentage: string => string,
   surchargeMsgAmountForCard: string => string,
-  surchargeMsgPercentageForCard: string => string,
   billingNameLabel: string,
   billingNamePlaceholder: string,
   cardHolderName: string,
@@ -99,11 +97,8 @@ let defaultLocale = {
   enterValidDetailsText: "Please enter valid details",
   card: "Card",
   surchargeMsgAmount: str => `A surcharge amount of ${str} will be applied for this transaction`,
-  surchargeMsgPercentage: str => `A surcharge of ${str}% will be applied for this transaction`,
   surchargeMsgAmountForCard: str =>
     `A surcharge amount of upto ${str} will be applied for this transaction`,
-  surchargeMsgPercentageForCard: str =>
-    `A surcharge of upto ${str}% will be applied for this transaction`,
   billingNameLabel: "Billing name",
   billingNamePlaceholder: "First and last name",
   cardHolderName: "Card Holder Name",
@@ -159,11 +154,8 @@ let localeStrings = [
     enterValidDetailsText: "Please enter valid details",
     card: "Card",
     surchargeMsgAmount: str => `A surcharge amount of ${str} will be applied for this transaction`,
-    surchargeMsgPercentage: str => `A surcharge of ${str}% will be applied for this transaction`,
     surchargeMsgAmountForCard: str =>
       `A surcharge amount of upto ${str} will be applied for this transaction`,
-    surchargeMsgPercentageForCard: str =>
-      `A surcharge of upto ${str}% will be applied for this transaction`,
     billingNameLabel: "Billing name",
     billingNamePlaceholder: "First and last name",
     cardHolderName: "Card Holder Name",
@@ -216,11 +208,8 @@ let localeStrings = [
     enterValidDetailsText: `יש להזין פרטים תקינים`,
     card: `כרטיס`,
     surchargeMsgAmount: str => `סכום היטל של ${str} יוחל עבור עסקה זו`,
-    surchargeMsgPercentage: str => `תוספת של ${str}% תחול עבור עסקה זו`,
     surchargeMsgAmountForCard: str =>
       `סכום היטל של עד ${str} יחול עבור עסקה זו`,
-    surchargeMsgPercentageForCard: str =>
-      `תוספת של עד ${str}% תחול על עסקה זו`,
     billingNameLabel: `שם החיוב`,
     billingNamePlaceholder: `שם פרטי ושם משפחה`,
     cardHolderName: `שם בעל הכרטיס`,
@@ -274,12 +263,8 @@ let localeStrings = [
     card: `Carte`,
     surchargeMsgAmount: str =>
       `Un montant supplémentaire d'${str} sera appliqué pour cette transaction`,
-    surchargeMsgPercentage: str =>
-      `Un supplément de ${str}% sera appliqué pour cette transaction`,
     surchargeMsgAmountForCard: str =>
       `Un montant supplémentaire allant jusqu'à ${str} sera appliqué pour cette transaction.`,
-    surchargeMsgPercentageForCard: str =>
-      `Un supplément allant jusqu'à ${str}% sera appliqué pour cette transaction`,
     billingNameLabel: `Nom de facturation`,
     billingNamePlaceholder: `Prénom et nom de famille`,
     cardHolderName: `Nom du titulaire`,
@@ -332,11 +317,8 @@ let localeStrings = [
     enterValidDetailsText: "Please enter valid details",
     card: "Card",
     surchargeMsgAmount: str => `A surcharge amount of ${str} will be applied for this transaction`,
-    surchargeMsgPercentage: str => `A surcharge of ${str}% will be applied for this transaction`,
     surchargeMsgAmountForCard: str =>
       `A surcharge amount of upto ${str} will be applied for this transaction`,
-    surchargeMsgPercentageForCard: str =>
-      `A surcharge of upto ${str}% will be applied for this transaction`,
     billingNameLabel: "Billing name",
     billingNamePlaceholder: "First and last name",
     cardHolderName: "Card Holder Name",
@@ -390,12 +372,8 @@ let localeStrings = [
     card: `بطاقة`,
     surchargeMsgAmount: str =>
       `سيتم تطبيق مبلغ إضافي من ${str} على هذه المعاملة`,
-    surchargeMsgPercentage: str =>
-      `سيتم تطبيق رسوم إضافية بقيمة ${str}% على هذه المعاملة`,
     surchargeMsgAmountForCard: str =>
       `سيتم تطبيق مبلغ إضافي يصل إلى ${str} على هذه المعاملة`,
-    surchargeMsgPercentageForCard: str =>
-      `سيتم تطبيق رسوم إضافية تصل إلى ${str}% على هذه المعاملة`,
     billingNameLabel: `اسم الفواتير`,
     billingNamePlaceholder: `الاسم الأول والاسم الأخير`,
     cardHolderName: `إسم صاحب البطاقة`,
@@ -448,12 +426,8 @@ let localeStrings = [
     enterValidDetailsText: `有効な詳細を入力してください`,
     card: `カード`,
     surchargeMsgAmount: str => `この取引には ${str} の追加料金が適用されます`,
-    surchargeMsgPercentage: str =>
-      `この取引には ${str}% の追加料金が適用されます`,
     surchargeMsgAmountForCard: str =>
       `この取引には ${str} までの追加料金が適用されます`,
-    surchargeMsgPercentageForCard: str =>
-      `この取引には ${str}% までの追加料金が適用されます`,
     billingNameLabel: `課金名`,
     billingNamePlaceholder: `名前と苗字`,
     cardHolderName: `クレジットカード名義人氏名`,
@@ -507,11 +481,8 @@ let localeStrings = [
     card: `Karte`,
     surchargeMsgAmount: str =>
       `Für diese Transaktion wird ein Zuschlag in Höhe von ${str} erhoben`,
-    surchargeMsgPercentage: str => `Für diese Transaktion wird ein Aufschlag von ${str}% erhoben`,
     surchargeMsgAmountForCard: str =>
       `Für diese Transaktion wird ein Zuschlagsbetrag von bis zu ${str} erhoben`,
-    surchargeMsgPercentageForCard: str =>
-      `Für diese Transaktion wird ein Zuschlag von bis zu ${str}% erhoben`,
     billingNameLabel: `Abrechnungsname`,
     billingNamePlaceholder: `Vor-und Nachname`,
     cardHolderName: `Name des Karteninhabers`,

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -43,17 +43,7 @@ type bankNames = {
   eligible_connectors: array<string>,
 }
 
-type surchargeType = FIXED | RATE | NONE
-type surchargeValue =
-  | VAL(float)
-  | PERCENTAGE({percentage: float})
-
-type surcharge = {
-  surchargeType: surchargeType,
-  value: surchargeValue,
-}
-
-type surchargeDetails = {surcharge: surcharge}
+type surchargeDetails = {displayTotalSurchargeAmount: float}
 
 type paymentMethodsContent = {
   paymentMethodName: string,
@@ -699,54 +689,25 @@ let getPaymentExperience = (dict, str) => {
   })
 }
 
-let getSurchargeTypeFromStr = str => {
-  switch str->Js.String2.toLowerCase {
-  | "fixed" => FIXED
-  | "rate" => RATE
-  | _ => NONE
-  }
-}
-
 let getSurchargeDetails = dict => {
   let surchargDetails =
     dict
     ->Js.Dict.get("surcharge_details")
     ->Belt.Option.flatMap(Js.Json.decodeObject)
-    ->Belt.Option.flatMap(x => x->Js.Dict.get("surcharge"))
-    ->Belt.Option.flatMap(Js.Json.decodeObject)
     ->Belt.Option.getWithDefault(Js.Dict.empty())
 
-  let surchargeType = surchargDetails->Utils.getString("type", "none")->getSurchargeTypeFromStr
-  let getSurchargeVal = switch surchargeType {
-  | RATE =>
-    PERCENTAGE({
-      percentage: surchargDetails
-      ->Js.Dict.get("value")
-      ->Belt.Option.flatMap(Js.Json.decodeObject)
-      ->Belt.Option.flatMap(x => x->Js.Dict.get("percentage"))
-      ->Belt.Option.flatMap(Js.Json.decodeNumber)
-      ->Belt.Option.getWithDefault(0.0),
-    })
-  | FIXED
-  | _ =>
-    VAL(
-      surchargDetails
-      ->Js.Dict.get("value")
-      ->Belt.Option.flatMap(Js.Json.decodeNumber)
-      ->Belt.Option.getWithDefault(0.0),
-    )
-  }
+  let displayTotalSurchargeAmount =
+    surchargDetails
+    ->Js.Dict.get("display_total_surcharge_amount")
+    ->Belt.Option.flatMap(Js.Json.decodeNumber)
+    ->Belt.Option.getWithDefault(0.0)
 
-  switch surchargeType {
-  | FIXED
-  | RATE =>
+  if displayTotalSurchargeAmount !== 0.0 {
     Some({
-      surcharge: {
-        surchargeType: surchargeType,
-        value: getSurchargeVal,
-      },
+      displayTotalSurchargeAmount,
     })
-  | _ => None
+  } else {
+    None
   }
 }
 


### PR DESCRIPTION
**Problem Description -** Changed Surcharge Flow

**Solution -** Instead of taking surcharge from value inside surcharge object, now it will be taken from surcharge_amount and tax_on_surcharge_amount.

Surcharge Object - 

```
"surcharge_details": {
  "surcharge": {
    "type": "fixed",
    "value": 123,
  },
  "tax_on_surcharge": {
    "percentage": 5.09
  },
  "display_surcharge_amount": 1.23,
  "display_tax_on_surcharge_amount": 0.07,
  "display_total_surcharge_amount": 1.30,
  "display_final_amount": 66.7
},
```