### PR TITLE
fix: apple-pay outline

### DIFF
--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -83,7 +83,7 @@ let make = (~sessionObj: option<JSON.t>) => {
 
   let buttonColor = switch options.wallets.style.theme {
   | Outline
-  | Light => "white"
+  | Light => "white-outline"
   | Dark => "black"
   }
 

--- a/src/Types/PaymentModeType.res
+++ b/src/Types/PaymentModeType.res
@@ -48,6 +48,9 @@ let paymentMode = str => {
 }
 
 let defaultOrder = [
+  "apple_pay",
+  "google_pay",
+  "paypal",
   "card",
   "klarna",
   "affirm",
@@ -63,9 +66,6 @@ let defaultOrder = [
   "giropay",
   "ideal",
   "eps",
-  "google_pay",
-  "apple_pay",
-  "paypal",
   "crypto",
   "bancontact_card",
   "boleto",

--- a/src/Types/PaymentModeType.res
+++ b/src/Types/PaymentModeType.res
@@ -48,9 +48,6 @@ let paymentMode = str => {
 }
 
 let defaultOrder = [
-  "apple_pay",
-  "google_pay",
-  "paypal",
   "card",
   "klarna",
   "affirm",
@@ -66,6 +63,9 @@ let defaultOrder = [
   "giropay",
   "ideal",
   "eps",
+  "apple_pay",
+  "google_pay",
+  "paypal",
   "crypto",
   "bancontact_card",
   "boleto",


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added border apple pay border outline

<img width="565" alt="image" src="https://github.com/juspay/hyperswitch-web/assets/77892330/d8565a1d-584f-4793-8582-91fb397d251b">




## How did you test it?

Via UI

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
