### PR TITLE
fix: HS-132: Removing Dynamic Fields from rendering on SDK

### DIFF
--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -528,17 +528,31 @@ let getRequiredFieldsFromJson = dict => {
 
 let dynamicFieldsEnabledPaymentMethods = ["crypto_currency", "debit", "credit", "blik"]
 
-let getPaymentMethodFields = (paymentMethod, requiredFields, ~isSavedCardFlow=false, ~isAllStoredCardsHaveName=false, ()) => {
+let getPaymentMethodFields = (
+  paymentMethod,
+  requiredFields,
+  ~isSavedCardFlow=false,
+  ~isAllStoredCardsHaveName=false,
+  (),
+) => {
   let requiredFieldsArr =
     requiredFields
     ->Utils.getDictFromJson
     ->Js.Dict.values
     ->Js.Array2.map(item => {
-      let val = item->Utils.getDictFromJson->getRequiredFieldsFromJson
-      if isSavedCardFlow && val.display_name === "card_holder_name" && isAllStoredCardsHaveName {
-        None
+      let requiredField = item->Utils.getDictFromJson->getRequiredFieldsFromJson
+      if requiredField.value === "" {
+        if (
+          isSavedCardFlow &&
+          requiredField.display_name === "card_holder_name" &&
+          isAllStoredCardsHaveName
+        ) {
+          None
+        } else {
+          requiredField.field_type
+        }
       } else {
-        val.field_type
+        None
       }
     })
   requiredFieldsArr->Js.Array2.concat(


### PR DESCRIPTION
**Problem Description -** Removing Dynamic Fields from rendering on SDK when there is already a value for the required_field in PaymentMethodList API