### PR TITLE
fix: mandate data pass hide checkbox

### DIFF
--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -191,8 +191,6 @@ let make = (
 
   let nicknameFieldClassName = conditionsForShowingSaveCardCheckbox ? "pt-2" : "pt-5"
 
-  Js.log2("sdvjnsddsjd", (list.mandate_payment, options.terms.card))
-
   <div className="animate-slowShow">
     <RenderIf condition={showFields || isBancontact}>
       <div

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -183,6 +183,7 @@ let make = (
   let paymentMethod = isBancontact ? "bank_redirect" : "card"
   let paymentMethodType = isBancontact ? "bancontact_card" : "debit"
   let conditionsForShowingSaveCardCheckbox =
+    list.mandate_payment->Option.isNone &&
     !isGuestCustomer &&
     list.payment_type !== SETUP_MANDATE &&
     options.displaySavedPaymentMethodsCheckbox &&


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Whenever mandate_data is been passed in the flow the checkbox need not to be shown as customer_acceptance will always be sent.

## How did you test it?

Pass mandate_data in payments. and customer_acceptance will be passed and checkbox will not be visible. 

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
