### PR TITLE
fix: sdk button loader issue

### DIFF
--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -21,9 +21,23 @@ let make = () => {
   let confirmPayload = sdkHandleConfirmPayment->PaymentBody.confirmPayloadForSDKButton
   let buttonText = sdkHandleConfirmPayment.buttonText->Option.getOr(localeString.payNowButton)
 
+  let handleMessage = (event: Types.event) => {
+    let json = event.data->Identity.anyTypeToJson->getStringFromJson("")->safeParse
+    let dict = json->getDictFromJson
+    switch dict->Dict.get("submitSuccessful") {
+    | Some(submitSuccessfulVal) =>
+      if !(submitSuccessfulVal->JSON.Decode.bool->Option.getOr(false)) {
+        setIsPayNowButtonDisable(_ => false)
+        setShowLoader(_ => false)
+      }
+    | None => ()
+    }
+  }
+
   let handleOnClick = _ => {
     setIsPayNowButtonDisable(_ => true)
     setShowLoader(_ => true)
+    EventListenerManager.addSmartEventListener("message", handleMessage, "onSubmitSuccessful")
     handlePostMessage([("handleSdkConfirm", confirmPayload)])
   }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Loader was not getting stopped in case of failed payments

## How did you test it?

Via making a failed and a succesfull payment

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
