### PR TITLE
fix: card brand configuration error added

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orca-payment-page",
-  "version": "0.50.6",
+  "version": "0.50.7",
   "main": "index.js",
   "private": true,
   "dependencies": {

--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -110,6 +110,25 @@ let getCardType = val => {
   }
 }
 
+let getCardStringFromType = val => {
+  switch val {
+  | VISA => "Visa"
+  | MASTERCARD => "Mastercard"
+  | AMEX => "AmericanExpress"
+  | MAESTRO => "Maestro"
+  | DINERSCLUB => "DinersClub"
+  | DISCOVER => "Discover"
+  | BAJAJ => "BAJAJ"
+  | SODEXO => "SODEXO"
+  | RUPAY => "RuPay"
+  | JCB => "JCB"
+  | CARTESBANCAIRES => "CartesBancaires"
+  | UNIONPAY => "UnionPay"
+  | INTERAC => "Interac"
+  | NOTFOUND => "NOTFOUND"
+  }
+}
+
 let getobjFromCardPattern = cardBrand => {
   let patternsDict = CardPattern.cardPatterns
   patternsDict

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `اسم البطاقة (اختياري)`,
   cardExpiredText: `انتهت صلاحية هذه البطاقة`,
   cardHeader: `معلومات البطاقة`,
-  cardBrandConfiguredErrorText: `علامة بطاقة غير مكونة`,
+  cardBrandConfiguredErrorText: str => `${str} غير مدعوم في الوقت الحالي.`,
 }

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `اسم البطاقة (اختياري)`,
   cardExpiredText: `انتهت صلاحية هذه البطاقة`,
   cardHeader: `معلومات البطاقة`,
+  cardBrandConfiguredErrorText: `علامة بطاقة غير مكونة`,
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Seleccioneu una forma de pagament i torneu-ho a provar`,
   cardExpiredText: `Aquesta targeta ha caducat`,
   cardHeader: `Informació de la targeta`,
-  cardBrandConfiguredErrorText: `Marca de targeta no configurada`,
+  cardBrandConfiguredErrorText: str => `${str} no està suportat en aquest moment.`,
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Seleccioneu una forma de pagament i torneu-ho a provar`,
   cardExpiredText: `Aquesta targeta ha caducat`,
   cardHeader: `Informació de la targeta`,
+  cardBrandConfiguredErrorText: `Marca de targeta no configurada`,
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `Kartenname (optional)`,
   cardExpiredText: `Diese Karte ist abgelaufen`,
   cardHeader: `Kartendaten`,
+  cardBrandConfiguredErrorText: `Kartenmarke nicht konfiguriert`,
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `Kartenname (optional)`,
   cardExpiredText: `Diese Karte ist abgelaufen`,
   cardHeader: `Kartendaten`,
-  cardBrandConfiguredErrorText: `Kartenmarke nicht konfiguriert`,
+  cardBrandConfiguredErrorText: str => `${str} wird derzeit nicht unterstützt.`,
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Selecteer een betaalmethode en probeer het opnieuw`,
   cardExpiredText: `Deze kaart is verlopen`,
   cardHeader: `Kaartinformatie`,
+  cardBrandConfiguredErrorText: `Kaartmerk niet geconfigureerd`,
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Selecteer een betaalmethode en probeer het opnieuw`,
   cardExpiredText: `Deze kaart is verlopen`,
   cardHeader: `Kaartinformatie`,
-  cardBrandConfiguredErrorText: `Kaartmerk niet geconfigureerd`,
+  cardBrandConfiguredErrorText: str => `${str} wordt op dit moment niet ondersteund.`,
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: "Card Nickname (Optional)",
   cardExpiredText: `This card has expired`,
   cardHeader: `Card information`,
+  cardBrandConfiguredErrorText: `Card brand not configured`,
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: "Card Nickname (Optional)",
   cardExpiredText: `This card has expired`,
   cardHeader: `Card information`,
-  cardBrandConfiguredErrorText: `Card brand not configured`,
+  cardBrandConfiguredErrorText: str => `${str} is not supported at the moment.`,
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: "Card Nickname (Optional)",
   cardExpiredText: `This card has expired`,
   cardHeader: `Card information`,
+  cardBrandConfiguredErrorText: `Card brand not configured`,
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: "Card Nickname (Optional)",
   cardExpiredText: `This card has expired`,
   cardHeader: `Card information`,
-  cardBrandConfiguredErrorText: `Card brand not configured`,
+  cardBrandConfiguredErrorText: str => `${str} is not supported at the moment.`,
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Veuillez sélectionner un mode de paiement et réessayer`,
   cardExpiredText: `Cette carte a expiré`,
   cardHeader: `Informations de carte`,
+  cardBrandConfiguredErrorText: `Marque de carte non configurée`,
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Veuillez sélectionner un mode de paiement et réessayer`,
   cardExpiredText: `Cette carte a expiré`,
   cardHeader: `Informations de carte`,
-  cardBrandConfiguredErrorText: `Marque de carte non configurée`,
+  cardBrandConfiguredErrorText: str => `${str} n'est pas pris en charge pour le moment.`,
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `Surnom de la carte (facultatif)`,
   cardExpiredText: `Cette carte a expiré`,
   cardHeader: `Informations de carte`,
-  cardBrandConfiguredErrorText: `Marque de carte non configurée`,
+  cardBrandConfiguredErrorText: str => `${str} n'est pas pris en charge pour le moment.`,
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `Surnom de la carte (facultatif)`,
   cardExpiredText: `Cette carte a expiré`,
   cardHeader: `Informations de carte`,
+  cardBrandConfiguredErrorText: `Marque de carte non configurée`,
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `כינוי לכרטיס (אופציונלי)`,
   cardExpiredText: `הכרטיס הזה פג תוקף`,
   cardHeader: `מידע כרטיס`,
-  cardBrandConfiguredErrorText: `מותג הכרטיס לא מוגדר`,
+  cardBrandConfiguredErrorText: str => `${str} לא נתמך כרגע.`,
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `כינוי לכרטיס (אופציונלי)`,
   cardExpiredText: `הכרטיס הזה פג תוקף`,
   cardHeader: `מידע כרטיס`,
+  cardBrandConfiguredErrorText: `מותג הכרטיס לא מוגדר`,
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Seleziona un metodo di pagamento e riprova`,
   cardExpiredText: `Questa carta è scaduta`,
   cardHeader: `Informazioni sulla carta`,
+  cardBrandConfiguredErrorText: `Marca della carta non configurata`,
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Seleziona un metodo di pagamento e riprova`,
   cardExpiredText: `Questa carta è scaduta`,
   cardHeader: `Informazioni sulla carta`,
-  cardBrandConfiguredErrorText: `Marca della carta non configurata`,
+  cardBrandConfiguredErrorText: str => `${str} non è supportato al momento.`,
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `カードニックネーム（任意）`,
   cardExpiredText: `このカードは期限切れです`,
   cardHeader: `カード情報`,
+  cardBrandConfiguredErrorText: `カードブランドが設定されていません`,
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   nicknamePlaceholder: `カードニックネーム（任意）`,
   cardExpiredText: `このカードは期限切れです`,
   cardHeader: `カード情報`,
-  cardBrandConfiguredErrorText: `カードブランドが設定されていません`,
+  cardBrandConfiguredErrorText: str => `${str} は現在サポートされていません。`,
 }

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -72,4 +72,5 @@ type localeStrings = {
   nicknamePlaceholder: string,
   cardExpiredText: string,
   cardHeader: string,
+  cardBrandConfiguredErrorText: string,
 }

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -72,5 +72,5 @@ type localeStrings = {
   nicknamePlaceholder: string,
   cardExpiredText: string,
   cardHeader: string,
-  cardBrandConfiguredErrorText: string,
+  cardBrandConfiguredErrorText: string => string,
 }

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Wybierz metodę płatności i spróbuj ponownie`,
   cardExpiredText: `Ta karta wygasła`,
   cardHeader: `Informacje o karcie`,
+  cardBrandConfiguredErrorText: `Marka karty nie skonfigurowana`,
 }

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Wybierz metodę płatności i spróbuj ponownie`,
   cardExpiredText: `Ta karta wygasła`,
   cardHeader: `Informacje o karcie`,
-  cardBrandConfiguredErrorText: `Marka karty nie skonfigurowana`,
+  cardBrandConfiguredErrorText: str => `${str} nie jest obecnie obsługiwany.`,
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Selecione uma forma de pagamento e tente novamente`,
   cardExpiredText: `Este cartão expirou`,
   cardHeader: `Informações do cartão`,
+  cardBrandConfiguredErrorText: `Marca do cartão não configurada`,
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Selecione uma forma de pagamento e tente novamente`,
   cardExpiredText: `Este cartão expirou`,
   cardHeader: `Informações do cartão`,
-  cardBrandConfiguredErrorText: `Marca do cartão não configurada`,
+  cardBrandConfiguredErrorText: str => `${str} não é suportado no momento.`,
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -84,5 +84,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Пожалуйста, выберите способ оплаты и повторите попытку.`,
   cardExpiredText: `Эта карта истекла`,
   cardHeader: `Информация о карте`,
-  cardBrandConfiguredErrorText: `Бренд карты не настроен`,
+  cardBrandConfiguredErrorText: str =>
+    `${str} в данный момент не поддерживается.`,
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -84,4 +84,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Пожалуйста, выберите способ оплаты и повторите попытку.`,
   cardExpiredText: `Эта карта истекла`,
   cardHeader: `Информация о карте`,
+  cardBrandConfiguredErrorText: `Бренд карты не настроен`,
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Por favor seleccione un método de pago y vuelva a intentarlo`,
   cardExpiredText: `Esta tarjeta ha caducado`,
   cardHeader: `Información de la tarjeta`,
+  cardBrandConfiguredErrorText: `Marca de tarjeta no configurada`,
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Por favor seleccione un método de pago y vuelva a intentarlo`,
   cardExpiredText: `Esta tarjeta ha caducado`,
   cardHeader: `Información de la tarjeta`,
-  cardBrandConfiguredErrorText: `Marca de tarjeta no configurada`,
+  cardBrandConfiguredErrorText: str => `${str} no está soportado en este momento.`,
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -81,4 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Välj en betalningsmetod och försök igen`,
   cardExpiredText: `Detta kort har gått ut`,
   cardHeader: `Kortinformation`,
+  cardBrandConfiguredErrorText: `Kortmärke inte konfigurerat`,
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -81,5 +81,5 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   selectPaymentMethodText: `Välj en betalningsmetod och försök igen`,
   cardExpiredText: `Detta kort har gått ut`,
   cardHeader: `Kortinformation`,
-  cardBrandConfiguredErrorText: `Kortmärke inte konfigurerat`,
+  cardBrandConfiguredErrorText: str => `${str} stöds inte för tillfället.`,
 }

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -72,7 +72,6 @@ let make = (
   let setUserError = message => {
     postFailedSubmitResponse(~errortype="validation_error", ~message)
   }
-  Console.log(paymentMethodListValue)
   let combinedCardNetworks = React.useMemo1(() =>
     (
       paymentMethodListValue.payment_methods

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -84,12 +84,16 @@ let make = (
     ).payment_method_types
     ->Array.map(ele => ele.card_networks)
     ->Array.reduce([], (acc, ele) =>
-      acc->Array.concat(ele->Array.map(val => val.card_network->CardUtils.getCardStringFromType))
+      acc->Array.concat(
+        ele->Array.map(
+          val => val.card_network->CardUtils.getCardStringFromType->String.toLowerCase,
+        ),
+      )
     )
     ->Utils.getUniqueArray
   , [paymentMethodListValue])
 
-  let isCardBrandValid = combinedCardNetworks->Array.includes(cardBrand)
+  let isCardBrandValid = combinedCardNetworks->Array.includes(cardBrand->String.toLowerCase)
 
   let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1245,6 +1245,4 @@ let isWalletElementPaymentType = (paymentType: CardThemeType.mode) => {
   walletElementPaymentType->Array.includes(paymentType)
 }
 
-let getUniqueArray = arr => {
-  arr->Array.map(item => (item, ""))->Dict.fromArray->Dict.keysToArray
-}
+let getUniqueArray = arr => arr->Array.map(item => (item, ""))->Dict.fromArray->Dict.keysToArray

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -462,12 +462,14 @@ let isAllValid = (
   card: option<bool>,
   cvc: option<bool>,
   expiry: option<bool>,
+  cardBrand: bool,
   zip: bool,
   paymentMode: string,
 ) => {
   card->getBoolValue &&
   cvc->getBoolValue &&
   expiry->getBoolValue &&
+  cardBrand &&
   (paymentMode == "payment" || zip)
 }
 
@@ -1241,4 +1243,8 @@ let walletElementPaymentType: array<CardThemeType.mode> = [
 
 let isWalletElementPaymentType = (paymentType: CardThemeType.mode) => {
   walletElementPaymentType->Array.includes(paymentType)
+}
+
+let getUniqueArray = arr => {
+  arr->Array.map(item => (item, ""))->Dict.fromArray->Dict.keysToArray
 }

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -462,14 +462,12 @@ let isAllValid = (
   card: option<bool>,
   cvc: option<bool>,
   expiry: option<bool>,
-  cardBrand: bool,
   zip: bool,
   paymentMode: string,
 ) => {
   card->getBoolValue &&
   cvc->getBoolValue &&
   expiry->getBoolValue &&
-  cardBrand &&
   (paymentMode == "payment" || zip)
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
 
Added error for the card networks which are not configured via merchant.

## How did you test it?

tested via account which has not configured one network like Rupay and tested with that flow. the error was being thrown and confirm call didn't happen.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
