### PR TITLE
fix: HS-183: ApplePay Payment Request to take client's country in case session sends null

### DIFF
--- a/src/Types/ApplePayTypes.res
+++ b/src/Types/ApplePayTypes.res
@@ -63,8 +63,8 @@ let jsonToPaymentRequestDataType: Js.Dict.t<Js.Json.t> => paymentRequestData = j
 
   if Utils.getString(jsonDict, "merchant_identifier", "") == "" {
     paymentRequestData(
-      ~countryCode=Utils.getString(jsonDict, "country_code", ""),
-      ~currencyCode=Utils.getString(jsonDict, "currency_code", defaultCountryCode),
+      ~countryCode=Utils.getString(jsonDict, "country_code", defaultCountryCode),
+      ~currencyCode=Utils.getString(jsonDict, "currency_code", ""),
       ~merchantCapabilities=Utils.getStrArray(jsonDict, "merchant_capabilities"),
       ~supportedNetworks=Utils.getStrArray(jsonDict, "supported_networks"),
       ~total=getTotal(jsonDict->Utils.getDictFromObj("total")),

--- a/src/Types/ApplePayTypes.res
+++ b/src/Types/ApplePayTypes.res
@@ -42,6 +42,10 @@ type paymentRequestData = {
 }
 
 let jsonToPaymentRequestDataType: Js.Dict.t<Js.Json.t> => paymentRequestData = jsonDict => {
+  let clientTimeZone = CardUtils.dateTimeFormat(.).resolvedOptions(.).timeZone
+  let clientCountry = Utils.getClientCountry(clientTimeZone)
+  let defaultCountryCode = clientCountry.isoAlpha2
+
   let getTotal = totalDict => {
     Utils.getString(totalDict, "type", "") == ""
       ? total(
@@ -60,7 +64,7 @@ let jsonToPaymentRequestDataType: Js.Dict.t<Js.Json.t> => paymentRequestData = j
   if Utils.getString(jsonDict, "merchant_identifier", "") == "" {
     paymentRequestData(
       ~countryCode=Utils.getString(jsonDict, "country_code", ""),
-      ~currencyCode=Utils.getString(jsonDict, "currency_code", ""),
+      ~currencyCode=Utils.getString(jsonDict, "currency_code", defaultCountryCode),
       ~merchantCapabilities=Utils.getStrArray(jsonDict, "merchant_capabilities"),
       ~supportedNetworks=Utils.getStrArray(jsonDict, "supported_networks"),
       ~total=getTotal(jsonDict->Utils.getDictFromObj("total")),


### PR DESCRIPTION
In new flow it is possible for BE to not know what the country code will be. In such scenarios where Client has to send a country, we are setting the country as client's country by default. 