### PR TITLE
fix: (paymenthelpers, paymentelement) promise being unresolved 

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -398,7 +398,8 @@ let make = (
   React.useEffect(() => {
     let evalMethodsList = () =>
       switch methodslist {
-      | SemiLoaded | Loaded(_) => handlePostMessage([("ready", true->JSON.Encode.bool)])
+      | SemiLoaded | LoadError(_) | Loaded(_) =>
+        handlePostMessage([("ready", true->JSON.Encode.bool)])
       | _ => ()
       }
     if !displaySavedPaymentMethods {


### PR DESCRIPTION
## Description

For users it looked like Promise is being unresolved as the button was being stuck in the loading state.


-  Ready promise was not getting created 
-  Ready message was not being sent to create the promise (missed one edge case) 
-  Return the appropriate msg and resolve the promise in the case of empty PML instead of () empty function
-  Send Ready msg even in the case of Semiloaded -> LoadError state cuz this will have card form by default. 
-  Do not make /confirm call if the PML response is empty. Resolve the promise and throw a warning on console

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
