### PR TITLE
fix: added display_voucher_information again

### DIFF
--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -652,6 +652,40 @@ let rec intentCall = (
                     ("metadata", metaData->JSON.Encode.object),
                   ])
                 }
+              } else if intent.nextAction.type_ === "display_voucher_information" {
+                let voucherData = intent.nextAction.voucher_details->Belt.Option.getWithDefault({
+                  download_url: "",
+                  reference: "",
+                })
+                let headerObj = Dict.make()
+                headers->Array.forEach(
+                  entries => {
+                    let (x, val) = entries
+                    Dict.set(headerObj, x, val->JSON.Encode.string)
+                  },
+                )
+                let metaData =
+                  [
+                    ("voucherUrl", voucherData.download_url->JSON.Encode.string),
+                    ("reference", voucherData.reference->JSON.Encode.string),
+                    ("returnUrl", url.href->JSON.Encode.string),
+                    ("paymentMethod", paymentMethod->JSON.Encode.string),
+                    ("payment_intent_data", data),
+                  ]->Dict.fromArray
+                handleLogging(
+                  ~optLogger,
+                  ~value="",
+                  ~internalMetadata=metaData->JSON.Encode.object->JSON.stringify,
+                  ~eventName=DISPLAY_VOUCHER,
+                  ~paymentMethod,
+                  (),
+                )
+                handlePostMessage([
+                  ("fullscreen", true->JSON.Encode.bool),
+                  ("param", `voucherData`->JSON.Encode.string),
+                  ("iframeId", iframeId->JSON.Encode.string),
+                  ("metadata", metaData->JSON.Encode.object),
+                ])
               } else if intent.nextAction.type_ == "third_party_sdk_session_token" {
                 let session_token = switch intent.nextAction.session_token {
                 | Some(token) => token->getDictFromJson

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -653,7 +653,7 @@ let rec intentCall = (
                   ])
                 }
               } else if intent.nextAction.type_ === "display_voucher_information" {
-                let voucherData = intent.nextAction.voucher_details->Belt.Option.getWithDefault({
+                let voucherData = intent.nextAction.voucher_details->Option.getOr({
                   download_url: "",
                   reference: "",
                 })


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added display_voucher_information again. Causing issue for boleto

## How did you test it?

Tested Boleto Pay end to end flow. Modal should open post /confirm

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
