### PR TITLE
feat: removed ApplePay from Tabs and collecting Dynamic Fields in ApplePay Modal

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -24,7 +24,6 @@ let make = (
   } = Recoil.useRecoilValueFromAtom(optionAtom)
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let optionAtomValue = Recoil.useRecoilValueFromAtom(optionAtom)
-  let isApplePayReady = Recoil.useRecoilValueFromAtom(isApplePayReady)
   let isGooglePayReady = Recoil.useRecoilValueFromAtom(isGooglePayReady)
   let methodslist = Recoil.useRecoilValueFromAtom(list)
   let paymentOrder = paymentMethodOrder->Utils.getOptionalArr->Utils.removeDuplicate
@@ -113,13 +112,7 @@ let make = (
     ~paymentMethodType="google_pay",
   )
 
-  let areAllApplePayRequiredFieldsPrefilled = DynamicFieldsUtils.useAreAllRequiredFieldsPrefilled(
-    ~list,
-    ~paymentMethod="wallet",
-    ~paymentMethodType="apple_pay",
-  )
-
-  let (walletList, paymentOptionsList, actualList) = React.useMemo6(() => {
+  let (walletList, paymentOptionsList, actualList) = React.useMemo4(() => {
     switch methodslist {
     | Loaded(paymentlist) =>
       let paymentOrder =
@@ -128,10 +121,8 @@ let make = (
       let (wallets, otherOptions) =
         plist->PaymentUtils.paymentListLookupNew(
           ~order=paymentOrder,
-          ~showApplePay=isApplePayReady,
           ~showGooglePay=isGooglePayReady,
           ~areAllGooglePayRequiredFieldsPrefilled,
-          ~areAllApplePayRequiredFieldsPrefilled,
         )
       (
         wallets->Utils.removeDuplicate,
@@ -144,14 +135,7 @@ let make = (
         : ([], [], [])
     | _ => ([], [], [])
     }
-  }, (
-    methodslist,
-    paymentMethodOrder,
-    isApplePayReady,
-    isGooglePayReady,
-    areAllGooglePayRequiredFieldsPrefilled,
-    areAllApplePayRequiredFieldsPrefilled,
-  ))
+  }, (methodslist, paymentMethodOrder, isGooglePayReady, areAllGooglePayRequiredFieldsPrefilled))
 
   React.useEffect(() => {
     switch methodslist {
@@ -275,8 +259,6 @@ let make = (
   }
   let dict = sessions->Utils.getDictFromJson
   let sessionObj = SessionsType.itemToObjMapper(dict, Others)
-  let applePaySessionObj = SessionsType.itemToObjMapper(dict, ApplePayObject)
-  let applePayToken = SessionsType.getPaymentSessionObj(applePaySessionObj.sessionsToken, ApplePay)
   let klarnaTokenObj = SessionsType.getPaymentSessionObj(sessionObj.sessionsToken, Klarna)
   let gPayToken = SessionsType.getPaymentSessionObj(sessionObj.sessionsToken, Gpay)
   let googlePayThirdPartySessionObj = SessionsType.itemToObjMapper(dict, GooglePayThirdPartyObject)
@@ -369,12 +351,6 @@ let make = (
               />
             </React.Suspense>
           }
-        | _ => React.null
-        }
-      | ApplePay =>
-        switch applePayToken {
-        | ApplePayTokenOptional(optToken) =>
-          <ApplePayLazy sessionObj=optToken list walletOptions paymentType />
         | _ => React.null
         }
       | Boleto =>

--- a/src/Payments/ApplePay.resi
+++ b/src/Payments/ApplePay.resi
@@ -1,7 +1,2 @@
 @react.component
-let default: (
-  ~sessionObj: option<JSON.t>,
-  ~list: PaymentMethodsRecord.list,
-  ~paymentType: option<CardThemeType.mode>,
-  ~walletOptions: array<string>,
-) => React.element
+let default: (~sessionObj: option<JSON.t>, ~list: PaymentMethodsRecord.list) => React.element

--- a/src/Payments/ApplePayLazy.res
+++ b/src/Payments/ApplePayLazy.res
@@ -3,8 +3,6 @@ open LazyUtils
 type props = {
   sessionObj: option<JSON.t>,
   list: PaymentMethodsRecord.list,
-  paymentType: CardThemeType.mode,
-  walletOptions: array<string>,
 }
 
 let make: props => React.element = reactLazy(() => import_("./ApplePay.bs.js"))

--- a/src/Payments/PaymentRequestButtonElement.res
+++ b/src/Payments/PaymentRequestButtonElement.res
@@ -104,8 +104,7 @@ let make = (~sessions, ~walletOptions, ~list: PaymentMethodsRecord.list) => {
               </SessionPaymentWrapper>
             | ApplePayWallet =>
               switch applePayToken {
-              | ApplePayTokenOptional(optToken) =>
-                <ApplePayLazy sessionObj=optToken list paymentType=NONE walletOptions />
+              | ApplePayTokenOptional(optToken) => <ApplePayLazy sessionObj=optToken list />
               | _ => React.null
               }
 

--- a/src/Types/ApplePayTypes.res
+++ b/src/Types/ApplePayTypes.res
@@ -1,5 +1,20 @@
 type token = {paymentData: JSON.t}
-type paymentResult = {token: JSON.t}
+type billingContact = {
+  addressLines: array<string>,
+  administrativeArea: string,
+  countryCode: string,
+  familyName: string,
+  givenName: string,
+  locality: string,
+  postalCode: string,
+}
+
+type shippingContact = {
+  emailAddress: string,
+  phoneNumber: string,
+}
+
+type paymentResult = {token: JSON.t, billingContact: JSON.t, shippingContact: JSON.t}
 type event = {validationURL: string, payment: paymentResult}
 type innerSession
 type session = {
@@ -80,5 +95,24 @@ let jsonToPaymentRequestDataType: Dict.t<JSON.t> => paymentRequestData = jsonDic
       ~merchantIdentifier=Utils.getString(jsonDict, "merchant_identifier", ""),
       (),
     )
+  }
+}
+
+let billingContactItemToObjMapper = dict => {
+  {
+    addressLines: dict->Utils.getStrArray("addressLines"),
+    administrativeArea: dict->Utils.getString("administrativeArea", ""),
+    countryCode: dict->Utils.getString("countryCode", ""),
+    familyName: dict->Utils.getString("familyName", ""),
+    givenName: dict->Utils.getString("givenName", ""),
+    locality: dict->Utils.getString("locality", ""),
+    postalCode: dict->Utils.getString("postalCode", ""),
+  }
+}
+
+let shippingContactItemToObjMapper = dict => {
+  {
+    emailAddress: dict->Utils.getString("emailAddress", ""),
+    phoneNumber: dict->Utils.getString("phoneNumber", ""),
   }
 }

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -1,10 +1,8 @@
 let paymentListLookupNew = (
   list: PaymentMethodsRecord.list,
   ~order,
-  ~showApplePay,
   ~showGooglePay,
   ~areAllGooglePayRequiredFieldsPrefilled,
-  ~areAllApplePayRequiredFieldsPrefilled,
 ) => {
   let pmList = list->PaymentMethodsRecord.buildFromPaymentList
   let walletsList = []
@@ -25,18 +23,10 @@ let paymentListLookupNew = (
   ]
   let otherPaymentList = []
   let googlePayFields = pmList->Array.find(item => item.paymentMethodName === "google_pay")
-  let applePayFields = pmList->Array.find(item => item.paymentMethodName === "apple_pay")
   switch googlePayFields {
   | Some(val) =>
     if val.fields->Array.length > 0 && showGooglePay && !areAllGooglePayRequiredFieldsPrefilled {
       walletToBeDisplayedInTabs->Array.push("google_pay")->ignore
-    }
-  | None => ()
-  }
-  switch applePayFields {
-  | Some(val) =>
-    if val.fields->Array.length > 0 && showApplePay && !areAllApplePayRequiredFieldsPrefilled {
-      walletToBeDisplayedInTabs->Array.push("apple_pay")->ignore
     }
   | None => ()
   }

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -701,6 +701,32 @@ let getStateNames = (list: JSON.t, country: RecoilAtomTypes.field) => {
   })
 }
 
+let getStateNameFromStateCodeAndCountry = (list: JSON.t, stateCode: string, country: string) => {
+  let options =
+    list
+    ->getDictFromJson
+    ->getOptionalArrayFromDict(country)
+    ->Option.getOr([])
+
+  let val = options->Array.find(item =>
+    item
+    ->getDictFromJson
+    ->Dict.get("code")
+    ->Option.flatMap(JSON.Decode.string)
+    ->Option.getOr("") === stateCode
+  )
+
+  switch val {
+  | Some(stateObj) =>
+    stateObj
+    ->getDictFromJson
+    ->Dict.get("name")
+    ->Option.flatMap(JSON.Decode.string)
+    ->Option.getOr(stateCode)
+  | None => stateCode
+  }
+}
+
 let isAddressComplete = (
   line1: RecoilAtomTypes.field,
   city: RecoilAtomTypes.field,

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -402,9 +402,14 @@ let make = (
           let (json, applePayPresent, googlePayPresent) = res
           if componentType === "payment" && applePayPresent->Option.isSome {
             //do operations here
-            let processPayment = (token: JSON.t) => {
+            let processPayment = (payment: ApplePayTypes.paymentResult) => {
               //let body = PaymentBody.applePayBody(~token)
-              let msg = [("applePayProcessPayment", token)]->Dict.fromArray
+              let msg =
+                [
+                  ("applePayProcessPayment", payment.token),
+                  ("applePayBillingContact", payment.billingContact),
+                  ("applePayShippingContact", payment.shippingContact),
+                ]->Dict.fromArray
               mountedIframeRef->Window.iframePostMessage(msg)
             }
 
@@ -567,7 +572,7 @@ let make = (
                           ssn.onpaymentauthorized = event => {
                             ssn.completePayment({"status": ssn.\"STATUS_SUCCESS"}->objToJson)
                             applePaySessionRef := Nullable.null
-                            processPayment(event.payment.token)
+                            processPayment(event.payment)
                           }
                           ssn.oncancel = _ev => {
                             let msg =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Moved ApplePay outside of tabs when Dynamic Fields was enabled. Collecting required fields inside Apple Modal and sending them to backend in the confirm call. (Fields will be collecting from Apple based on `payment_request_data` received in Session Token)

## How did you test it?

1. Test transaction when ApplePay without required fields
2. Test transaction when ApplePay with required fields

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
