### PR TITLE
fix: HS-175: Improved prompts and endpoint fix

### DIFF
--- a/Hyperswitch-React-Demo-App/promptScript.js
+++ b/Hyperswitch-React-Demo-App/promptScript.js
@@ -1,22 +1,15 @@
 const fs = require("fs");
 const prompt = require("prompt-sync")({ sigint: true });
-const publishableKey = prompt("Publishable Key : ");
-const secretKey = prompt("Secret Key : ");
-const serverURL = prompt("Self-hosted Hyperswitch Server URL : ");
-const clientURL = prompt("Self-hosted Hyperswitch Client URL : ");
-
-const appServerURL = prompt("Application Server URL : ");
-const appClientURL = prompt("Application Client URL : ");
 
 const envPath = "./.env";
 
 const obj = {
-  HYPERSWITCH_PUBLISHABLE_KEY: publishableKey,
-  HYPERSWITCH_SECRET_KEY: secretKey,
-  HYPERSWITCH_SERVER_URL: serverURL,
-  HYPERSWITCH_CLIENT_URL: clientURL,
-  SELF_SERVER_URL: appServerURL,
-  SELF_CLIENT_URL: appClientURL,
+  HYPERSWITCH_PUBLISHABLE_KEY: "Publishable Key",
+  HYPERSWITCH_SECRET_KEY: "Secret Key",
+  HYPERSWITCH_SERVER_URL: "Self-hosted Hyperswitch Server URL (URL of your Hyperswitch Backend)",
+  HYPERSWITCH_CLIENT_URL: "Self-hosted Hyperswitch Client URL (URL of your Hyperswitch SDK)",
+  SELF_SERVER_URL: "Application Server URL (URL of your node server)",
+  SELF_CLIENT_URL: "Application Client URL (URL where your application is running)",
 };
 
 function initializeValues(filePath, keyValuePairs) {
@@ -32,11 +25,15 @@ function initializeValues(filePath, keyValuePairs) {
       let index = lines.findIndex((line) => line.startsWith(`${key}=`));
 
       if (index !== -1) {
-        // If the key exists, update its value
-        lines[index] = `${key}="${value}"`;
+        if (lines[index] === `${key}=` || lines[index] === `${key}=""`) {
+          const promptVal = prompt(`${value} : `)
+          // If the key exists, and has not been updated once, update its value
+          lines[index] = `${key}="${promptVal}"`;
+        }
       } else {
+        const promptVal = prompt(`${value} : `)
         // If the key doesn't exist, add a new line with the key-value pair
-        lines.push(`${key}="${value}"`);
+        lines.push(`${key}="${promptVal}"`);
       }
     });
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ To see your Web Client functioning you can run the command below, this will open
 npm run start:playground
 ```
 
+### About Env Configs
+
+For ease of development and deployment there are configs in /Hyperswitch-react-demo-app/.env
+
+- `HYPERSWITCH_PUBLISHABLE_KEY` - Publishable key of your Hyperswitch Account
+- `HYPERSWITCH_SECRET_KEY` - Api key of your Hyperswitch Account
+- `HYPERSWITCH_SERVER_URL` - URL of your hosted Hyperswitch Backend server
+- `HYPERSWITCH_CLIENT_URL` - URL of your hosted Hyperswitch SDK
+- `SELF_SERVER_URL` - URL of your node server (/Hyperswitch-react-demo-app/server.js)
+- `SELF_CLIENT_URL` - URL where your application is running
+
 ### Logging
 
 Logging from the payment checkout web client is crucial for tracking and monitoring the flow of payments. It provides a transparent record of events, errors, and user interactions, aiding developers and support teams in identifying issues, debugging, and ensuring the security and reliability of payment processes. Well-implemented logging enhances traceability and facilitates a more efficient resolution of potential problems in the payment checkout experience.


### PR DESCRIPTION
**Problem Description -** OSS setup improvement

**Solution -**

- [x] Asking for prompts while running `npm run start:playground` only when they are empty
- [x] Make the  playground prompts more descriptive and understandable as well as add the explanation in the README for the configs