### PR TITLE
fix: move applepay thirdparty event listeners outside

### DIFF
--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -273,13 +273,6 @@ let make = (
           let bodyDict = PaymentBody.applePayRedirectBody(~connectors)
           processPayment(bodyDict)
         }
-        let value = "Payment Data Filled: New Payment Method"
-        loggerState.setLogInfo(
-          ~value,
-          ~eventName=PAYMENT_DATA_FILLED,
-          ~paymentMethod="APPLE_PAY",
-          (),
-        )
       } else {
         setApplePayClicked(_ => false)
       }

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -149,13 +149,6 @@ let make = (
     makeOneClickHandlerPromise(sdkHandleOneClickConfirmPayment)->then(result => {
       let result = result->JSON.Decode.bool->Option.getOr(false)
       if result {
-        let value = "Payment Data Filled: New Payment Method"
-        loggerState.setLogInfo(
-          ~value,
-          ~eventName=PAYMENT_DATA_FILLED,
-          ~paymentMethod="GOOGLE_PAY",
-          (),
-        )
         if isInvokeSDKFlow {
           if isDelayedSessionToken {
             handlePostMessage([


### PR DESCRIPTION
move Trustpay applepay event listeners outside of handleSessionTokensLoaded event listener

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
