### PR TITLE
feat:HS-186: added metadata support for logs

### DIFF
--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -211,11 +211,15 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger) => {
                 let publishableKey = dict->getString("publishableKey", "")
                 logger.setMerchantId(publishableKey)
               }
+
               if dict->getDictIsSome("endpoint") {
                 let endpoint = dict->getString("endpoint", "")
                 ApiEndpoint.setApiEndPoint(endpoint)
               }
-
+              if dict->getDictIsSome("analyticsMetadata") {
+                let metadata = dict->getJsonObjectFromDict("analyticsMetadata")
+                logger.setMetadata(metadata)
+              }
               if dict->getDictIsSome("paymentOptions") {
                 let paymentOptions = dict->Utils.getDictFromObj("paymentOptions")
 

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -21,6 +21,7 @@ let make = (
   ~sdkSessionId,
   ~publishableKey,
   ~logger: option<OrcaLogger.loggerMake>,
+  ~analyticsMetadata,
 ) => {
   let handleApplePayMessages = ref(_ => ())
   let applePaySessionRef = ref(Js.Nullable.null)
@@ -225,6 +226,7 @@ let make = (
             ("sdkSessionId", sdkSessionId->Js.Json.string),
             ("sdkHandleConfirmPayment", sdkHandleConfirmPayment->Js.Json.boolean),
             ("parentURL", "*"->Js.Json.string),
+            ("analyticsMetadata", analyticsMetadata),
           ]->Js.Dict.fromArray
 
         let handleApplePayMounted = (event: Types.event) => {

--- a/src/orca-loader/Hyper.res
+++ b/src/orca-loader/Hyper.res
@@ -75,6 +75,12 @@ let make = (publishableKey, options: option<Js.Json.t>, analyticsInfo: option<Js
       ->Belt.Option.getWithDefault(Js.Json.null)
       ->Utils.getDictFromJson
       ->Utils.getBool("isPreloadEnabled", true)
+    let analyticsMetadata =
+      options
+      ->Belt.Option.getWithDefault(Js.Json.null)
+      ->Utils.getDictFromJson
+      ->Utils.getDictFromObj("analytics")
+      ->Utils.getJsonObjectFromDict("metadata")
     if isPreloadEnabled {
       preloader()
     }
@@ -88,6 +94,7 @@ let make = (publishableKey, options: option<Js.Json.t>, analyticsInfo: option<Js
       ~sessionId=sessionID,
       ~source=Loader,
       ~merchantId=publishableKey,
+      ~metadata=analyticsMetadata,
       (),
     )
     switch options {
@@ -336,6 +343,7 @@ let make = (publishableKey, options: option<Js.Json.t>, analyticsInfo: option<Js
           ~sdkSessionId=sessionID,
           ~publishableKey,
           ~logger=Some(logger),
+          ~analyticsMetadata,
         )
       }
       let confirmCardPaymentFn =

--- a/src/orca-log-catcher/ErrorBoundary.res
+++ b/src/orca-log-catcher/ErrorBoundary.res
@@ -135,6 +135,7 @@ module ErrorCard = {
           latency: "",
           paymentMethod: "",
           firstEvent: false,
+          metadata: Js.Json.null,
         }
         beaconApiCall([errorLog])
       }


### PR DESCRIPTION
The SDK `loadHyper` and `Hyper` method now accept `options.analytics.metadata` which is a JSON object in case the merchant wishes to send their metadata to their system without code change.