### PR TITLE
fix:HS-175: Build pre-running concurrently in playground

### DIFF
--- a/Hyperswitch-React-Demo-App/package.json
+++ b/Hyperswitch-React-Demo-App/package.json
@@ -23,8 +23,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "concurrently \"npm run start-client\" \"npm run start-server\"",
-    "start-client": " webpack --config webpack.dev.js && webpack serve --config webpack.dev.js",
+    "start": " webpack --config webpack.dev.js && concurrently \"npm run start-client\" \"npm run start-server\"",
+    "start-client": "webpack serve --config webpack.dev.js",
     "start-server": "node dist/server.js",
     "build": "webpack --config webpack.common.js",
     "test": "react-scripts test",


### PR DESCRIPTION
Due to start being called, frontend starts creating a bundle while the server starts to run. The server file is however consumed from the dist folder. So a prebuild is necessary before starting the playground.