### PR TITLE
fix: HS-132: Fixed Card Holder Name

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -276,6 +276,7 @@ let make = (
         | _ => acc
         }
       }, "")
+      ->Js.String2.trim
     }
 
     let setFields = (
@@ -394,8 +395,9 @@ let make = (
         }
         if (
           isSavedCardFlow &&
+          (item.field_type === BillingName || item.field_type === FullName) &&
           item.display_name === "card_holder_name" &&
-          (item.field_type === BillingName || item.field_type === FullName)
+          item.required_field === "payment_method_data.card.card_holder_name"
         ) {
           if !isAllStoredCardsHaveName {
             acc->Js.Dict.set(


### PR DESCRIPTION
1. Passing card holder name inside card_token only when it is saved card flow and required_field is `payment_method_data.card_token.card_holder_name`
2. Fixed bug in getNameValue in DynamicFields