### PR TITLE
fix: combined Dynamic Fields for credit and debit

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -29,9 +29,19 @@ let make = (
     ~paymentMethodType,
   )
 
+  let creditPaymentMethodTypes = PaymentUtils.usePaymentMethodTypeFromList(
+    ~paymentMethodListValue,
+    ~paymentMethod,
+    ~paymentMethodType="credit",
+  )
+
   let requiredFieldsWithBillingDetails = React.useMemo(() => {
     if paymentMethod === "card" {
+      let creditRequiredFields = creditPaymentMethodTypes.required_fields
+
       paymentMethodTypes.required_fields
+      ->Array.concat(creditRequiredFields)
+      ->DynamicFieldsUtils.removeRequiredFieldsDuplicates
     } else if (
       PaymentMethodsRecord.dynamicFieldsEnabledPaymentMethods->Array.includes(paymentMethodType)
     ) {

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -783,3 +783,23 @@ let useAreAllRequiredFieldsPrefilled = (
     acc && requiredField.value != ""
   })
 }
+
+let removeRequiredFieldsDuplicates = (
+  requiredFields: array<PaymentMethodsRecord.required_fields>,
+) => {
+  let (_, requiredFields) = requiredFields->Array.reduce(([], []), (
+    (requiredFieldKeys, uniqueRequiredFields),
+    item,
+  ) => {
+    let requiredField = item.required_field
+
+    if requiredFieldKeys->Array.includes(requiredField)->not {
+      requiredFieldKeys->Array.push(requiredField)
+      uniqueRequiredFields->Array.push(item)
+    }
+
+    (requiredFieldKeys, uniqueRequiredFields)
+  })
+
+  requiredFields
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Combined Dynamic Fields for credit and debit

## How did you test it?

Even if Dynamic Fields are only coming for credit, the fields should still be visible

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
