### PR TITLE
fix: saved Payment Method stuck in loading state and Card Holder Name for every saved card

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -7,7 +7,7 @@ let make = (
   ~paymentMethodType,
   ~setRequiredFieldsBody,
   ~isSavedCardFlow=false,
-  ~savedCards=[]: array<PaymentType.customerMethods>,
+  ~savedMethod=PaymentType.defaultCustomerMethods,
   ~cardProps=None,
   ~expiryProps=None,
   ~cvcProps=None,
@@ -46,8 +46,8 @@ let make = (
   }, [requiredFieldsWithBillingDetails])
 
   let isAllStoredCardsHaveName = React.useMemo1(() => {
-    PaymentType.getIsAllStoredCardsHaveName(savedCards)
-  }, [savedCards])
+    PaymentType.getIsStoredPaymentMethodHasName(savedMethod)
+  }, [savedMethod])
 
   //<...>//
   let fieldsArr = React.useMemo3(() => {

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -9,7 +9,6 @@ let make = (
   ~cvcProps,
   ~paymentType,
   ~list,
-  ~savedMethods,
   ~setRequiredFieldsBody,
 ) => {
   let {themeObj, config} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
@@ -162,7 +161,7 @@ let make = (
                 paymentMethodType
                 setRequiredFieldsBody
                 isSavedCardFlow=true
-                savedCards=savedMethods
+                savedMethod=paymentItem
               />
               <Surcharge
                 list

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -57,7 +57,6 @@ let make = (
         cvcProps
         paymentType
         list
-        savedMethods
         setRequiredFieldsBody
       />
     })

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -388,11 +388,6 @@ let make = (
     </ErrorBoundary>
   }
 
-  React.useEffect(() => {
-    setShowFields(_ => !displaySavedPaymentMethods)
-    None
-  }, [displaySavedPaymentMethods])
-
   let paymentLabel = if displaySavedPaymentMethods {
     showFields
       ? optionAtomValue.paymentMethodsHeaderText

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -974,14 +974,6 @@ let itemToObjMapper = (dict, logger) => {
 
 type loadType = Loading | Loaded(JSON.t) | SemiLoaded | LoadError(JSON.t)
 
-let getIsAllStoredCardsHaveName = (savedCards: array<customerMethods>) => {
-  savedCards
-  ->Array.filter(savedCard => {
-    switch savedCard.card.cardHolderName {
-    | None
-    | Some("") => false
-    | _ => true
-    }
-  })
-  ->Array.length === savedCards->Array.length
+let getIsStoredPaymentMethodHasName = (savedMethod: customerMethods) => {
+  savedMethod.card.cardHolderName->Option.getOr("")->String.length > 0
 }


### PR DESCRIPTION
## Description

1. SDK getting stuck on Saved Payment Method screen when no customer was provided
2. Card Holder Name field was being asked by Dynamic Fields even when card holder name was present for that specific saved card
