### PR TITLE
fix: HS-123: created separate iframe for full screen

### DIFF
--- a/public/fullscreenIndexTemplate.html
+++ b/public/fullscreenIndexTemplate.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <!-- <link rel="icon" href="/orca/elements/favicon.ico" /> -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <meta name="theme-color" content="#000000" />
+    <!-- <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Qwitcher+Grypen:wght@400;700&display=swap"
+      rel="stylesheet"
+    /> -->
+    <link href="<%= publicPath%>/app.css" rel="stylesheet" />
+
+    <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Hyperswitch</title>
+  </head>
+
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="app"></div>
+    <script src="<%= publicPath%>/app.js"></script>
+
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/src/orca-loader/LoaderPaymentElement.res
+++ b/src/orca-loader/LoaderPaymentElement.res
@@ -243,8 +243,8 @@ let make = (componentType, options, setIframeRef, iframeRef, mountPostMessage) =
             )
             let iframeURL =
               fullscreenParam.contents != ""
-                ? `${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=${fullscreenParam.contents}`
-                : `${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=fullscreen`
+                ? `${ApiEndpoint.sdkDomainUrl}/fullscreenIndex.html?fullscreenType=${fullscreenParam.contents}`
+                : `${ApiEndpoint.sdkDomainUrl}/fullscreenIndex.html?fullscreenType=fullscreen`
             fullscreen.contents
               ? {
                   if iframeID == localSelectorString {
@@ -333,15 +333,15 @@ let make = (componentType, options, setIframeRef, iframeRef, mountPostMessage) =
     }
 
     {
-      on: on,
-      collapse: collapse,
-      blur: blur,
-      focus: focus,
-      clear: clear,
-      unmount: unmount,
-      destroy: destroy,
-      update: update,
-      mount: mount,
+      on,
+      collapse,
+      blur,
+      focus,
+      clear,
+      unmount,
+      destroy,
+      update,
+      mount,
     }
   } catch {
   | e => {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -128,6 +128,16 @@ module.exports = (publicPath = "auto") => {
         inject: false,
         template: "./public/build.html",
       }),
+      new HtmlWebpackPlugin({
+        inject: false,
+        template: "./public/build.html",
+      }),
+      new HtmlWebpackPlugin({
+        // Also generate a test.html
+        inject: false,
+        filename: "fullscreenIndex.html",
+        template: "./public/fullscreenIndexTemplate.html",
+      }),
       new BundleAnalyzerPlugin({
         analyzerMode: "static",
         reportFilename: "bundle-report.html",


### PR DESCRIPTION
Currently all the iframes, from the main app to the full screen pop up iframes were using the same assets, i.e., the same index.html file. This led to repeated calls for some assets, and some scripts. This PR includes configuring webpack to use a different index.html template.