### PR TITLE
fix: paynow button fix for required fields

### DIFF
--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -17,6 +17,7 @@ let make = () => {
   let {themeObj, localeString} = configAtom->Recoil.useRecoilValueFromAtom
   let {sdkHandleConfirmPayment} = optionAtom->Recoil.useRecoilValueFromAtom
   let (isPayNowButtonDisable, setIsPayNowButtonDisable) = payNowButtonDisable->Recoil.useRecoilState
+  let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
 
   let confirmPayload = sdkHandleConfirmPayment->PaymentBody.confirmPayloadForSDKButton
   let buttonText = sdkHandleConfirmPayment.buttonText->Option.getOr(localeString.payNowButton)
@@ -31,6 +32,11 @@ let make = () => {
     | None => ()
     }
   }
+
+  React.useEffect1(() => {
+    setIsPayNowButtonDisable(_ => !areRequiredFieldsValid)
+    None
+  }, [areRequiredFieldsValid])
 
   let handleOnClick = _ => {
     setIsPayNowButtonDisable(_ => true)

--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -17,7 +17,6 @@ let make = () => {
   let {themeObj, localeString} = configAtom->Recoil.useRecoilValueFromAtom
   let {sdkHandleConfirmPayment} = optionAtom->Recoil.useRecoilValueFromAtom
   let (isPayNowButtonDisable, setIsPayNowButtonDisable) = payNowButtonDisable->Recoil.useRecoilState
-  let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
 
   let confirmPayload = sdkHandleConfirmPayment->PaymentBody.confirmPayloadForSDKButton
   let buttonText = sdkHandleConfirmPayment.buttonText->Option.getOr(localeString.payNowButton)
@@ -32,11 +31,6 @@ let make = () => {
     | None => ()
     }
   }
-
-  React.useEffect1(() => {
-    setIsPayNowButtonDisable(_ => !areRequiredFieldsValid)
-    None
-  }, [areRequiredFieldsValid])
 
   let handleOnClick = _ => {
     setIsPayNowButtonDisable(_ => true)

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -22,6 +22,7 @@ let make = (
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
   let areRequiredFieldsEmpty = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsEmpty)
+  let setIsPayNowButtonDisable = Recoil.useSetRecoilState(payNowButtonDisable)
   let status = CommonHooks.useScript("https://pay.google.com/gp/p/js/pay.js")
   let isGooglePaySDKFlow = React.useMemo(() => {
     sessionObj->Option.isSome
@@ -78,6 +79,11 @@ let make = (
       (),
     )
   }
+
+  React.useEffect(() => {
+    setIsPayNowButtonDisable(_ => !areRequiredFieldsValid)
+    None
+  }, [areRequiredFieldsValid])
 
   React.useEffect(() => {
     let handle = (ev: Window.event) => {

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -22,7 +22,6 @@ let make = (
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
   let areRequiredFieldsEmpty = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsEmpty)
-  let setIsPayNowButtonDisable = Recoil.useSetRecoilState(payNowButtonDisable)
   let status = CommonHooks.useScript("https://pay.google.com/gp/p/js/pay.js")
   let isGooglePaySDKFlow = React.useMemo(() => {
     sessionObj->Option.isSome
@@ -80,10 +79,11 @@ let make = (
     )
   }
 
-  React.useEffect(() => {
-    setIsPayNowButtonDisable(_ => !areRequiredFieldsValid)
-    None
-  }, [areRequiredFieldsValid])
+  UtilityHooks.useHandlePostMessages(
+    ~complete=areRequiredFieldsValid,
+    ~empty=areRequiredFieldsEmpty,
+    ~paymentType="google_pay",
+  )
 
   React.useEffect(() => {
     let handle = (ev: Window.event) => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Pay now button was not enabling for req fields fix

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
