### PR TITLE
fix: removing payment_method_category getting passed in Klarna SDK

### DIFF
--- a/src/Payments/KlarnaSDK.res
+++ b/src/Payments/KlarnaSDK.res
@@ -48,7 +48,7 @@ let make = (~sessionObj: SessionsType.token) => {
         {
           container: None,
           color_text: None,
-          payment_method_category: Some("klarna"),
+          payment_method_category: None,
         },
         Dict.make()->JSON.Encode.object,
         (res: res) => {
@@ -76,7 +76,7 @@ let make = (~sessionObj: SessionsType.token) => {
         {
           container: Some("#klarna-payments"),
           color_text: Some("#E51515"),
-          payment_method_category: Some("pay_later"),
+          payment_method_category: None,
         },
         (_res: res) => {
           handlePostMessageEvents(~complete=true, ~empty=false, ~paymentType="klarna", ~loggerState)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removing paymentMethodData being passed to Klarna, according to their documentation - [Link](https://docs.klarna.com/klarna-payments/additional-resources/klarna-payments-sdk-reference/#load)

<img width="802" alt="Screenshot 2024-06-04 at 8 15 28 PM" src="https://github.com/juspay/hyperswitch-web/assets/121166031/3270af28-5c84-44ad-bb2a-ffed737c38a0">

## How did you test it?

Tested Klarna SDK flow with amount less than $30 and another with amount greater than $60

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
