### PR TITLE
fix: sdk button redirect issue

### DIFF
--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -26,8 +26,10 @@ let make = () => {
     let dict = json->getDictFromJson
     switch dict->Dict.get("submitSuccessful") {
     | Some(_) =>
-      setIsPayNowButtonDisable(_ => false)
-      setShowLoader(_ => false)
+      if sdkHandleConfirmPayment.confirmParams.redirect === Some("if_required") {
+        setIsPayNowButtonDisable(_ => false)
+        setShowLoader(_ => false)
+      }
     | None => ()
     }
   }

--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -21,23 +21,9 @@ let make = () => {
   let confirmPayload = sdkHandleConfirmPayment->PaymentBody.confirmPayloadForSDKButton
   let buttonText = sdkHandleConfirmPayment.buttonText->Option.getOr(localeString.payNowButton)
 
-  let handleMessage = (event: Types.event) => {
-    let json = event.data->Identity.anyTypeToJson->getStringFromJson("")->safeParse
-    let dict = json->getDictFromJson
-    switch dict->Dict.get("submitSuccessful") {
-    | Some(_) =>
-      if sdkHandleConfirmPayment.confirmParams.redirect === Some("if_required") {
-        setIsPayNowButtonDisable(_ => false)
-        setShowLoader(_ => false)
-      }
-    | None => ()
-    }
-  }
-
   let handleOnClick = _ => {
     setIsPayNowButtonDisable(_ => true)
     setShowLoader(_ => true)
-    EventListenerManager.addSmartEventListener("message", handleMessage, "onSubmitSuccessful")
     handlePostMessage([("handleSdkConfirm", confirmPayload)])
   }
 

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -166,12 +166,7 @@ let confirmPayloadForSDKButton = (sdkHandleConfirmPayment: PaymentType.sdkHandle
       "confirmParams",
       [
         ("return_url", sdkHandleConfirmPayment.confirmParams.return_url->JSON.Encode.string),
-        (
-          "redirect",
-          sdkHandleConfirmPayment.confirmParams.redirect
-          ->Option.getOr("if_required")
-          ->JSON.Encode.string,
-        ),
+        ("redirect", "always"->JSON.Encode.string),
       ]->Utils.getJsonFromArrayOfJson,
     ),
   ]->Utils.getJsonFromArrayOfJson

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -166,7 +166,12 @@ let confirmPayloadForSDKButton = (sdkHandleConfirmPayment: PaymentType.sdkHandle
       "confirmParams",
       [
         ("return_url", sdkHandleConfirmPayment.confirmParams.return_url->JSON.Encode.string),
-        ("redirect", "always"->JSON.Encode.string),
+        (
+          "redirect",
+          sdkHandleConfirmPayment.confirmParams.redirect
+          ->Option.getOr("if_required")
+          ->JSON.Encode.string,
+        ),
       ]->Utils.getJsonFromArrayOfJson,
     ),
   ]->Utils.getJsonFromArrayOfJson

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -166,7 +166,7 @@ let confirmPayloadForSDKButton = (sdkHandleConfirmPayment: PaymentType.sdkHandle
       "confirmParams",
       [
         ("return_url", sdkHandleConfirmPayment.confirmParams.return_url->JSON.Encode.string),
-        ("redirect", "always"->JSON.Encode.string),
+        ("redirect", "always"->JSON.Encode.string), // *As in the case of SDK Button we are not returning the promise back so it will always redirect
       ]->Utils.getJsonFromArrayOfJson,
     ),
   ]->Utils.getJsonFromArrayOfJson

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -162,11 +162,11 @@ let paymentTypeBody = paymentType =>
 
 let confirmPayloadForSDKButton = (sdkHandleConfirmPayment: PaymentType.sdkHandleConfirmPayment) =>
   [
-    ("redirect", "always"->JSON.Encode.string),
     (
       "confirmParams",
       [
         ("return_url", sdkHandleConfirmPayment.confirmParams.return_url->JSON.Encode.string),
+        ("redirect", "always"->JSON.Encode.string),
       ]->Utils.getJsonFromArrayOfJson,
     ),
   ]->Utils.getJsonFromArrayOfJson


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fix for redirect as it was been passed in wrong place

## How did you test it?

Via passing redirect = always and checking the redirection

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
