### PR TITLE
fix: applePay Dynamic Fields Error Handling and Dynamic Fields PostalCode Error

### DIFF
--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -333,7 +333,7 @@ let make = (
     None
   }, (isApplePayReady, isInvokeSDKFlow, paymentExperience, isWallet))
 
-  let submitCallback = (ev: Window.event) => {
+  let submitCallback = React.useCallback((ev: Window.event) => {
     if !isWallet {
       let json = ev.data->JSON.parseExn
       let confirm = json->getDictFromJson->ConfirmType.itemToObjMapper
@@ -353,7 +353,7 @@ let make = (
         )
       }
     }
-  }
+  }, (areRequiredFieldsValid, areRequiredFieldsEmpty))
   useSubmitPaymentData(submitCallback)
 
   {

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -142,10 +142,10 @@ let useRequiredFieldsEmptyAndValid = (
       | StateAndCity => state.value !== "" && city.value !== ""
       | CountryAndPincode(countryArr) =>
         (country !== "" || countryArr->Array.length === 0) &&
-          postalCode.isValid->Option.getOr(false)
+          postalCode.value !== ""
 
       | AddressCity => city.value !== ""
-      | AddressPincode => postalCode.isValid->Option.getOr(false)
+      | AddressPincode => postalCode.value !== ""
       | AddressState => state.value !== ""
       | BlikCode => blikCode.value !== ""
       | Currency(currencyArr) => currency !== "" || currencyArr->Array.length === 0

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -529,49 +529,68 @@ let make = (
                         | _ => ()
                         }
                       } else {
-                        let paymentRequest =
-                          applePayPresent
-                          ->Option.flatMap(JSON.Decode.object)
-                          ->Option.getOr(Dict.make())
-                          ->Dict.get("payment_request_data")
-                          ->Option.getOr(Dict.make()->JSON.Encode.object)
-                          ->Utils.transformKeys(Utils.CamelCase)
-
-                        let ssn = applePaySession(3, paymentRequest)
-                        switch applePaySessionRef.contents->Nullable.toOption {
-                        | Some(session) =>
-                          try {
-                            session.abort()
-                          } catch {
-                          | error => Console.log2("Abort fail", error)
-                          }
-                        | None => ()
-                        }
-
-                        ssn.begin()
-                        applePaySessionRef := ssn->Nullable.make
-
-                        ssn.onvalidatemerchant = _event => {
-                          let merchantSession =
+                        try {
+                          let paymentRequest =
                             applePayPresent
                             ->Option.flatMap(JSON.Decode.object)
                             ->Option.getOr(Dict.make())
-                            ->Dict.get("session_token_data")
+                            ->Dict.get("payment_request_data")
                             ->Option.getOr(Dict.make()->JSON.Encode.object)
                             ->Utils.transformKeys(Utils.CamelCase)
-                          ssn.completeMerchantValidation(merchantSession)
-                        }
 
-                        ssn.onpaymentauthorized = event => {
-                          ssn.completePayment({"status": ssn.\"STATUS_SUCCESS"}->objToJson)
-                          applePaySessionRef := Nullable.null
-                          processPayment(event.payment.token)
-                        }
-                        ssn.oncancel = _ev => {
-                          let msg = [("showApplePayButton", true->JSON.Encode.bool)]->Dict.fromArray
-                          mountedIframeRef->Window.iframePostMessage(msg)
-                          applePaySessionRef := Nullable.null
-                          Utils.logInfo(Console.log("Apple Pay payment cancelled"))
+                          let ssn = applePaySession(3, paymentRequest)
+                          switch applePaySessionRef.contents->Nullable.toOption {
+                          | Some(session) =>
+                            try {
+                              session.abort()
+                            } catch {
+                            | error => Console.log2("Abort fail", error)
+                            }
+                          | None => ()
+                          }
+
+                          applePaySessionRef := ssn->Nullable.make
+
+                          ssn.onvalidatemerchant = _event => {
+                            let merchantSession =
+                              applePayPresent
+                              ->Option.flatMap(JSON.Decode.object)
+                              ->Option.getOr(Dict.make())
+                              ->Dict.get("session_token_data")
+                              ->Option.getOr(Dict.make()->JSON.Encode.object)
+                              ->Utils.transformKeys(Utils.CamelCase)
+                            ssn.completeMerchantValidation(merchantSession)
+                          }
+
+                          ssn.onpaymentauthorized = event => {
+                            ssn.completePayment({"status": ssn.\"STATUS_SUCCESS"}->objToJson)
+                            applePaySessionRef := Nullable.null
+                            processPayment(event.payment.token)
+                          }
+                          ssn.oncancel = _ev => {
+                            let msg =
+                              [("showApplePayButton", true->JSON.Encode.bool)]->Dict.fromArray
+                            mountedIframeRef->Window.iframePostMessage(msg)
+                            applePaySessionRef := Nullable.null
+                            Utils.logInfo(Console.log("Apple Pay payment cancelled"))
+                          }
+
+                          ssn.begin()
+                        } catch {
+                        | exn => {
+                            logger.setLogInfo(
+                              ~value=exn->Utils.formatException->JSON.stringify,
+                              ~eventName=APPLE_PAY_FLOW,
+                              ~paymentMethod="APPLE_PAY",
+                              (),
+                            )
+                            Utils.logInfo(Console.error2("Apple Pay Error", exn))
+
+                            let msg =
+                              [("showApplePayButton", true->JSON.Encode.bool)]->Dict.fromArray
+                            mountedIframeRef->Window.iframePostMessage(msg)
+                            applePaySessionRef := Nullable.null
+                          }
                         }
                       }
                     } else {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

1. ApplePay Dynamic Fields Error handling failing. The merchant button getting stuck in Processing...
2. Dynamic Fields areRequiredFieldsValid failing because of postal code validation in scenario (found by not passing country in `/create-payment-intent` call)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
