### PR TITLE
fix(hyper.res): prefetch assets instead of preload

### DIFF
--- a/Hyperswitch-React-Demo-App/webpack.dev.js
+++ b/Hyperswitch-React-Demo-App/webpack.dev.js
@@ -16,7 +16,7 @@ let devServer = {
     },
   },
   headers: {
-    "Cache-Control": "max-age=31536000,must-revalidate",
+    "Cache-Control": "must-revalidate",
   },
 };
 

--- a/src/orca-loader/Hyper.res
+++ b/src/orca-loader/Hyper.res
@@ -36,7 +36,7 @@ let preloadFile = (~type_, ~href=``, ()) => {
   let link = CommonHooks.createElement("link")
   link.href = href
   link.\"as" = type_
-  link.rel = "preload"
+  link.rel = "prefetch"
   link.crossorigin = "anonymous"
   checkAndAppend(`link[href="${href}"]`, link)
 }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -32,7 +32,7 @@ let devServer = {
     // },
   },
   headers: {
-    "Cache-Control": "max-age=31536000,must-revalidate",
+    "Cache-Control": "must-revalidate",
   },
 };
 


### PR DESCRIPTION
## Description
Prefetching assets will cache the resources in prefetch cache and will be available for subsiquient pages, iframes or diff domain which increases the performance in loading time of SDK

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
