### PR TITLE
fix: Added envLoggingUrl in webpack

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,21 +5,20 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
-const BundleAnalyzerPlugin =
-  require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 
 const sdkEnv = process.env.sdkEnv;
 const envSdkUrl = process.env.envSdkUrl;
 const envBackendUrl = process.env.envBackendUrl;
+const envLoggingUrl = process.env.envBackendUrl;
 
 //git rev-parse --abbrev-ref HEAD
 let repoVersion = require("./package.json").version;
 let majorVersion = "v" + repoVersion.split(".")[0];
 
 let repoName = require("./package.json").name;
-let repoPublicPath =
-  sdkEnv === "local" ? "" : `/${repoVersion}/${majorVersion}`;
+let repoPublicPath = sdkEnv === "local" ? "" : `/${repoVersion}/${majorVersion}`;
 
 let sdkUrl;
 
@@ -64,10 +63,15 @@ if (envBackendUrl === undefined) {
   confirmEndPoint = envBackendUrl;
 }
 
-let logEndpoint =
-  sdkEnv === "prod"
-    ? "https://api.hyperswitch.io/logs/sdk"
-    : "https://sandbox.hyperswitch.io/logs/sdk";
+let logEndpoint;
+if (envLoggingUrl === undefined) {
+  logEndpoint =
+    sdkEnv === "prod"
+      ? "https://api.hyperswitch.io/logs/sdk"
+      : "https://sandbox.hyperswitch.io/logs/sdk";
+} else {
+  logEndpoint = envLoggingUrl;
+}
 
 // Set this to true to enable logging
 let enableLogging = true;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,7 +11,7 @@ const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 const sdkEnv = process.env.sdkEnv;
 const envSdkUrl = process.env.envSdkUrl;
 const envBackendUrl = process.env.envBackendUrl;
-const envLoggingUrl = process.env.envBackendUrl;
+const envLoggingUrl = process.env.envLoggingUrl;
 
 //git rev-parse --abbrev-ref HEAD
 let repoVersion = require("./package.json").version;

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -16,6 +16,7 @@ let backendEndPoint =
 let devServer = {
   contentBase: path.join(__dirname, "dist"),
   hot: true,
+  host: "0.0.0.0",
   port: 9050,
   historyApiFallback: true,
   proxy: {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added envLoggingUrl to consume logging url from env in webpack if available

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
