### PR TITLE
feat: hideExpiredPaymentMethods prop added

### DIFF
--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -12,6 +12,7 @@ let make = (
   ~setRequiredFieldsBody,
 ) => {
   let {themeObj, config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {hideExpiredPaymentMethods} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let (cardBrand, setCardBrand) = Recoil.useRecoilState(RecoilAtoms.cardBrand)
   let (
     isCVCValid,
@@ -59,135 +60,137 @@ let make = (
   | None => "debit"
   }
 
-  <button
-    className={`PickerItem ${pickerItemClass} flex flex-row items-stretch`}
-    type_="button"
-    style={ReactDOMStyle.make(
-      ~minWidth="150px",
-      ~width="100%",
-      ~padding="1rem 0 1rem 0",
-      ~cursor="pointer",
-      ~borderBottom=index == savedCardlength - 1 ? "0px" : `1px solid ${themeObj.borderColor}`,
-      ~borderTop="none",
-      ~borderLeft="none",
-      ~borderRight="none",
-      ~borderRadius="0px",
-      ~background="transparent",
-      ~color=themeObj.colorTextSecondary,
-      ~boxShadow="none",
-      ~opacity={isCardExpired ? "0.7" : "1"},
-      (),
-    )}
-    onClick={_ => setPaymentToken(_ => (paymentItem.paymentToken, paymentItem.customerId))}>
-    <div className="w-full">
-      <div>
-        <div className="flex flex-row justify-between items-center">
-          <div
-            className={`flex flex-row justify-center items-center`}
-            style={ReactDOMStyle.make(~columnGap=themeObj.spacingUnit, ())}>
-            <div style={ReactDOMStyle.make(~color=isActive ? themeObj.colorPrimary : "", ())}>
-              <Radio
-                checked=isActive
-                height="18px"
-                className="savedcard"
-                marginTop="-2px"
-                opacity="20%"
-                padding="46%"
-                border="1px solid currentColor"
-              />
-            </div>
-            <div className={`PickerItemIcon mx-3 flex  items-center `}> brandIcon </div>
-            <div className="flex flex-col">
-              <div className="flex items-center gap-4">
-                {isCard
-                  ? <div className="flex flex-col items-start">
-                      <div> {React.string(paymentItem.card.nickname)} </div>
-                      <div className={`PickerItemLabel flex flex-row gap-3 items-center`}>
-                        <div className="tracking-widest"> {React.string(`****`)} </div>
-                        <div> {React.string(paymentItem.card.last4Digits)} </div>
-                      </div>
-                    </div>
-                  : <div> {React.string(paymentMethodType->Utils.snakeToTitleCase)} </div>}
-                <RenderIf condition={paymentItem.defaultPaymentMethodSet}>
-                  <Icon
-                    size=18
-                    name="checkmark"
-                    style={ReactDOMStyle.make(~color=themeObj.colorPrimary, ())}
-                  />
-                </RenderIf>
-              </div>
-            </div>
-          </div>
-          <RenderIf condition={isCard}>
+  <RenderIf condition={!hideExpiredPaymentMethods || !isCardExpired}>
+    <button
+      className={`PickerItem ${pickerItemClass} flex flex-row items-stretch`}
+      type_="button"
+      style={ReactDOMStyle.make(
+        ~minWidth="150px",
+        ~width="100%",
+        ~padding="1rem 0 1rem 0",
+        ~cursor="pointer",
+        ~borderBottom=index == savedCardlength - 1 ? "0px" : `1px solid ${themeObj.borderColor}`,
+        ~borderTop="none",
+        ~borderLeft="none",
+        ~borderRight="none",
+        ~borderRadius="0px",
+        ~background="transparent",
+        ~color=themeObj.colorTextSecondary,
+        ~boxShadow="none",
+        ~opacity={isCardExpired ? "0.7" : "1"},
+        (),
+      )}
+      onClick={_ => setPaymentToken(_ => (paymentItem.paymentToken, paymentItem.customerId))}>
+      <div className="w-full">
+        <div>
+          <div className="flex flex-row justify-between items-center">
             <div
-              className={`flex flex-row items-center justify-end gap-3 -mt-1`}
-              style={ReactDOMStyle.make(~fontSize="14px", ~opacity="0.5", ())}>
-              <div className="flex">
-                {React.string(
-                  `${paymentItem.card.expiryMonth} / ${paymentItem.card.expiryYear->CardUtils.formatExpiryToTwoDigit}`,
-                )}
+              className={`flex flex-row justify-center items-center`}
+              style={ReactDOMStyle.make(~columnGap=themeObj.spacingUnit, ())}>
+              <div style={ReactDOMStyle.make(~color=isActive ? themeObj.colorPrimary : "", ())}>
+                <Radio
+                  checked=isActive
+                  height="18px"
+                  className="savedcard"
+                  marginTop="-2px"
+                  opacity="20%"
+                  padding="46%"
+                  border="1px solid currentColor"
+                />
+              </div>
+              <div className={`PickerItemIcon mx-3 flex  items-center `}> brandIcon </div>
+              <div className="flex flex-col">
+                <div className="flex items-center gap-4">
+                  {isCard
+                    ? <div className="flex flex-col items-start">
+                        <div> {React.string(paymentItem.card.nickname)} </div>
+                        <div className={`PickerItemLabel flex flex-row gap-3 items-center`}>
+                          <div className="tracking-widest"> {React.string(`****`)} </div>
+                          <div> {React.string(paymentItem.card.last4Digits)} </div>
+                        </div>
+                      </div>
+                    : <div> {React.string(paymentMethodType->Utils.snakeToTitleCase)} </div>}
+                  <RenderIf condition={paymentItem.defaultPaymentMethodSet}>
+                    <Icon
+                      size=18
+                      name="checkmark"
+                      style={ReactDOMStyle.make(~color=themeObj.colorPrimary, ())}
+                    />
+                  </RenderIf>
+                </div>
               </div>
             </div>
-          </RenderIf>
-        </div>
-        <div className="w-full ">
-          <div className="flex flex-col items-start mx-8">
-            <RenderIf condition={isActive && isRenderCvv}>
+            <RenderIf condition={isCard}>
               <div
-                className={`flex flex-row items-start justify-start gap-2`}
+                className={`flex flex-row items-center justify-end gap-3 -mt-1`}
                 style={ReactDOMStyle.make(~fontSize="14px", ~opacity="0.5", ())}>
-                <div className="w-12 mt-6"> {React.string("CVC: ")} </div>
-                <div
-                  className={`flex h mx-4 justify-start w-16 ${isActive
-                      ? "opacity-1 mt-4"
-                      : "opacity-0"}`}>
-                  <PaymentInputField
-                    isValid=isCVCValid
-                    setIsValid=setIsCVCValid
-                    value=cvcNumber
-                    onChange=changeCVCNumber
-                    onBlur=handleCVCBlur
-                    errorString=cvcError
-                    inputFieldClassName="flex justify-start"
-                    paymentType
-                    appearance=config.appearance
-                    type_="tel"
-                    className={`tracking-widest justify-start w-full`}
-                    maxLength=4
-                    inputRef=cvcRef
-                    placeholder="123"
-                    height="2.2rem"
-                  />
+                <div className="flex">
+                  {React.string(
+                    `${paymentItem.card.expiryMonth} / ${paymentItem.card.expiryYear->CardUtils.formatExpiryToTwoDigit}`,
+                  )}
                 </div>
               </div>
             </RenderIf>
-            <RenderIf condition={isCardExpired}>
-              <div
-                className="italic mt-3 ml-1"
-                style={ReactDOMStyle.make(~fontSize="14px", ~opacity="0.7", ())}>
-                {`*${localeString.cardExpiredText}`->React.string}
-              </div>
-            </RenderIf>
-            <RenderIf condition={isActive}>
-              <DynamicFields
-                paymentType
-                list
-                paymentMethod=paymentItem.paymentMethod
-                paymentMethodType
-                setRequiredFieldsBody
-                isSavedCardFlow=true
-                savedMethod=paymentItem
-              />
-              <Surcharge
-                list
-                paymentMethod=paymentItem.paymentMethod
-                paymentMethodType
-                cardBrand={cardBrand->CardUtils.getCardType}
-              />
-            </RenderIf>
+          </div>
+          <div className="w-full ">
+            <div className="flex flex-col items-start mx-8">
+              <RenderIf condition={isActive && isRenderCvv}>
+                <div
+                  className={`flex flex-row items-start justify-start gap-2`}
+                  style={ReactDOMStyle.make(~fontSize="14px", ~opacity="0.5", ())}>
+                  <div className="w-12 mt-6"> {React.string("CVC: ")} </div>
+                  <div
+                    className={`flex h mx-4 justify-start w-16 ${isActive
+                        ? "opacity-1 mt-4"
+                        : "opacity-0"}`}>
+                    <PaymentInputField
+                      isValid=isCVCValid
+                      setIsValid=setIsCVCValid
+                      value=cvcNumber
+                      onChange=changeCVCNumber
+                      onBlur=handleCVCBlur
+                      errorString=cvcError
+                      inputFieldClassName="flex justify-start"
+                      paymentType
+                      appearance=config.appearance
+                      type_="tel"
+                      className={`tracking-widest justify-start w-full`}
+                      maxLength=4
+                      inputRef=cvcRef
+                      placeholder="123"
+                      height="2.2rem"
+                    />
+                  </div>
+                </div>
+              </RenderIf>
+              <RenderIf condition={isCardExpired}>
+                <div
+                  className="italic mt-3 ml-1"
+                  style={ReactDOMStyle.make(~fontSize="14px", ~opacity="0.7", ())}>
+                  {`*${localeString.cardExpiredText}`->React.string}
+                </div>
+              </RenderIf>
+              <RenderIf condition={isActive}>
+                <DynamicFields
+                  paymentType
+                  list
+                  paymentMethod=paymentItem.paymentMethod
+                  paymentMethodType
+                  setRequiredFieldsBody
+                  isSavedCardFlow=true
+                  savedMethod=paymentItem
+                />
+                <Surcharge
+                  list
+                  paymentMethod=paymentItem.paymentMethod
+                  paymentMethodType
+                  cardBrand={cardBrand->CardUtils.getCardType}
+                />
+              </RenderIf>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </button>
+    </button>
+  </RenderIf>
 }

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -49,8 +49,10 @@ let make = (
 
   let isCard = paymentItem.paymentMethod === "card"
   let isRenderCvv = isCard && paymentItem.requiresCvv
+  let expiryMonth = paymentItem.card.expiryMonth
+  let expiryYear = paymentItem.card.expiryYear
 
-  let expiryDate = Date.fromString(`${paymentItem.card.expiryYear}-${paymentItem.card.expiryMonth}`)
+  let expiryDate = Date.fromString(`${expiryYear}-${expiryMonth}`)
   expiryDate->Date.setMonth(expiryDate->Date.getMonth + 1)
   let currentDate = Date.make()
   let isCardExpired = isCard && expiryDate < currentDate
@@ -125,14 +127,12 @@ let make = (
                 className={`flex flex-row items-center justify-end gap-3 -mt-1`}
                 style={ReactDOMStyle.make(~fontSize="14px", ~opacity="0.5", ())}>
                 <div className="flex">
-                  {React.string(
-                    `${paymentItem.card.expiryMonth} / ${paymentItem.card.expiryYear->CardUtils.formatExpiryToTwoDigit}`,
-                  )}
+                  {React.string(`${expiryMonth} / ${expiryYear->CardUtils.formatExpiryToTwoDigit}`)}
                 </div>
               </div>
             </RenderIf>
           </div>
-          <div className="w-full ">
+          <div className="w-full">
             <div className="flex flex-col items-start mx-8">
               <RenderIf condition={isActive && isRenderCvv}>
                 <div

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -161,6 +161,7 @@ type options = {
   sdkHandleConfirmPayment: sdkHandleConfirmPayment,
   paymentMethodsHeaderText?: string,
   savedPaymentMethodsHeaderText?: string,
+  hideExpiredPaymentMethods: bool,
 }
 let defaultCardDetails = {
   scheme: None,
@@ -289,6 +290,7 @@ let defaultOptions = {
   showCardFormByDefault: true,
   billingAddress: defaultBillingAddress,
   sdkHandleConfirmPayment: defaultSdkHandleConfirmPayment,
+  hideExpiredPaymentMethods: false,
 }
 let getLayout = (str, logger) => {
   switch str {
@@ -935,6 +937,7 @@ let itemToObjMapper = (dict, logger) => {
       "sdkHandleConfirmPayment",
       "paymentMethodsHeaderText",
       "savedPaymentMethodsHeaderText",
+      "hideExpiredPaymentMethods",
     ],
     dict,
     "options",
@@ -975,6 +978,7 @@ let itemToObjMapper = (dict, logger) => {
     ->getSdkHandleConfirmPaymentProps,
     paymentMethodsHeaderText: ?getOptionString(dict, "paymentMethodsHeaderText"),
     savedPaymentMethodsHeaderText: ?getOptionString(dict, "savedPaymentMethodsHeaderText"),
+    hideExpiredPaymentMethods: getBool(dict, "hideExpiredPaymentMethods", false),
   }
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

There was no prop for hiding the expired saved payment methods now we can hide expired saved payment methods via passing this prop in PaymentElementOptions. 

```js
  let options = {
    ...,
    "hideExpiredPaymentMethods": true,
  }
```

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Via passing hideExpiredPaymentMethods in options it will hide the expied cards.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
