### PR TITLE
fix: added Loader and Error Handling for TrustPay GooglePay

### DIFF
--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -151,6 +151,11 @@ let make = (
       if result {
         if isInvokeSDKFlow {
           if isDelayedSessionToken {
+            handlePostMessage([
+              ("fullscreen", true->JSON.Encode.bool),
+              ("param", "paymentloader"->JSON.Encode.string),
+              ("iframeId", iframeId->JSON.Encode.string),
+            ])
             let bodyDict = PaymentBody.gPayThirdPartySdkBody(~connectors)
             processPayment(bodyDict)
           } else {

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -12,11 +12,18 @@ type payment = Card | BankTransfer | BankDebits | KlarnaRedirect | Gpay | Applep
 let closePaymentLoaderIfAny = () =>
   Utils.handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
 
-let retrievePaymentIntent = (clientSecret, headers, ~optLogger, ~switchToCustomPod) => {
+let retrievePaymentIntent = (
+  clientSecret,
+  headers,
+  ~optLogger,
+  ~switchToCustomPod,
+  ~isForceSync=false,
+) => {
   open Promise
   let paymentIntentID = String.split(clientSecret, "_secret_")->Array.get(0)->Option.getOr("")
   let endpoint = ApiEndpoint.getApiEndPoint()
-  let uri = `${endpoint}/payments/${paymentIntentID}?client_secret=${clientSecret}`
+  let forceSync = isForceSync ? "&force_sync=true" : ""
+  let uri = `${endpoint}/payments/${paymentIntentID}?client_secret=${clientSecret}${forceSync}`
 
   logApi(
     ~optLogger,
@@ -129,9 +136,15 @@ let threeDsAuth = (~clientSecret, ~optLogger, ~threeDsMethodComp, ~headers) => {
   })
 }
 
-let rec pollRetrievePaymentIntent = (clientSecret, headers, ~optLogger, ~switchToCustomPod) => {
+let rec pollRetrievePaymentIntent = (
+  clientSecret,
+  headers,
+  ~optLogger,
+  ~switchToCustomPod,
+  ~isForceSync=false,
+) => {
   open Promise
-  retrievePaymentIntent(clientSecret, headers, ~optLogger, ~switchToCustomPod)
+  retrievePaymentIntent(clientSecret, headers, ~optLogger, ~switchToCustomPod, ~isForceSync)
   ->then(json => {
     let dict = json->JSON.Decode.object->Option.getOr(Dict.make())
     let status = dict->getString("status", "")
@@ -140,13 +153,19 @@ let rec pollRetrievePaymentIntent = (clientSecret, headers, ~optLogger, ~switchT
       resolve(json)
     } else {
       delay(2000)->then(_val => {
-        pollRetrievePaymentIntent(clientSecret, headers, ~optLogger, ~switchToCustomPod)
+        pollRetrievePaymentIntent(
+          clientSecret,
+          headers,
+          ~optLogger,
+          ~switchToCustomPod,
+          ~isForceSync,
+        )
       })
     }
   })
   ->catch(e => {
     Console.log2("Unable to retrieve payment due to following error", e)
-    pollRetrievePaymentIntent(clientSecret, headers, ~optLogger, ~switchToCustomPod)
+    pollRetrievePaymentIntent(clientSecret, headers, ~optLogger, ~switchToCustomPod, ~isForceSync)
   })
 }
 

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -300,40 +300,79 @@ let make = (
                 paymentDataRequest->GooglePayType.jsonToPaymentRequestDataType(
                   googlePayThirdPartySession,
                 )
-              let secrets = googlePayThirdPartySession->getJsonFromDict("secrets", JSON.Encode.null)
 
-              let payment = secrets->getDictFromJson->getString("payment", "")
+              let headers = [("Content-Type", "application/json"), ("api-key", publishableKey)]
+
+              let connector =
+                googlePayThirdPartySession
+                ->Dict.get("connector")
+                ->Option.getOr(JSON.Encode.null)
+                ->JSON.Decode.string
+                ->Option.getOr("")
 
               try {
-                let trustpay = trustPayApi(secrets)
-                trustpay.executeGooglePayment(payment, googlePayRequest)
-                ->then(res => {
-                  logger.setLogInfo(
-                    ~value="TrustPay GooglePay Success Response",
-                    ~internalMetadata=res->JSON.stringify,
-                    ~eventName=GOOGLE_PAY_FLOW,
-                    ~paymentMethod="GOOGLE_PAY",
-                    (),
-                  )
-                  let msg = [("googlePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
-                  mountedIframeRef->Window.iframePostMessage(msg)
-                  resolve()
-                })
-                ->catch(err => {
-                  let exceptionMessage = err->formatException->JSON.stringify
-                  logger.setLogInfo(
-                    ~value=exceptionMessage,
-                    ~eventName=GOOGLE_PAY_FLOW,
-                    ~paymentMethod="GOOGLE_PAY",
-                    ~logType=ERROR,
-                    ~logCategory=USER_ERROR,
-                    (),
-                  )
-                  let msg = [("googlePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
-                  mountedIframeRef->Window.iframePostMessage(msg)
-                  resolve()
-                })
-                ->ignore
+                switch connector {
+                | "trustpay" => {
+                    let secrets =
+                      googlePayThirdPartySession->Utils.getJsonFromDict("secrets", JSON.Encode.null)
+
+                    let payment = secrets->Utils.getDictFromJson->Utils.getString("payment", "")
+
+                    let trustpay = trustPayApi(secrets)
+
+                    let polling =
+                      Utils.delay(2000)->then(_ =>
+                        PaymentHelpers.pollRetrievePaymentIntent(
+                          clientSecret,
+                          headers,
+                          ~optLogger=Some(logger),
+                          ~switchToCustomPod,
+                          ~isForceSync=true,
+                        )
+                      )
+                    let executeGooglePayment = trustpay.executeGooglePayment(
+                      payment,
+                      googlePayRequest,
+                    )
+                    let timeOut = Utils.delay(600000)->then(_ => {
+                      let errorMsg =
+                        [("error", "Request Timed Out"->JSON.Encode.string)]
+                        ->Dict.fromArray
+                        ->JSON.Encode.object
+                      reject(Exn.anyToExnInternal(errorMsg))
+                    })
+
+                    Promise.race([polling, executeGooglePayment, timeOut])
+                    ->then(res => {
+                      logger.setLogInfo(
+                        ~value="TrustPay GooglePay Response",
+                        ~internalMetadata=res->JSON.stringify,
+                        ~eventName=GOOGLE_PAY_FLOW,
+                        ~paymentMethod="GOOGLE_PAY",
+                        (),
+                      )
+                      let msg = [("googlePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
+                      mountedIframeRef->Window.iframePostMessage(msg)
+                      resolve()
+                    })
+                    ->catch(err => {
+                      let exceptionMessage = err->Utils.formatException->JSON.stringify
+                      logger.setLogInfo(
+                        ~value=exceptionMessage,
+                        ~eventName=GOOGLE_PAY_FLOW,
+                        ~paymentMethod="GOOGLE_PAY",
+                        ~logType=ERROR,
+                        ~logCategory=USER_ERROR,
+                        (),
+                      )
+                      let msg = [("googlePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
+                      mountedIframeRef->Window.iframePostMessage(msg)
+                      resolve()
+                    })
+                    ->ignore
+                  }
+                | _ => ()
+                }
               } catch {
               | err => {
                   let exceptionMessage = err->formatException->JSON.stringify


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

1. Added Background Loader once TrustPay GooglePay button is clicked.
2. Added polling and timeout for TrustPay GooglePay

## How did you test it?

Tested transactions via TrustPay GooglePay

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
