### PR TITLE
fix(savedcarditem): fixed Dynamic Fields not rendering for some saved…

### DIFF
--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -50,7 +50,7 @@ let make = (
   let isRenderCvv = isCard && paymentItem.requiresCvv
 
   let paymentMethodType = switch paymentItem.paymentMethodType {
-  | Some(paymentMethodType) => paymentMethodType->Utils.snakeToTitleCase
+  | Some(paymentMethodType) => paymentMethodType
   | None => "debit"
   }
 
@@ -100,7 +100,7 @@ let make = (
                       <div> {React.string(paymentItem.card.last4Digits)} </div>
                     </div>
                   </div>
-                : <div> {React.string(paymentMethodType)} </div>}
+                : <div> {React.string(paymentMethodType->Utils.snakeToTitleCase)} </div>}
               <RenderIf condition={paymentItem.defaultPaymentMethodSet}>
                 <Icon
                   size=18


### PR DESCRIPTION
… payment methods

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Dynamic Fields not rendering for Saved Payment Methods (credit, google_pay, apple_pay)

## How did you test it?

![Screenshot 2024-03-21 at 2 53 53 PM](https://github.com/juspay/hyperswitch-web/assets/121166031/8c8abfe6-7529-4e09-b798-674b96514115)

