### PR TITLE
fix(intentCall): handling no response on confirm

### DIFF
--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -14,7 +14,8 @@ let closePaymentLoaderIfAny = () =>
 
 let retrievePaymentIntent = (clientSecret, headers, ~optLogger, ~switchToCustomPod) => {
   open Promise
-  let paymentIntentID = Js.String2.split(clientSecret, "_secret_")[0]
+  let paymentIntentID =
+    Js.String2.split(clientSecret, "_secret_")->Belt.Array.get(0)->Belt.Option.getWithDefault("")
   let endpoint = ApiEndpoint.getApiEndPoint()
   let uri = `${endpoint}/payments/${paymentIntentID}?client_secret=${clientSecret}`
 
@@ -205,9 +206,12 @@ let rec intentCall = (
             openUrl(url.href)
           }
         } else {
-          let paymentIntentID = Js.String2.split(clientSecret, "_secret_")[0]
+          let paymentIntentID =
+            Js.String2.split(clientSecret, "_secret_")
+            ->Belt.Array.get(0)
+            ->Belt.Option.getWithDefault("")
           let endpoint = ApiEndpoint.getApiEndPoint(~publishableKey=confirmParam.publishableKey, ())
-          let retrieveUri = `${endpoint}/payments/${paymentIntentID}?force_sync=true&client_secret=${clientSecret}`
+          let retrieveUri = `${endpoint}/payments/${paymentIntentID}?client_secret=${clientSecret}`
           intentCall(
             ~fetchApi,
             ~uri=retrieveUri,
@@ -466,9 +470,12 @@ let rec intentCall = (
         openUrl(url.href)
       }
     } else {
-      let paymentIntentID = Js.String2.split(clientSecret, "_secret_")[0]
+      let paymentIntentID =
+        Js.String2.split(clientSecret, "_secret_")
+        ->Belt.Array.get(0)
+        ->Belt.Option.getWithDefault("")
       let endpoint = ApiEndpoint.getApiEndPoint(~publishableKey=confirmParam.publishableKey, ())
-      let retrieveUri = `${endpoint}/payments/${paymentIntentID}?force_sync=true&client_secret=${clientSecret}`
+      let retrieveUri = `${endpoint}/payments/${paymentIntentID}?client_secret=${clientSecret}`
       intentCall(
         ~fetchApi,
         ~uri=retrieveUri,
@@ -500,7 +507,10 @@ let usePaymentSync = (optLogger: option<OrcaLogger.loggerMake>, paymentType: pay
   (~handleUserError=false, ~confirmParam: ConfirmType.confirmParams, ~iframeId="", ()) => {
     switch keys.clientSecret {
     | Some(clientSecret) =>
-      let paymentIntentID = Js.String2.split(clientSecret, "_secret_")[0]
+      let paymentIntentID =
+        Js.String2.split(clientSecret, "_secret_")
+        ->Belt.Array.get(0)
+        ->Belt.Option.getWithDefault("")
       let headers = [("Content-Type", "application/json"), ("api-key", confirmParam.publishableKey)]
       let endpoint = ApiEndpoint.getApiEndPoint(~publishableKey=confirmParam.publishableKey, ())
       let uri = `${endpoint}/payments/${paymentIntentID}?force_sync=true&client_secret=${clientSecret}`
@@ -586,7 +596,10 @@ let usePaymentIntent = (optLogger: option<OrcaLogger.loggerMake>, paymentType: p
   ) => {
     switch keys.clientSecret {
     | Some(clientSecret) =>
-      let paymentIntentID = Js.String2.split(clientSecret, "_secret_")[0]
+      let paymentIntentID =
+        Js.String2.split(clientSecret, "_secret_")
+        ->Belt.Array.get(0)
+        ->Belt.Option.getWithDefault("")
       let headers = [("Content-Type", "application/json"), ("api-key", confirmParam.publishableKey)]
       let returnUrlArr = [("return_url", confirmParam.return_url->Js.Json.string)]
       let manual_retry = isManualRetryEnabled


### PR DESCRIPTION
In case of no response from server, or a timed out request, try to retrieve the payment intent to know the true payment status