### PR TITLE
feat: address collection for one click widgets

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -484,7 +484,14 @@ let make = (
           | BlikCode
           | SpecialField(_)
           | CountryAndPincode(_)
-          | AddressCountry(_) => React.null
+          | AddressCountry(_)
+          | ShippingName // Shipping Details are currently supported by only one click widgets
+          | ShippingAddressLine1
+          | ShippingAddressLine2
+          | ShippingAddressCity
+          | ShippingAddressPincode
+          | ShippingAddressState
+          | ShippingAddressCountry(_) => React.null
           }}
         </div>
       })
@@ -757,6 +764,13 @@ let make = (
                 | CardExpiryAndCvc
                 | Currency(_)
                 | FullName
+                | ShippingName // Shipping Details are currently supported by only one click widgets
+                | ShippingAddressLine1
+                | ShippingAddressLine2
+                | ShippingAddressCity
+                | ShippingAddressPincode
+                | ShippingAddressState
+                | ShippingAddressCountry(_)
                 | None => React.null
                 }}
               </div>

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -344,7 +344,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
         showFields}>
       <div className="flex flex-col place-items-center">
         <ErrorBoundary key="payment_request_buttons_all" level={ErrorBoundary.RequestButton}>
-          <PaymentRequestButtonElement sessions walletOptions />
+          <PaymentRequestButtonElement sessions walletOptions paymentType />
         </ErrorBoundary>
         <RenderIf
           condition={paymentOptions->Array.length > 0 &&

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -226,8 +226,6 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
   }
   let dict = sessions->getDictFromJson
   let sessionObj = SessionsType.itemToObjMapper(dict, Others)
-  let applePaySessionObj = SessionsType.itemToObjMapper(dict, ApplePayObject)
-  let applePayToken = SessionsType.getPaymentSessionObj(applePaySessionObj.sessionsToken, ApplePay)
   let klarnaTokenObj = SessionsType.getPaymentSessionObj(sessionObj.sessionsToken, Klarna)
   let gPayToken = SessionsType.getPaymentSessionObj(sessionObj.sessionsToken, Gpay)
   let googlePayThirdPartySessionObj = SessionsType.itemToObjMapper(dict, GooglePayThirdPartyObject)
@@ -317,12 +315,6 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
               <GPayLazy paymentType sessionObj=optToken thirdPartySessionObj=None walletOptions />
             </React.Suspense>
           }
-        | _ => React.null
-        }
-      | ApplePay =>
-        switch applePayToken {
-        | ApplePayTokenOptional(optToken) =>
-          <ApplePayLazy sessionObj=optToken walletOptions paymentType />
         | _ => React.null
         }
       | Boleto =>

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -25,9 +25,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
   let (walletOptions, setWalletOptions) = React.useState(_ => [])
   let {sdkHandleConfirmPayment} = Recoil.useRecoilValueFromAtom(optionAtom)
 
-  let (paymentMethodListValue, setPaymentMethodListValue) = Recoil.useRecoilState(
-    PaymentUtils.paymentMethodListValue,
-  )
+  let setPaymentMethodListValue = Recoil.useSetRecoilState(PaymentUtils.paymentMethodListValue)
   let (cardsContainerWidth, setCardsContainerWidth) = React.useState(_ => 0)
   let layoutClass = CardUtils.getLayoutClass(layout)
   let (selectedOption, setSelectedOption) = Recoil.useRecoilState(selectedOptionAtom)
@@ -102,7 +100,6 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
   }, [savedMethods])
 
   let (walletList, paymentOptionsList, actualList) = PaymentUtils.useGetPaymentMethodList(
-    ~paymentMethodListValue,
     ~paymentOptions,
     ~paymentType,
   )
@@ -227,12 +224,6 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
   let dict = sessions->getDictFromJson
   let sessionObj = SessionsType.itemToObjMapper(dict, Others)
   let klarnaTokenObj = SessionsType.getPaymentSessionObj(sessionObj.sessionsToken, Klarna)
-  let gPayToken = SessionsType.getPaymentSessionObj(sessionObj.sessionsToken, Gpay)
-  let googlePayThirdPartySessionObj = SessionsType.itemToObjMapper(dict, GooglePayThirdPartyObject)
-  let googlePayThirdPartyToken = SessionsType.getPaymentSessionObj(
-    googlePayThirdPartySessionObj.sessionsToken,
-    Gpay,
-  )
 
   let loader = () => {
     handlePostMessageEvents(
@@ -297,26 +288,6 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
         <React.Suspense fallback={loader()}>
           <BecsBankDebitLazy paymentType />
         </React.Suspense>
-      | GooglePay =>
-        switch gPayToken {
-        | OtherTokenOptional(optToken) =>
-          switch googlePayThirdPartyToken {
-          | GooglePayThirdPartyTokenOptional(googlePayThirdPartyOptToken) =>
-            <React.Suspense fallback={loader()}>
-              <GPayLazy
-                paymentType
-                sessionObj=optToken
-                thirdPartySessionObj=googlePayThirdPartyOptToken
-                walletOptions
-              />
-            </React.Suspense>
-          | _ =>
-            <React.Suspense fallback={loader()}>
-              <GPayLazy paymentType sessionObj=optToken thirdPartySessionObj=None walletOptions />
-            </React.Suspense>
-          }
-        | _ => React.null
-        }
       | Boleto =>
         <React.Suspense fallback={loader()}>
           <BoletoLazy paymentType />

--- a/src/PaymentElementRenderer.res
+++ b/src/PaymentElementRenderer.res
@@ -15,12 +15,12 @@ let make = (
   switch (sessions, paymentMethodList) {
   | (_, Loading) =>
     <RenderIf condition=showLoader>
-      {paymentType->Utils.isWalletElementPaymentType
+      {paymentType->Utils.getIsWalletElementPaymentType
         ? <WalletShimmer />
         : <PaymentElementShimmer />}
     </RenderIf>
   | _ =>
-    paymentType->Utils.isWalletElementPaymentType
+    paymentType->Utils.getIsWalletElementPaymentType
       ? <WalletElement paymentType />
       : <PaymentElement cardProps expiryProps cvcProps paymentType />
   }

--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -300,7 +300,7 @@ let make = (~sessionObj: option<JSON.t>) => {
             ->Option.getOr(Dict.make())
             ->ApplePayTypes.shippingContactItemToObjMapper
 
-          let requiredFieldsBody = DynamicFieldsUtils.getApplePayRequiredFieldsFromBillingAndShippingContact(
+          let requiredFieldsBody = DynamicFieldsUtils.getApplePayRequiredFields(
             ~billingContact,
             ~shippingContact,
             ~paymentMethodTypes,

--- a/src/Payments/ApplePay.resi
+++ b/src/Payments/ApplePay.resi
@@ -1,6 +1,2 @@
 @react.component
-let default: (
-  ~sessionObj: option<JSON.t>,
-  ~paymentType: option<CardThemeType.mode>,
-  ~walletOptions: array<string>,
-) => React.element
+let default: (~sessionObj: option<JSON.t>) => React.element

--- a/src/Payments/ApplePayLazy.res
+++ b/src/Payments/ApplePayLazy.res
@@ -1,9 +1,7 @@
 open LazyUtils
 
 type props = {
-  sessionObj: option<JSON.t>,
-  paymentType: CardThemeType.mode,
-  walletOptions: array<string>,
+  sessionObj: option<JSON.t>
 }
 
 let make: props => React.element = reactLazy(() => import_("./ApplePay.bs.js"))

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -2,26 +2,18 @@ open Utils
 open RecoilAtoms
 
 open GooglePayType
+open Promise
 
 @react.component
-let make = (
-  ~sessionObj: option<SessionsType.token>,
-  ~thirdPartySessionObj: option<JSON.t>,
-  ~paymentType: option<CardThemeType.mode>,
-  ~walletOptions: array<string>,
-) => {
-  let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
+let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: option<JSON.t>) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let {publishableKey, sdkHandleOneClickConfirmPayment} = Recoil.useRecoilValueFromAtom(keys)
-  let {localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Gpay)
   let sync = PaymentHelpers.usePaymentSync(Some(loggerState), Gpay)
   let isGPayReady = Recoil.useRecoilValueFromAtom(isGooglePayReady)
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
-  let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
-  let areRequiredFieldsEmpty = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsEmpty)
   let status = CommonHooks.useScript("https://pay.google.com/gp/p/js/pay.js")
   let isGooglePaySDKFlow = React.useMemo(() => {
     sessionObj->Option.isSome
@@ -44,7 +36,6 @@ let make = (
   | None => PaymentMethodsRecord.defaultPaymentMethodType
   }
 
-  let isWallet = walletOptions->Array.includes("google_pay")
   let paymentExperience = switch googlePayPaymentMethodType.payment_experience[0] {
   | Some(paymentExperience) => paymentExperience.payment_experience_type
   | None => PaymentMethodsRecord.RedirectToURL
@@ -79,11 +70,24 @@ let make = (
     )
   }
 
-  UtilityHooks.useHandlePostMessages(
-    ~complete=areRequiredFieldsValid,
-    ~empty=areRequiredFieldsEmpty,
-    ~paymentType="google_pay",
+  let paymentMethodTypes = DynamicFieldsUtils.usePaymentMethodTypeFromList(
+    ~paymentMethodListValue,
+    ~paymentMethod="wallet",
+    ~paymentMethodType="google_pay",
   )
+
+  let (stateJson, setStatesJson) = React.useState(_ => JSON.Encode.null)
+
+  React.useEffect0(() => {
+    AddressPaymentInput.importStates("./../States.json")
+    ->then(res => {
+      setStatesJson(_ => res.states)
+      resolve()
+    })
+    ->ignore
+
+    None
+  })
 
   React.useEffect(() => {
     let handle = (ev: Window.event) => {
@@ -102,6 +106,33 @@ let make = (
           ~body=PaymentBody.gpayBody(~payObj=obj, ~connectors),
         )
 
+        let billingContact =
+          obj.paymentMethodData.info
+          ->getDictFromJson
+          ->Utils.getJsonObjectFromDict("billingAddress")
+          ->getDictFromJson
+          ->billingContactItemToObjMapper
+
+        let shippingContact =
+          metadata
+          ->getDictFromJson
+          ->Utils.getJsonObjectFromDict("shippingAddress")
+          ->getDictFromJson
+          ->billingContactItemToObjMapper
+
+        let email =
+          metadata
+          ->getDictFromJson
+          ->Utils.getString("email", "")
+
+        let requiredFieldsBody = DynamicFieldsUtils.getGooglePayRequiredFields(
+          ~billingContact,
+          ~shippingContact,
+          ~paymentMethodTypes,
+          ~statesList=stateJson,
+          ~email,
+        )
+
         let body = {
           gPayBody
           ->getJsonFromArrayOfJson
@@ -113,14 +144,11 @@ let make = (
       }
       if dict->Dict.get("gpayError")->Option.isSome {
         Utils.handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
-        if !isWallet {
-          postFailedSubmitResponse(~errortype="server_error", ~message="Something went wrong")
-        }
       }
     }
     Window.addEventListener("message", handle)
     Some(() => {Window.removeEventListener("message", handle)})
-  }, [requiredFieldsBody])
+  }, (paymentMethodTypes, stateJson))
 
   let (_, buttonType, _) = options.wallets.style.type_
   let (_, heightType, _) = options.wallets.style.height
@@ -151,7 +179,6 @@ let make = (
       ~paymentMethod="GOOGLE_PAY",
       (),
     )
-    open Promise
     makeOneClickHandlerPromise(sdkHandleOneClickConfirmPayment)->then(result => {
       let result = result->JSON.Decode.bool->Option.getOr(false)
       if result {
@@ -204,10 +231,9 @@ let make = (
   React.useEffect(() => {
     if (
       status == "ready" &&
-      (isGPayReady ||
-      isDelayedSessionToken ||
-      paymentExperience == PaymentMethodsRecord.RedirectToURL) &&
-      isWallet
+        (isGPayReady ||
+        isDelayedSessionToken ||
+        paymentExperience == PaymentMethodsRecord.RedirectToURL)
     ) {
       setIsShowOrPayUsing(_ => true)
       addGooglePayButton()
@@ -240,9 +266,7 @@ let make = (
   })
 
   let isRenderGooglePayButton =
-    (isGPayReady ||
-    paymentExperience == PaymentMethodsRecord.RedirectToURL ||
-    isDelayedSessionToken) && isWallet
+    isGPayReady || paymentExperience == PaymentMethodsRecord.RedirectToURL || isDelayedSessionToken
 
   React.useEffect(() => {
     areOneClickWalletsRendered(prev => {
@@ -252,51 +276,13 @@ let make = (
     None
   }, [isRenderGooglePayButton])
 
-  let submitCallback = (ev: Window.event) => {
-    if !isWallet {
-      let json = ev.data->JSON.parseExn
-      let confirm = json->getDictFromJson->ConfirmType.itemToObjMapper
-      if confirm.doSubmit && areRequiredFieldsValid && !areRequiredFieldsEmpty {
-        handlePostMessage([
-          ("fullscreen", true->JSON.Encode.bool),
-          ("param", "paymentloader"->JSON.Encode.string),
-          ("iframeId", iframeId->JSON.Encode.string),
-        ])
-        options.readOnly ? () : handlePostMessage([("GpayClicked", true->JSON.Encode.bool)])
-      } else if areRequiredFieldsEmpty {
-        postFailedSubmitResponse(
-          ~errortype="validation_error",
-          ~message=localeString.enterFieldsText,
-        )
-      } else if !areRequiredFieldsValid {
-        postFailedSubmitResponse(
-          ~errortype="validation_error",
-          ~message=localeString.enterValidDetailsText,
-        )
-      }
-    }
-  }
-  useSubmitPaymentData(submitCallback)
-
-  {
-    isWallet
-      ? <RenderIf condition={isRenderGooglePayButton}>
-          <div
-            style={height: `${height->Belt.Int.toString}px`}
-            id="google-pay-button"
-            className={`w-full flex flex-row justify-center rounded-md`}
-          />
-        </RenderIf>
-      : <DynamicFields
-          paymentType={switch paymentType {
-          | Some(val) => val
-          | _ => NONE
-          }}
-          paymentMethod="wallet"
-          paymentMethodType="google_pay"
-          setRequiredFieldsBody
-        />
-  }
+  <RenderIf condition={isRenderGooglePayButton}>
+    <div
+      style={height: `${height->Belt.Int.toString}px`}
+      id="google-pay-button"
+      className={`w-full flex flex-row justify-center rounded-md`}
+    />
+  </RenderIf>
 }
 
 let default = make

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -78,16 +78,7 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
 
   let (stateJson, setStatesJson) = React.useState(_ => JSON.Encode.null)
 
-  React.useEffect0(() => {
-    AddressPaymentInput.importStates("./../States.json")
-    ->then(res => {
-      setStatesJson(_ => res.states)
-      resolve()
-    })
-    ->ignore
-
-    None
-  })
+  PaymentUtils.useStatesJson(setStatesJson)
 
   React.useEffect(() => {
     let handle = (ev: Window.event) => {
@@ -96,7 +87,7 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
       } catch {
       | _ => Dict.make()->JSON.Encode.object
       }
-      let dict = json->Utils.getDictFromJson
+      let dict = json->getDictFromJson
       if dict->Dict.get("gpayResponse")->Option.isSome {
         let metadata = dict->getJsonObjectFromDict("gpayResponse")
         let obj = metadata->getDictFromJson->itemToObjMapper
@@ -109,21 +100,21 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
         let billingContact =
           obj.paymentMethodData.info
           ->getDictFromJson
-          ->Utils.getJsonObjectFromDict("billingAddress")
+          ->getJsonObjectFromDict("billingAddress")
           ->getDictFromJson
           ->billingContactItemToObjMapper
 
         let shippingContact =
           metadata
           ->getDictFromJson
-          ->Utils.getJsonObjectFromDict("shippingAddress")
+          ->getJsonObjectFromDict("shippingAddress")
           ->getDictFromJson
           ->billingContactItemToObjMapper
 
         let email =
           metadata
           ->getDictFromJson
-          ->Utils.getString("email", "")
+          ->getString("email", "")
 
         let requiredFieldsBody = DynamicFieldsUtils.getGooglePayRequiredFields(
           ~billingContact,
@@ -143,7 +134,7 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
         processPayment(body, ())
       }
       if dict->Dict.get("gpayError")->Option.isSome {
-        Utils.handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+        handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
       }
     }
     Window.addEventListener("message", handle)
@@ -248,13 +239,13 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
       } catch {
       | _ => Dict.make()->JSON.Encode.object
       }
-      let dict = json->Utils.getDictFromJson
+      let dict = json->getDictFromJson
       try {
         if dict->Dict.get("googlePaySyncPayment")->Option.isSome {
           syncPayment()
         }
       } catch {
-      | _ => Utils.logInfo(Console.log("Error in syncing GooglePay Payment"))
+      | _ => logInfo(Console.log("Error in syncing GooglePay Payment"))
       }
     }
     Window.addEventListener("message", handleGooglePayMessages)

--- a/src/Payments/GPay.resi
+++ b/src/Payments/GPay.resi
@@ -2,6 +2,4 @@
 let default: (
   ~sessionObj: option<SessionsType.token>,
   ~thirdPartySessionObj: option<JSON.t>,
-  ~paymentType: option<CardThemeType.mode>,
-  ~walletOptions: array<string>,
 ) => React.element

--- a/src/Payments/GPayLazy.res
+++ b/src/Payments/GPayLazy.res
@@ -3,8 +3,6 @@ open LazyUtils
 type props = {
   sessionObj: option<SessionsType.token>,
   thirdPartySessionObj: option<JSON.t>,
-  paymentType: CardThemeType.mode,
-  walletOptions: array<string>,
 }
 
 let make: props => React.element = reactLazy(() => import_("./GPay.bs.js"))

--- a/src/Payments/PayPal.res
+++ b/src/Payments/PayPal.res
@@ -3,7 +3,7 @@ open RecoilAtoms
 module Loader = {
   @react.component
   let make = () => {
-    <div className=" w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600">
+    <div className="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600">
       <Icon size=32 name="loader" />
     </div>
   }

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -552,10 +552,12 @@ let getOptionsFromPaymentMethodFieldType = (dict, key, ~isAddressCountry=true) =
       isAddressCountry ? AddressCountry(countryArr) : ShippingAddressCountry(countryArr)
     }
   | _ => {
-      let countryArr =
-        Country.country
-        ->Array.filter(item => options->Array.includes(item.isoAlpha2))
-        ->Array.map(item => item.countryName)
+      let countryArr = Country.country->Array.reduce([], (acc, country) => {
+        if options->Array.includes(country.isoAlpha2) {
+          acc->Array.push(country.countryName)
+        }
+        acc
+      })
       isAddressCountry ? AddressCountry(countryArr) : ShippingAddressCountry(countryArr)
     }
   }

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -27,6 +27,13 @@ type paymentMethodsFields =
   | CardExpiryMonthAndYear
   | CardCvc
   | CardExpiryAndCvc
+  | ShippingName
+  | ShippingAddressLine1
+  | ShippingAddressLine2
+  | ShippingAddressCity
+  | ShippingAddressPincode
+  | ShippingAddressState
+  | ShippingAddressCountry(array<string>)
 
 let getPaymentMethodsFieldsOrder = paymentMethodField => {
   switch paymentMethodField {
@@ -526,21 +533,31 @@ let getPaymentMethodsFieldTypeFromString = (str, isBancontact) => {
   | ("user_card_expiry_month", true) => CardExpiryMonth
   | ("user_card_expiry_year", true) => CardExpiryYear
   | ("user_card_cvc", true) => CardCvc
+  | ("user_shipping_name", _) => ShippingName
+  | ("user_shipping_address_line1", _) => ShippingAddressLine1
+  | ("user_shipping_address_line2", _) => ShippingAddressLine2
+  | ("user_shipping_address_city", _) => ShippingAddressCity
+  | ("user_shipping_address_pincode", _) => ShippingAddressPincode
+  | ("user_shipping_address_state", _) => ShippingAddressState
   | _ => None
   }
 }
 
-let getOptionsFromPaymentMethodFieldType = (dict, key) => {
+let getOptionsFromPaymentMethodFieldType = (dict, key, ~isAddressCountry=true) => {
   let options = dict->Utils.getArrayValFromJsonDict(key, "options")
   switch options->Array.get(0)->Option.getOr("") {
   | "" => None
-  | "ALL" => AddressCountry(Country.country->Array.map(item => item.countryName))
-  | _ =>
-    AddressCountry(
-      Country.country
-      ->Array.filter(item => options->Array.includes(item.isoAlpha2))
-      ->Array.map(item => item.countryName),
-    )
+  | "ALL" => {
+      let countryArr = Country.country->Array.map(item => item.countryName)
+      isAddressCountry ? AddressCountry(countryArr) : ShippingAddressCountry(countryArr)
+    }
+  | _ => {
+      let countryArr =
+        Country.country
+        ->Array.filter(item => options->Array.includes(item.isoAlpha2))
+        ->Array.map(item => item.countryName)
+      isAddressCountry ? AddressCountry(countryArr) : ShippingAddressCountry(countryArr)
+    }
   }
 }
 
@@ -554,6 +571,11 @@ let getPaymentMethodsFieldTypeFromDict = dict => {
     }
   | "user_country" => dict->getOptionsFromPaymentMethodFieldType("user_country")
   | "user_address_country" => dict->getOptionsFromPaymentMethodFieldType("user_address_country")
+  | "user_shipping_address_country" =>
+    dict->getOptionsFromPaymentMethodFieldType(
+      "user_shipping_address_country",
+      ~isAddressCountry=false,
+    )
   | _ => None
   }
 }
@@ -1057,5 +1079,12 @@ let paymentMethodFieldToStrMapper = (field: paymentMethodsFields) => {
   | CardExpiryMonthAndYear => "CardExpiryMonthAndYear"
   | CardCvc => "CardCvc"
   | CardExpiryAndCvc => "CardExpiryAndCvc"
+  | ShippingName => "ShippingName"
+  | ShippingAddressLine1 => "ShippingAddressLine1"
+  | ShippingAddressLine2 => "ShippingAddressLine2"
+  | ShippingAddressCity => "ShippingAddressCity"
+  | ShippingAddressPincode => "ShippingAddressPincode"
+  | ShippingAddressState => "ShippingAddressState"
+  | ShippingAddressCountry(_) => "ShippingAddressCountry"
   }
 }

--- a/src/Payments/PaymentRequestButtonElement.res
+++ b/src/Payments/PaymentRequestButtonElement.res
@@ -100,8 +100,7 @@ let make = (~sessions, ~walletOptions) => {
               </SessionPaymentWrapper>
             | ApplePayWallet =>
               switch applePayToken {
-              | ApplePayTokenOptional(optToken) =>
-                <ApplePayLazy sessionObj=optToken paymentType=NONE walletOptions />
+              | ApplePayTokenOptional(optToken) => <ApplePayLazy sessionObj=optToken />
               | _ => React.null
               }
 

--- a/src/Payments/PaymentRequestButtonElement.res
+++ b/src/Payments/PaymentRequestButtonElement.res
@@ -74,15 +74,9 @@ let make = (~sessions, ~walletOptions) => {
                   switch googlePayThirdPartyToken {
                   | GooglePayThirdPartyTokenOptional(googlePayThirdPartyOptToken) =>
                     <GPayLazy
-                      paymentType=NONE
-                      sessionObj=optToken
-                      thirdPartySessionObj=googlePayThirdPartyOptToken
-                      walletOptions
+                      sessionObj=optToken thirdPartySessionObj=googlePayThirdPartyOptToken
                     />
-                  | _ =>
-                    <GPayLazy
-                      paymentType=NONE sessionObj=optToken thirdPartySessionObj=None walletOptions
-                    />
+                  | _ => <GPayLazy sessionObj=optToken thirdPartySessionObj=None />
                   }
                 | _ => React.null
                 }}

--- a/src/Payments/PaymentRequestButtonElement.res
+++ b/src/Payments/PaymentRequestButtonElement.res
@@ -36,7 +36,7 @@ module WalletsSaveDetailsText = {
 }
 
 @react.component
-let make = (~sessions, ~walletOptions) => {
+let make = (~sessions, ~walletOptions, ~paymentType) => {
   open SessionsType
   let dict = sessions->Utils.getDictFromJson
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
@@ -86,7 +86,7 @@ let make = (~sessions, ~walletOptions) => {
                 {switch paypalToken {
                 | OtherTokenOptional(optToken) =>
                   switch optToken {
-                  | Some(token) => <PaypalSDKLazy sessionObj=token />
+                  | Some(token) => <PaypalSDKLazy sessionObj=token paymentType />
                   | None => <PayPalLazy />
                   }
                 | _ => <PayPalLazy />

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -2,7 +2,7 @@ open PaypalSDKTypes
 open Promise
 
 @react.component
-let make = (~sessionObj: SessionsType.token) => {
+let make = (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) => {
   let {iframeId, publishableKey, sdkHandleOneClickConfirmPayment} = Recoil.useRecoilValueFromAtom(
     RecoilAtoms.keys,
   )
@@ -11,7 +11,7 @@ let make = (~sessionObj: SessionsType.token) => {
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
 
   let token = sessionObj.token
-  let orderDetails = sessionObj.orderDetails->getOrderDetails
+  let orderDetails = sessionObj.orderDetails->getOrderDetails(paymentType)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Paypal)
   let checkoutScript =
     Window.document(Window.window)->Window.getElementById("braintree-checkout")->Nullable.toOption

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -49,16 +49,7 @@ let make = (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) =
     ~paymentMethodType="paypal",
   )
 
-  React.useEffect0(() => {
-    AddressPaymentInput.importStates("./../States.json")
-    ->then(res => {
-      setStatesJson(_ => res.states)
-      resolve()
-    })
-    ->ignore
-
-    None
-  })
+  PaymentUtils.useStatesJson(setStatesJson)
 
   let loadPaypalSdk = () => {
     loggerState.setLogInfo(
@@ -122,8 +113,7 @@ let make = (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) =
 
                               let paypalBody =
                                 body
-                                ->Dict.fromArray
-                                ->JSON.Encode.object
+                                ->Utils.getJsonFromArrayOfJson
                                 ->Utils.flattenObject(true)
                                 ->Utils.mergeTwoFlattenedJsonDicts(requiredFieldsBody)
                                 ->Utils.getArrayOfTupleFromDict

--- a/src/Payments/PaypalSDK.resi
+++ b/src/Payments/PaypalSDK.resi
@@ -1,2 +1,2 @@
 @react.component
-let default: (~sessionObj: SessionsType.token) => React.element
+let default: (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) => React.element

--- a/src/Payments/PaypalSDKLazy.res
+++ b/src/Payments/PaypalSDKLazy.res
@@ -1,5 +1,5 @@
 open LazyUtils
 
-type props = {sessionObj: SessionsType.token}
+type props = {sessionObj: SessionsType.token, paymentType: CardThemeType.mode}
 
 let make: props => React.element = reactLazy(() => import_("./PaypalSDK.bs.js"))

--- a/src/RenderPaymentMethods.res
+++ b/src/RenderPaymentMethods.res
@@ -85,7 +85,7 @@ let make = (
         | Payment =>
           <React.Suspense
             fallback={<RenderIf condition={showLoader}>
-              {paymentType->Utils.isWalletElementPaymentType
+              {paymentType->Utils.getIsWalletElementPaymentType
                 ? <WalletShimmer />
                 : <PaymentElementShimmer />}
             </RenderIf>}>

--- a/src/Types/ApplePayTypes.res
+++ b/src/Types/ApplePayTypes.res
@@ -1,5 +1,27 @@
 type token = {paymentData: JSON.t}
-type paymentResult = {token: JSON.t}
+type billingContact = {
+  addressLines: array<string>,
+  administrativeArea: string,
+  countryCode: string,
+  familyName: string,
+  givenName: string,
+  locality: string,
+  postalCode: string,
+}
+
+type shippingContact = {
+  emailAddress: string,
+  phoneNumber: string,
+  addressLines: array<string>,
+  administrativeArea: string,
+  countryCode: string,
+  familyName: string,
+  givenName: string,
+  locality: string,
+  postalCode: string,
+}
+
+type paymentResult = {token: JSON.t, billingContact: JSON.t, shippingContact: JSON.t}
 type event = {validationURL: string, payment: paymentResult}
 type innerSession
 type session = {
@@ -80,5 +102,31 @@ let jsonToPaymentRequestDataType: Dict.t<JSON.t> => paymentRequestData = jsonDic
       ~merchantIdentifier=Utils.getString(jsonDict, "merchant_identifier", ""),
       (),
     )
+  }
+}
+
+let billingContactItemToObjMapper = dict => {
+  {
+    addressLines: dict->Utils.getStrArray("addressLines"),
+    administrativeArea: dict->Utils.getString("administrativeArea", ""),
+    countryCode: dict->Utils.getString("countryCode", ""),
+    familyName: dict->Utils.getString("familyName", ""),
+    givenName: dict->Utils.getString("givenName", ""),
+    locality: dict->Utils.getString("locality", ""),
+    postalCode: dict->Utils.getString("postalCode", ""),
+  }
+}
+
+let shippingContactItemToObjMapper = dict => {
+  {
+    emailAddress: dict->Utils.getString("emailAddress", ""),
+    phoneNumber: dict->Utils.getString("phoneNumber", ""),
+    addressLines: dict->Utils.getStrArray("addressLines"),
+    administrativeArea: dict->Utils.getString("administrativeArea", ""),
+    countryCode: dict->Utils.getString("countryCode", ""),
+    familyName: dict->Utils.getString("familyName", ""),
+    givenName: dict->Utils.getString("givenName", ""),
+    locality: dict->Utils.getString("locality", ""),
+    postalCode: dict->Utils.getString("postalCode", ""),
   }
 }

--- a/src/Types/GooglePayType.res
+++ b/src/Types/GooglePayType.res
@@ -144,15 +144,15 @@ let jsonToPaymentRequestDataType: (paymentDataRequest, Dict.t<JSON.t>) => paymen
 
 let billingContactItemToObjMapper = dict => {
   {
-    address1: dict->Utils.getString("address1", ""),
-    address2: dict->Utils.getString("address2", ""),
-    address3: dict->Utils.getString("address3", ""),
-    administrativeArea: dict->Utils.getString("administrativeArea", ""),
-    countryCode: dict->Utils.getString("countryCode", ""),
-    locality: dict->Utils.getString("locality", ""),
-    name: dict->Utils.getString("name", ""),
-    phoneNumber: dict->Utils.getString("phoneNumber", ""),
-    postalCode: dict->Utils.getString("postalCode", ""),
-    sortingCode: dict->Utils.getString("sortingCode", ""),
+    address1: dict->getString("address1", ""),
+    address2: dict->getString("address2", ""),
+    address3: dict->getString("address3", ""),
+    administrativeArea: dict->getString("administrativeArea", ""),
+    countryCode: dict->getString("countryCode", ""),
+    locality: dict->getString("locality", ""),
+    name: dict->getString("name", ""),
+    phoneNumber: dict->getString("phoneNumber", ""),
+    postalCode: dict->getString("postalCode", ""),
+    sortingCode: dict->getString("sortingCode", ""),
   }
 }

--- a/src/Types/GooglePayType.res
+++ b/src/Types/GooglePayType.res
@@ -11,6 +11,9 @@ type paymentDataRequest = {
   mutable allowedPaymentMethods: array<JSON.t>,
   mutable transactionInfo: JSON.t,
   mutable merchantInfo: JSON.t,
+  mutable shippingAddressRequired: bool,
+  mutable emailRequired: bool,
+  mutable shippingAddressParameters: JSON.t,
 }
 @val @scope("Object") external assign2: (JSON.t, JSON.t) => paymentDataRequest = "assign"
 type element = {
@@ -62,6 +65,19 @@ type paymentMethodData = {
   info: JSON.t,
   tokenizationData: JSON.t,
   \"type": string,
+}
+
+type billingContact = {
+  address1: string,
+  address2: string,
+  address3: string,
+  administrativeArea: string,
+  countryCode: string,
+  locality: string,
+  name: string,
+  phoneNumber: string,
+  postalCode: string,
+  sortingCode: string,
 }
 
 type paymentData = {paymentMethodData: paymentMethodData}
@@ -124,4 +140,19 @@ let jsonToPaymentRequestDataType: (paymentDataRequest, Dict.t<JSON.t>) => paymen
     ->transformKeys(CamelCase)
 
   paymentRequest
+}
+
+let billingContactItemToObjMapper = dict => {
+  {
+    address1: dict->Utils.getString("address1", ""),
+    address2: dict->Utils.getString("address2", ""),
+    address3: dict->Utils.getString("address3", ""),
+    administrativeArea: dict->Utils.getString("administrativeArea", ""),
+    countryCode: dict->Utils.getString("countryCode", ""),
+    locality: dict->Utils.getString("locality", ""),
+    name: dict->Utils.getString("name", ""),
+    phoneNumber: dict->Utils.getString("phoneNumber", ""),
+    postalCode: dict->Utils.getString("postalCode", ""),
+    sortingCode: dict->Utils.getString("sortingCode", ""),
+  }
 }

--- a/src/Types/PaypalSDKTypes.res
+++ b/src/Types/PaypalSDKTypes.res
@@ -4,7 +4,6 @@ type paypalCheckoutErr = {message: string}
 type data
 type actions
 type err
-type payload = {nonce: string}
 type vault = {vault: bool}
 type shipping = {
   recipientName: option<string>,
@@ -16,6 +15,12 @@ type shipping = {
   state: option<string>,
   phone: option<string>,
 }
+type details = {
+  email: string,
+  shippingAddress: shipping,
+  phone: option<string>,
+}
+type payload = {nonce: string, details: details}
 type orderDetails = {
   flow: string,
   billingAgreementDescription: option<string>,
@@ -87,3 +92,48 @@ type paypal = {"Buttons": buttons => some, "FUNDING": funding}
 
 @val external braintree: braintree = "braintree"
 @val external paypal: paypal = "paypal"
+
+let getShippingDetails = shippingAddressOverrideObj => {
+  let shippingAddressOverride = shippingAddressOverrideObj->Utils.getDictFromJson
+
+  let recipientName = shippingAddressOverride->Utils.getOptionString("recipient_name")
+  let line1 = shippingAddressOverride->Utils.getOptionString("line1")
+  let line2 = shippingAddressOverride->Utils.getOptionString("line2")
+  let city = shippingAddressOverride->Utils.getOptionString("city")
+  let countryCode = shippingAddressOverride->Utils.getOptionString("country_code")
+  let postalCode = shippingAddressOverride->Utils.getOptionString("postal_code")
+  let state = shippingAddressOverride->Utils.getOptionString("state")
+  let phone = shippingAddressOverride->Utils.getOptionString("phone")
+
+  if (
+    [recipientName, line1, line2, city, countryCode, postalCode, state, phone]->Array.includes(None)
+  ) {
+    None
+  } else {
+    Some({
+      recipientName,
+      line1,
+      line2,
+      city,
+      countryCode,
+      postalCode,
+      state,
+      phone,
+    })
+  }
+}
+
+let getOrderDetails = orderDetails => {
+  let orderDetailsDict = orderDetails->Utils.getDictFromJson
+
+  let shippingAddressOverride =
+    orderDetailsDict->Utils.getJsonObjectFromDict("shipping_address_override")->getShippingDetails
+
+  {
+    flow: orderDetailsDict->Utils.getString("flow", "vault"),
+    billingAgreementDescription: None,
+    enableShippingAddress: orderDetailsDict->Utils.getOptionBool("enable_shipping_address"),
+    shippingAddressEditable: None,
+    shippingAddressOverride,
+  }
+}

--- a/src/Types/PaypalSDKTypes.res
+++ b/src/Types/PaypalSDKTypes.res
@@ -123,16 +123,23 @@ let getShippingDetails = shippingAddressOverrideObj => {
   }
 }
 
-let getOrderDetails = orderDetails => {
+let getOrderDetails = (orderDetails, paymentType) => {
   let orderDetailsDict = orderDetails->Utils.getDictFromJson
 
-  let shippingAddressOverride =
-    orderDetailsDict->Utils.getJsonObjectFromDict("shipping_address_override")->getShippingDetails
+  let isWalletElementPaymentType = paymentType->Utils.getIsWalletElementPaymentType
+
+  let shippingAddressOverride = isWalletElementPaymentType
+    ? orderDetailsDict->Utils.getJsonObjectFromDict("shipping_address_override")->getShippingDetails
+    : None
+
+  let enableShippingAddress = isWalletElementPaymentType
+    ? orderDetailsDict->Utils.getOptionBool("enable_shipping_address")
+    : None
 
   {
     flow: orderDetailsDict->Utils.getString("flow", "vault"),
     billingAgreementDescription: None,
-    enableShippingAddress: orderDetailsDict->Utils.getOptionBool("enable_shipping_address"),
+    enableShippingAddress,
     shippingAddressEditable: None,
     shippingAddressOverride,
   }

--- a/src/Types/SessionsType.res
+++ b/src/Types/SessionsType.res
@@ -13,6 +13,7 @@ type token = {
   shippingAddressRequired: bool,
   emailRequired: bool,
   shippingAddressParameters: JSON.t,
+  orderDetails: JSON.t,
 }
 
 type tokenType =
@@ -39,6 +40,7 @@ let defaultToken = {
   shippingAddressRequired: false,
   emailRequired: false,
   shippingAddressParameters: Dict.make()->JSON.Encode.object,
+  orderDetails: Dict.make()->JSON.Encode.object,
 }
 let getWallet = str => {
   switch str {
@@ -68,6 +70,7 @@ let getSessionsToken = (dict, str) => {
         shippingAddressRequired: getBool(dict, "shipping_address_required", false),
         emailRequired: getBool(dict, "email_required", false),
         shippingAddressParameters: getJsonObjectFromDict(dict, "shipping_address_parameters"),
+        orderDetails: getJsonObjectFromDict(dict, "order_details"),
       }
     })
   })

--- a/src/Types/SessionsType.res
+++ b/src/Types/SessionsType.res
@@ -10,6 +10,9 @@ type token = {
   allowed_payment_methods: array<JSON.t>,
   transaction_info: JSON.t,
   merchant_info: JSON.t,
+  shippingAddressRequired: bool,
+  emailRequired: bool,
+  shippingAddressParameters: JSON.t,
 }
 
 type tokenType =
@@ -33,6 +36,9 @@ let defaultToken = {
   allowed_payment_methods: [],
   transaction_info: Dict.make()->JSON.Encode.object,
   merchant_info: Dict.make()->JSON.Encode.object,
+  shippingAddressRequired: false,
+  emailRequired: false,
+  shippingAddressParameters: Dict.make()->JSON.Encode.object,
 }
 let getWallet = str => {
   switch str {
@@ -59,6 +65,9 @@ let getSessionsToken = (dict, str) => {
         allowed_payment_methods: getArray(dict, "allowed_payment_methods"),
         transaction_info: getJsonObjectFromDict(dict, "transaction_info"),
         merchant_info: getJsonObjectFromDict(dict, "merchant_info"),
+        shippingAddressRequired: getBool(dict, "shipping_address_required", false),
+        emailRequired: getBool(dict, "email_required", false),
+        shippingAddressParameters: getJsonObjectFromDict(dict, "shipping_address_parameters"),
       }
     })
   })

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -3,8 +3,6 @@ let paymentMethodListValue = Recoil.atom("paymentMethodListValue", PaymentMethod
 let paymentListLookupNew = (
   list: PaymentMethodsRecord.paymentMethodList,
   ~order,
-  ~showGooglePay,
-  ~areAllGooglePayRequiredFieldsPrefilled,
   ~isShowPaypal,
 ) => {
   let pmList = list->PaymentMethodsRecord.buildFromPaymentList
@@ -25,14 +23,6 @@ let paymentListLookupNew = (
     "samsung_pay",
   ]
   let otherPaymentList = []
-  let googlePayFields = pmList->Array.find(item => item.paymentMethodName === "google_pay")
-  switch googlePayFields {
-  | Some(val) =>
-    if val.fields->Array.length > 0 && showGooglePay && !areAllGooglePayRequiredFieldsPrefilled {
-      walletToBeDisplayedInTabs->Array.push("google_pay")->ignore
-    }
-  | None => ()
-  }
 
   pmList->Array.forEach(item => {
     if walletToBeDisplayedInTabs->Array.includes(item.paymentMethodName) {
@@ -266,24 +256,16 @@ let useAreAllRequiredFieldsPrefilled = (
   })
 }
 
-let useGetPaymentMethodList = (~paymentMethodListValue, ~paymentOptions, ~paymentType) => {
+let useGetPaymentMethodList = (~paymentOptions, ~paymentType) => {
   open Utils
   let methodslist = Recoil.useRecoilValueFromAtom(RecoilAtoms.paymentMethodList)
 
   let {showCardFormByDefault, paymentMethodOrder} = Recoil.useRecoilValueFromAtom(
     RecoilAtoms.optionAtom,
   )
-
-  let isGooglePayReady = Recoil.useRecoilValueFromAtom(RecoilAtoms.isGooglePayReady)
   let optionAtomValue = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
 
   let paymentOrder = paymentMethodOrder->getOptionalArr->removeDuplicate
-
-  let areAllGooglePayRequiredFieldsPrefilled = useAreAllRequiredFieldsPrefilled(
-    ~paymentMethodListValue,
-    ~paymentMethod="wallet",
-    ~paymentMethodType="google_pay",
-  )
 
   React.useMemo(() => {
     switch methodslist {
@@ -294,8 +276,6 @@ let useGetPaymentMethodList = (~paymentMethodListValue, ~paymentOptions, ~paymen
       let (wallets, otherOptions) =
         plist->paymentListLookupNew(
           ~order=paymentOrder,
-          ~showGooglePay=isGooglePayReady,
-          ~areAllGooglePayRequiredFieldsPrefilled,
           ~isShowPaypal=optionAtomValue.wallets.payPal === Auto,
         )
       (
@@ -309,12 +289,5 @@ let useGetPaymentMethodList = (~paymentMethodListValue, ~paymentOptions, ~paymen
         : ([], [], [])
     | _ => ([], [], [])
     }
-  }, (
-    methodslist,
-    paymentMethodOrder,
-    isGooglePayReady,
-    areAllGooglePayRequiredFieldsPrefilled,
-    optionAtomValue.wallets.payPal,
-    paymentType,
-  ))
+  }, (methodslist, paymentMethodOrder, optionAtomValue.wallets.payPal, paymentType))
 }

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -3,10 +3,8 @@ let paymentMethodListValue = Recoil.atom("paymentMethodListValue", PaymentMethod
 let paymentListLookupNew = (
   list: PaymentMethodsRecord.paymentMethodList,
   ~order,
-  ~showApplePay,
   ~showGooglePay,
   ~areAllGooglePayRequiredFieldsPrefilled,
-  ~areAllApplePayRequiredFieldsPrefilled,
   ~isShowPaypal,
 ) => {
   let pmList = list->PaymentMethodsRecord.buildFromPaymentList
@@ -28,18 +26,10 @@ let paymentListLookupNew = (
   ]
   let otherPaymentList = []
   let googlePayFields = pmList->Array.find(item => item.paymentMethodName === "google_pay")
-  let applePayFields = pmList->Array.find(item => item.paymentMethodName === "apple_pay")
   switch googlePayFields {
   | Some(val) =>
     if val.fields->Array.length > 0 && showGooglePay && !areAllGooglePayRequiredFieldsPrefilled {
       walletToBeDisplayedInTabs->Array.push("google_pay")->ignore
-    }
-  | None => ()
-  }
-  switch applePayFields {
-  | Some(val) =>
-    if val.fields->Array.length > 0 && showApplePay && !areAllApplePayRequiredFieldsPrefilled {
-      walletToBeDisplayedInTabs->Array.push("apple_pay")->ignore
     }
   | None => ()
   }
@@ -284,7 +274,6 @@ let useGetPaymentMethodList = (~paymentMethodListValue, ~paymentOptions, ~paymen
     RecoilAtoms.optionAtom,
   )
 
-  let isApplePayReady = Recoil.useRecoilValueFromAtom(RecoilAtoms.isApplePayReady)
   let isGooglePayReady = Recoil.useRecoilValueFromAtom(RecoilAtoms.isGooglePayReady)
   let optionAtomValue = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
 
@@ -296,12 +285,6 @@ let useGetPaymentMethodList = (~paymentMethodListValue, ~paymentOptions, ~paymen
     ~paymentMethodType="google_pay",
   )
 
-  let areAllApplePayRequiredFieldsPrefilled = useAreAllRequiredFieldsPrefilled(
-    ~paymentMethodListValue,
-    ~paymentMethod="wallet",
-    ~paymentMethodType="apple_pay",
-  )
-
   React.useMemo(() => {
     switch methodslist {
     | Loaded(paymentlist) =>
@@ -311,10 +294,8 @@ let useGetPaymentMethodList = (~paymentMethodListValue, ~paymentOptions, ~paymen
       let (wallets, otherOptions) =
         plist->paymentListLookupNew(
           ~order=paymentOrder,
-          ~showApplePay=isApplePayReady,
           ~showGooglePay=isGooglePayReady,
           ~areAllGooglePayRequiredFieldsPrefilled,
-          ~areAllApplePayRequiredFieldsPrefilled,
           ~isShowPaypal=optionAtomValue.wallets.payPal === Auto,
         )
       (
@@ -331,10 +312,8 @@ let useGetPaymentMethodList = (~paymentMethodListValue, ~paymentOptions, ~paymen
   }, (
     methodslist,
     paymentMethodOrder,
-    isApplePayReady,
     isGooglePayReady,
     areAllGooglePayRequiredFieldsPrefilled,
-    areAllApplePayRequiredFieldsPrefilled,
     optionAtomValue.wallets.payPal,
     paymentType,
   ))

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -291,3 +291,17 @@ let useGetPaymentMethodList = (~paymentOptions, ~paymentType) => {
     }
   }, (methodslist, paymentMethodOrder, optionAtomValue.wallets.payPal, paymentType))
 }
+
+let useStatesJson = setStatesJson => {
+  open Promise
+  React.useEffect0(() => {
+    AddressPaymentInput.importStates("./../States.json")
+    ->then(res => {
+      setStatesJson(_ => res.states)
+      resolve()
+    })
+    ->ignore
+
+    None
+  })
+}

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1246,3 +1246,29 @@ let isWalletElementPaymentType = (paymentType: CardThemeType.mode) => {
 let getUniqueArray = arr => arr->Array.map(item => (item, ""))->Dict.fromArray->Dict.keysToArray
 
 let getJsonFromArrayOfJson = arr => arr->Dict.fromArray->JSON.Encode.object
+
+let getStateNameFromStateCodeAndCountry = (list: JSON.t, stateCode: string, country: string) => {
+  let options =
+    list
+    ->getDictFromJson
+    ->getOptionalArrayFromDict(country)
+    ->Option.getOr([])
+
+  let val = options->Array.find(item =>
+    item
+    ->getDictFromJson
+    ->Dict.get("code")
+    ->Option.flatMap(JSON.Decode.string)
+    ->Option.getOr("") === stateCode
+  )
+
+  switch val {
+  | Some(stateObj) =>
+    stateObj
+    ->getDictFromJson
+    ->Dict.get("name")
+    ->Option.flatMap(JSON.Decode.string)
+    ->Option.getOr(stateCode)
+  | None => stateCode
+  }
+}

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1261,18 +1261,14 @@ let getStateNameFromStateCodeAndCountry = (list: JSON.t, stateCode: string, coun
   let val = options->Array.find(item =>
     item
     ->getDictFromJson
-    ->Dict.get("code")
-    ->Option.flatMap(JSON.Decode.string)
-    ->Option.getOr("") === stateCode
+    ->getString("code", "") === stateCode
   )
 
   switch val {
   | Some(stateObj) =>
     stateObj
     ->getDictFromJson
-    ->Dict.get("name")
-    ->Option.flatMap(JSON.Decode.string)
-    ->Option.getOr(stateCode)
+    ->getString("name", stateCode)
   | None => stateCode
   }
 }

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1228,7 +1228,11 @@ let expressCheckoutComponents = ["googlePay", "payPal", "applePay", "paymentRequ
 
 let componentsForPaymentElementCreate = ["payment"]->Array.concat(expressCheckoutComponents)
 
-let isComponentTypeForPaymentElementCreate = componentType => {
+let getIsExpressCheckoutComponent = componentType => {
+  expressCheckoutComponents->Array.includes(componentType)
+}
+
+let getIsComponentTypeForPaymentElementCreate = componentType => {
   componentsForPaymentElementCreate->Array.includes(componentType)
 }
 
@@ -1239,7 +1243,7 @@ let walletElementPaymentType: array<CardThemeType.mode> = [
   PaymentRequestButtonsElement,
 ]
 
-let isWalletElementPaymentType = (paymentType: CardThemeType.mode) => {
+let getIsWalletElementPaymentType = (paymentType: CardThemeType.mode) => {
   walletElementPaymentType->Array.includes(paymentType)
 }
 

--- a/src/WalletElement.res
+++ b/src/WalletElement.res
@@ -30,7 +30,7 @@ let make = (~paymentType) => {
   <RenderIf condition={walletOptions->Array.length > 0}>
     <div className="flex flex-col place-items-center">
       <ErrorBoundary key="payment_request_buttons_all" level={ErrorBoundary.RequestButton}>
-        <PaymentRequestButtonElement sessions walletOptions />
+        <PaymentRequestButtonElement sessions walletOptions paymentType />
       </ErrorBoundary>
     </div>
   </RenderIf>

--- a/src/WalletElement.res
+++ b/src/WalletElement.res
@@ -5,15 +5,9 @@ let make = (~paymentType) => {
   let (sessions, setSessions) = React.useState(_ => Dict.make()->JSON.Encode.object)
   let (walletOptions, setWalletOptions) = React.useState(_ => [])
 
-  let (paymentMethodListValue, setPaymentMethodListValue) = Recoil.useRecoilState(
-    PaymentUtils.paymentMethodListValue,
-  )
+  let setPaymentMethodListValue = Recoil.useSetRecoilState(PaymentUtils.paymentMethodListValue)
 
-  let (walletList, _, _) = PaymentUtils.useGetPaymentMethodList(
-    ~paymentMethodListValue,
-    ~paymentOptions=[],
-    ~paymentType,
-  )
+  let (walletList, _, _) = PaymentUtils.useGetPaymentMethodList(~paymentOptions=[], ~paymentType)
 
   React.useEffect(() => {
     switch methodslist {

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -698,9 +698,14 @@ let make = (
                     applePayPresent->Belt.Option.isSome
                 ) {
                   //do operations here
-                  let processPayment = (token: JSON.t) => {
+                  let processPayment = (payment: ApplePayTypes.paymentResult) => {
                     //let body = PaymentBody.applePayBody(~token)
-                    let msg = [("applePayProcessPayment", token)]->Dict.fromArray
+                    let msg =
+                      [
+                        ("applePayProcessPayment", payment.token),
+                        ("applePayBillingContact", payment.billingContact),
+                        ("applePayShippingContact", payment.shippingContact),
+                      ]->Dict.fromArray
                     mountedIframeRef->Window.iframePostMessage(msg)
                   }
 
@@ -762,7 +767,7 @@ let make = (
                               {"status": ssn.\"STATUS_SUCCESS"}->Identity.anyTypeToJson,
                             )
                             applePaySessionRef := Nullable.null
-                            processPayment(event.payment.token)
+                            processPayment(event.payment)
                             let value = "Payment Data Filled: New Payment Method"
                             logger.setLogInfo(
                               ~value,

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -840,6 +840,11 @@ let make = (
                   paymentDataRequest.transactionInfo =
                     gpayobj.transaction_info->transformKeys(CamelCase)
                   paymentDataRequest.merchantInfo = gpayobj.merchant_info->transformKeys(CamelCase)
+                  paymentDataRequest.shippingAddressRequired = gpayobj.shippingAddressRequired
+                  paymentDataRequest.emailRequired = gpayobj.emailRequired
+                  paymentDataRequest.shippingAddressParameters =
+                    gpayobj.shippingAddressParameters->transformKeys(CamelCase)
+
                   try {
                     let gPayClient = GooglePayType.google(
                       {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added Support to collect billing and shipping details from ApplePay, GooglePay and Paypal instead of the SDK

## How did you test it?

https://docs.google.com/document/d/1yvMroZvHGQQrPwMg5WvjEd7kxRFWslpJzzdFsSQTXUk/edit?usp=sharing

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
