### PR TITLE
fix: do not unmount preMountLoader iframe

### DIFF
--- a/src/Payments/PreMountLoader.res
+++ b/src/Payments/PreMountLoader.res
@@ -96,7 +96,6 @@ let make = (~sessionId, ~publishableKey, ~clientSecret, ~endpoint) => {
     if (
       paymentMethodsResponseSent && customerPaymentMethodsResponseSent && sessionTokensResponseSent
     ) {
-      handlePostMessage([("preMountLoaderIframeUnMount", true->JSON.Encode.bool)])
       Window.removeEventListener("message", handle)
     }
     None

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -89,21 +89,12 @@ let make = (
 
     let preMountLoaderIframeDiv = mountPreMountLoaderIframe()
 
-    let unMountPreMountLoaderIframe = () => {
-      switch preMountLoaderIframeDiv->Nullable.toOption {
-      | Some(iframe) => iframe->remove
-      | None => ()
-      }
-    }
-
     let preMountLoaderMountedPromise = Promise.make((resolve, _reject) => {
       let preMountLoaderIframeCallback = (ev: Types.event) => {
         let json = ev.data->Identity.anyTypeToJson
         let dict = json->Utils.getDictFromJson
         if dict->Dict.get("preMountLoaderIframeMountedCallback")->Option.isSome {
           resolve(true->JSON.Encode.bool)
-        } else if dict->Dict.get("preMountLoaderIframeUnMount")->Option.isSome {
-          unMountPreMountLoaderIframe()
         }
       }
       addSmartEventListener(


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Not unmounting preMountLoader iframe after api calls

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
