### PR TITLE
refactor(paymentbody): refactored Payment Body

### DIFF
--- a/src/Payments/PaymentMethodsWrapper.res
+++ b/src/Payments/PaymentMethodsWrapper.res
@@ -76,7 +76,8 @@ let make = (
           ->Option.getOr(Bank.defaultBank)
         intent(
           ~bodyArr=PaymentBody.getPaymentBody(
-            ~paymentMethod=paymentMethodName,
+            ~paymentMethod=paymentMethodDetails.methodType,
+            ~paymentMethodType=paymentMethodName,
             ~country=countryCode.isoAlpha2,
             ~fullName=fullName.value,
             ~email=email.value,

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -1,5 +1,40 @@
 @val @scope("window")
 external btoa: string => string = "btoa"
+
+let billingDetailsTuple = (
+  ~fullName,
+  ~email,
+  ~line1,
+  ~line2,
+  ~city,
+  ~state,
+  ~postalCode,
+  ~country,
+) => {
+  (
+    "billing_details",
+    [
+      ("name", fullName->JSON.Encode.string),
+      ("email", email->JSON.Encode.string),
+      (
+        "address",
+        [
+          ("line1", line1->JSON.Encode.string),
+          ("line2", line2->JSON.Encode.string),
+          ("city", city->JSON.Encode.string),
+          ("state", state->JSON.Encode.string),
+          ("zip", postalCode->JSON.Encode.string),
+          ("country", country->JSON.Encode.string),
+        ]
+        ->Dict.fromArray
+        ->JSON.Encode.object,
+      ),
+    ]
+    ->Dict.fromArray
+    ->JSON.Encode.object,
+  )
+}
+
 let cardPaymentBody = (
   ~cardNumber,
   ~month,
@@ -181,27 +216,15 @@ let achBankDebitBody = (
             (
               "ach_bank_debit",
               [
-                (
-                  "billing_details",
-                  [
-                    ("name", cardHolderName->JSON.Encode.string),
-                    ("email", email->JSON.Encode.string),
-                    (
-                      "address",
-                      [
-                        ("line1", line1->JSON.Encode.string),
-                        ("line2", line2->JSON.Encode.string),
-                        ("city", city->JSON.Encode.string),
-                        ("state", state->JSON.Encode.string),
-                        ("zip", postalCode->JSON.Encode.string),
-                        ("country", country->JSON.Encode.string),
-                      ]
-                      ->Dict.fromArray
-                      ->JSON.Encode.object,
-                    ),
-                  ]
-                  ->Dict.fromArray
-                  ->JSON.Encode.object,
+                billingDetailsTuple(
+                  ~fullName=cardHolderName,
+                  ~email,
+                  ~line1,
+                  ~line2,
+                  ~city,
+                  ~state,
+                  ~postalCode,
+                  ~country,
                 ),
                 ("account_number", bank.accountNumber->JSON.Encode.string),
                 ("bank_account_holder_name", bank.accountHolderName->JSON.Encode.string),
@@ -243,27 +266,15 @@ let sepaBankDebitBody = (
           (
             "sepa_bank_debit",
             [
-              (
-                "billing_details",
-                [
-                  ("name", fullName->JSON.Encode.string),
-                  ("email", email->JSON.Encode.string),
-                  (
-                    "address",
-                    [
-                      ("line1", line1->JSON.Encode.string),
-                      ("line2", line2->JSON.Encode.string),
-                      ("city", city->JSON.Encode.string),
-                      ("state", state->JSON.Encode.string),
-                      ("zip", postalCode->JSON.Encode.string),
-                      ("country", country->JSON.Encode.string),
-                    ]
-                    ->Dict.fromArray
-                    ->JSON.Encode.object,
-                  ),
-                ]
-                ->Dict.fromArray
-                ->JSON.Encode.object,
+              billingDetailsTuple(
+                ~fullName,
+                ~email,
+                ~line1,
+                ~line2,
+                ~city,
+                ~state,
+                ~postalCode,
+                ~country,
               ),
               ("iban", data.iban->JSON.Encode.string),
               ("bank_account_holder_name", data.accountHolderName->JSON.Encode.string),
@@ -304,27 +315,15 @@ let bacsBankDebitBody = (
           (
             "bacs_bank_debit",
             [
-              (
-                "billing_details",
-                [
-                  ("name", bankAccountHolderName->JSON.Encode.string),
-                  ("email", email->JSON.Encode.string),
-                  (
-                    "address",
-                    [
-                      ("line1", line1->JSON.Encode.string),
-                      ("line2", line2->JSON.Encode.string),
-                      ("city", city->JSON.Encode.string),
-                      ("zip", zip->JSON.Encode.string),
-                      ("state", state->JSON.Encode.string),
-                      ("country", country->JSON.Encode.string),
-                    ]
-                    ->Dict.fromArray
-                    ->JSON.Encode.object,
-                  ),
-                ]
-                ->Dict.fromArray
-                ->JSON.Encode.object,
+              billingDetailsTuple(
+                ~fullName=bankAccountHolderName,
+                ~email,
+                ~line1,
+                ~line2,
+                ~city,
+                ~state,
+                ~postalCode=zip,
+                ~country,
               ),
               ("bank_account_holder_name", bankAccountHolderName->JSON.Encode.string),
               ("sort_code", sortCode->JSON.Encode.string),
@@ -365,27 +364,15 @@ let becsBankDebitBody = (
           (
             "becs_bank_debit",
             [
-              (
-                "billing_details",
-                [
-                  ("name", fullName->JSON.Encode.string),
-                  ("email", email->JSON.Encode.string),
-                  (
-                    "address",
-                    [
-                      ("line1", line1->JSON.Encode.string),
-                      ("line2", line2->JSON.Encode.string),
-                      ("city", city->JSON.Encode.string),
-                      ("state", state->JSON.Encode.string),
-                      ("zip", postalCode->JSON.Encode.string),
-                      ("country", country->JSON.Encode.string),
-                    ]
-                    ->Dict.fromArray
-                    ->JSON.Encode.object,
-                  ),
-                ]
-                ->Dict.fromArray
-                ->JSON.Encode.object,
+              billingDetailsTuple(
+                ~fullName,
+                ~email,
+                ~line1,
+                ~line2,
+                ~city,
+                ~state,
+                ~postalCode,
+                ~country,
               ),
               ("bsb_number", data.sortCode->JSON.Encode.string),
               ("account_number", data.accountNumber->JSON.Encode.string),
@@ -639,25 +626,6 @@ let applePayThirdPartySdkBody = (~connectors) => {
     ),
   ]
 }
-
-let affirmBody = () => [
-  ("payment_method", "pay_later"->JSON.Encode.string),
-  ("payment_method_type", "affirm"->JSON.Encode.string),
-  ("payment_experience", "redirect_to_url"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "pay_later",
-        [("affirm_redirect", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
 
 let cryptoBody = (~currency) => [
   ("payment_method", "crypto"->JSON.Encode.string),
@@ -1008,96 +976,6 @@ let interacBody = (~email, ~country) => [
   ),
 ]
 
-let mobilePayBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "mobile_pay"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("mobile_pay", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let aliPayRedirectBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "ali_pay"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("ali_pay_redirect", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let aliPayQrBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "ali_pay"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("ali_pay_qr", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let weChatPayRedirectBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "we_chat_pay"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("we_chat_pay_redirect", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let weChatPayQrBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "we_chat_pay"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("we_chat_pay_qr", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
 let trustlyBody = (~country) => [
   ("payment_method", "bank_redirect"->JSON.Encode.string),
   ("payment_method_type", "trustly"->JSON.Encode.string),
@@ -1112,24 +990,6 @@ let trustlyBody = (~country) => [
             [("country", country->JSON.Encode.string)]->Dict.fromArray->JSON.Encode.object,
           ),
         ]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let finlandOB = () => [
-  ("payment_method", "bank_redirect"->JSON.Encode.string),
-  ("payment_method_type", "online_banking_finland"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "bank_redirect",
-        [("online_banking_finland", []->Dict.fromArray->JSON.Encode.object)]
         ->Dict.fromArray
         ->JSON.Encode.object,
       ),
@@ -1208,41 +1068,6 @@ let slovakiaOB = (~bank) => [
   ),
 ]
 
-let walleyBody = () => [
-  ("payment_method", "pay_later"->JSON.Encode.string),
-  ("payment_method_type", "walley"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "pay_later",
-        [("walley_redirect", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let payBrightBody = () => [
-  ("payment_method", "pay_later"->JSON.Encode.string),
-  ("payment_method_type", "pay_bright"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "pay_later",
-        [("pay_bright_redirect", []->Dict.fromArray->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
 let mbWayBody = (~phoneNumber) => [
   ("payment_method", "wallet"->JSON.Encode.string),
   ("payment_method_type", "mb_way"->JSON.Encode.string),
@@ -1261,152 +1086,6 @@ let mbWayBody = (~phoneNumber) => [
         ]
         ->Dict.fromArray
         ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let twintBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "twint"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("twint_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let vippsBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "vipps"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("vipps_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let danaBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "dana"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("dana_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let goPayBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "go_pay"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("go_pay_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-let kakaoPayBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "kakao_pay"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("kakao_pay_redirect", Dict.make()->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let gcashBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "gcash"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("gcash_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-let momoBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "momo"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("momo_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let touchNGoBody = () => [
-  ("payment_method", "wallet"->JSON.Encode.string),
-  ("payment_method_type", "touch_n_go"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "wallet",
-        [("touch_n_go_redirect", Dict.make()->JSON.Encode.object)]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
-
-let bizumBody = () => [
-  ("payment_method", "bank_redirect"->JSON.Encode.string),
-  ("payment_method_type", "bizum"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "bank_redirect",
-        [("bizum", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
       ),
     ]
     ->Dict.fromArray
@@ -1464,32 +1143,7 @@ let thailandOBBody = (~bank) => [
     ->JSON.Encode.object,
   ),
 ]
-let almaBody = () => [
-  ("payment_method", "pay_later"->JSON.Encode.string),
-  ("payment_method_type", "alma"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [("pay_later", [("alma", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object)]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
 
-let atomeBody = () => [
-  ("payment_method", "pay_later"->JSON.Encode.string),
-  ("payment_method_type", "atome"->JSON.Encode.string),
-  (
-    "payment_method_data",
-    [
-      (
-        "pay_later",
-        [("atome_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object,
-  ),
-]
 let multibancoBody = (~email) => [
   ("payment_method", "bank_transfer"->JSON.Encode.string),
   ("payment_method_type", "multibanco"->JSON.Encode.string),
@@ -1520,34 +1174,67 @@ let multibancoBody = (~email) => [
   ),
 ]
 
-let cardRedirectBody = () => {
-  [
-    ("payment_method", "card_redirect"->JSON.Encode.string),
-    ("payment_method_type", "card_redirect"->JSON.Encode.string),
-    (
-      "payment_method_data",
-      [
-        (
-          "card_redirect",
-          [("card_redirect", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-        ),
-      ]
-      ->Dict.fromArray
-      ->JSON.Encode.object,
-    ),
-  ]
+let getPaymentMethodType = (paymentMethod, paymentMethodType) => {
+  switch paymentMethod {
+  | "bank_debit" => paymentMethodType->String.replace("_debit", "")
+  | "bank_transfer" => paymentMethodType->String.replace("_transfer", "")
+  | _ => paymentMethodType
+  }
 }
 
-let openBankingUKBody = () => {
+let appendRedirectPaymentMethods = [
+  "touch_n_go",
+  "momo",
+  "gcash",
+  "kakao_pay",
+  "go_pay",
+  "dana",
+  "vipps",
+  "twint",
+  "atome",
+  "pay_bright",
+  "walley",
+  "affirm",
+  "we_chat_pay",
+  "ali_pay",
+]
+
+let appendPaymentMethodExperience = (paymentMethodType, isQrPaymentMethod) => {
+  if isQrPaymentMethod {
+    paymentMethodType ++ "_qr"
+  } else if appendRedirectPaymentMethods->Array.includes(paymentMethodType) {
+    paymentMethodType ++ "_redirect"
+  } else {
+    paymentMethodType
+  }
+}
+
+let paymentExperiencePaymentMethods = ["affirm"]
+
+let appendPaymentExperience = (paymentBodyArr, paymentMethodType) => {
+  if paymentExperiencePaymentMethods->Array.includes(paymentMethodType) {
+    paymentBodyArr->Array.concat([("payment_experience", "redirect_to_url"->JSON.Encode.string)])
+  } else {
+    paymentBodyArr
+  }
+}
+
+let dynamicPaymentBody = (paymentMethod, paymentMethodType, ~isQrPaymentMethod=false) => {
+  let paymentMethodType = paymentMethod->getPaymentMethodType(paymentMethodType)
   [
-    ("payment_method", "bank_redirect"->JSON.Encode.string),
-    ("payment_method_type", "open_banking_uk"->JSON.Encode.string),
+    ("payment_method", paymentMethod->JSON.Encode.string),
+    ("payment_method_type", paymentMethodType->JSON.Encode.string),
     (
       "payment_method_data",
       [
         (
-          "bank_redirect",
-          [("open_banking_uk", Dict.make()->JSON.Encode.object)]
+          paymentMethod,
+          [
+            (
+              paymentMethodType->appendPaymentMethodExperience(isQrPaymentMethod),
+              Dict.make()->JSON.Encode.object,
+            ),
+          ]
           ->Dict.fromArray
           ->JSON.Encode.object,
         ),
@@ -1555,49 +1242,12 @@ let openBankingUKBody = () => {
       ->Dict.fromArray
       ->JSON.Encode.object,
     ),
-  ]
-}
-
-let pixTransferBody = () => {
-  [
-    ("payment_method", "bank_transfer"->JSON.Encode.string),
-    ("payment_method_type", "pix"->JSON.Encode.string),
-    (
-      "payment_method_data",
-      [
-        (
-          "bank_transfer",
-          [("pix", Dict.make()->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object,
-        ),
-      ]
-      ->Dict.fromArray
-      ->JSON.Encode.object,
-    ),
-  ]
-}
-
-let localBankTransferBody = () => {
-  [
-    ("payment_method", "bank_transfer"->JSON.Encode.string),
-    ("payment_method_type", "local_bank_transfer"->JSON.Encode.string),
-    (
-      "payment_method_data",
-      [
-        (
-          "bank_transfer",
-          [("local_bank_transfer", Dict.make()->JSON.Encode.object)]
-          ->Dict.fromArray
-          ->JSON.Encode.object,
-        ),
-      ]
-      ->Dict.fromArray
-      ->JSON.Encode.object,
-    ),
-  ]
+  ]->appendPaymentExperience(paymentMethodType)
 }
 
 let getPaymentBody = (
   ~paymentMethod,
+  ~paymentMethodType,
   ~fullName,
   ~email,
   ~country,
@@ -1607,60 +1257,41 @@ let getPaymentBody = (
   ~phoneNumber,
   ~currency,
 ) => {
-  switch paymentMethod {
-  | "affirm" => affirmBody()
+  switch paymentMethodType {
   | "afterpay_clearpay" => afterpayRedirectionBody(~fullName, ~email)
   | "crypto_currency" => cryptoBody(~currency)
   | "sofort" => sofortBody(~country, ~name=fullName, ~email)
   | "ideal" => iDealBody(~name=fullName, ~bankName=bank)
   | "eps" => epsBody(~name=fullName, ~bankName=bank)
   | "blik" => blikBody(~blikCode)
-  | "mobile_pay" => mobilePayBody()
   | "ali_pay" =>
     switch paymentExperience {
-    | QrFlow => aliPayQrBody()
+    | QrFlow => dynamicPaymentBody(paymentMethod, paymentMethodType, ~isQrPaymentMethod=true)
     | RedirectToURL
     | _ =>
-      aliPayRedirectBody()
+      dynamicPaymentBody(paymentMethod, paymentMethodType)
     }
   | "we_chat_pay" =>
     switch paymentExperience {
-    | QrFlow => weChatPayQrBody()
+    | QrFlow => dynamicPaymentBody(paymentMethod, paymentMethodType, ~isQrPaymentMethod=true)
     | RedirectToURL
     | _ =>
-      weChatPayRedirectBody()
+      dynamicPaymentBody(paymentMethod, paymentMethodType)
     }
   | "giropay" => giroPayBody(~name=fullName, ())
   | "trustly" => trustlyBody(~country)
-  | "online_banking_finland" => finlandOB()
   | "online_banking_poland" => polandOB(~bank)
   | "online_banking_czech_republic" => czechOB(~bank)
   | "online_banking_slovakia" => slovakiaOB(~bank)
-  | "walley" => walleyBody()
-  | "pay_bright" => payBrightBody()
   | "mb_way" => mbWayBody(~phoneNumber)
   | "interac" => interacBody(~email, ~country)
   | "przelewy24" => p24Body(~email)
-  | "twint" => twintBody()
-  | "vipps" => vippsBody()
-  | "dana" => danaBody()
-  | "go_pay" => goPayBody()
-  | "kakao_pay" => kakaoPayBody()
-  | "gcash" => gcashBody()
-  | "momo" => momoBody()
-  | "touch_n_go" => touchNGoBody()
-  | "bizum" => bizumBody()
   | "online_banking_fpx" => fpxOBBody(~bank)
   | "online_banking_thailand" => thailandOBBody(~bank)
-  | "alma" => almaBody()
-  | "atome" => atomeBody()
   | "multibanco" => multibancoBody(~email)
-  | "classic" => rewardBody(~paymentMethodType=paymentMethod)
-  | "card_redirect" => cardRedirectBody()
-  | "open_banking_uk" => openBankingUKBody()
-  | "evoucher" => rewardBody(~paymentMethodType=paymentMethod)
-  | "pix_transfer" => pixTransferBody()
-  | "local_bank_transfer_transfer" => localBankTransferBody()
-  | _ => []
+  | "classic"
+  | "evoucher" =>
+    rewardBody(~paymentMethodType)
+  | _ => dynamicPaymentBody(paymentMethod, paymentMethodType)
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## How did you test it?

Test the confirm body for the following payment methods -

- affirm
- mobile_pay
- ali_pay (Both redirection and QR)
- we_chat_pay (Both redirection and QR)
- online_banking_finland
- walley
- pay_bright
- twint
- vipps
- dana
- go_pay
- kakao_pay
- gcash
- momo
- touch_n_go
- bizum
- alma
- atome
- card_redirect
- open_banking_uk
- pix
- local_bank_transfer

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
