### PR TITLE
fix: removed fallback in case of sessions call fail based on payment experience

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -45,8 +45,6 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     setLoadSavedCards: (savedCardsLoadState => savedCardsLoadState) => unit,
   ) = React.useState(_ => LoadingSavedCards)
 
-  let isKlarnaRedirectFlow = PaymentUtils.getIsKlarnaRedirectFlow(sessions)
-
   React.useEffect(() => {
     switch (displaySavedPaymentMethods, customerPaymentMethods) {
     | (false, _) => {
@@ -246,11 +244,9 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
       {switch selectedOption->PaymentModeType.paymentMode {
       | Card => <CardPayment cardProps expiryProps cvcProps paymentType />
       | Klarna =>
-        <RenderIf condition={isKlarnaRedirectFlow}>
-          <React.Suspense fallback={loader()}>
-            <KlarnaPaymentLazy paymentType />
-          </React.Suspense>
-        </RenderIf>
+        <React.Suspense fallback={loader()}>
+          <KlarnaPaymentLazy paymentType />
+        </React.Suspense>
       | ACHTransfer =>
         <React.Suspense fallback={loader()}>
           <ACHBankTransferLazy paymentType />

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -78,10 +78,7 @@ let make = (
     let cardPaymentMethod =
       paymentMethodListValue.payment_methods
       ->Array.find(ele => ele.payment_method === "card")
-      ->Option.getOr({
-        payment_method: "card",
-        payment_method_types: [],
-      })
+      ->Option.getOr(PaymentMethodsRecord.defaultMethods)
 
     let cardNetworks = cardPaymentMethod.payment_method_types->Array.map(ele => ele.card_networks)
 

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -742,6 +742,11 @@ type methods = {
   payment_method_types: array<paymentMethodTypes>,
 }
 
+let defaultMethods = {
+  payment_method: "card",
+  payment_method_types: [],
+}
+
 type mandateType = {
   amount: int,
   currency: string,
@@ -1049,10 +1054,7 @@ let getPaymentMethodTypeFromList = (
     ->Array.find(item => {
       item.payment_method == paymentMethod
     })
-    ->Option.getOr({
-      payment_method: "card",
-      payment_method_types: [],
-    })
+    ->Option.getOr(defaultMethods)
   ).payment_method_types->Array.find(item => {
     item.payment_method_type == paymentMethodType
   })
@@ -1063,4 +1065,25 @@ let getCardNetwork = (~paymentMethodType, ~cardBrand) => {
   ->Array.filter(cardNetwork => cardNetwork.card_network === cardBrand)
   ->Array.get(0)
   ->Option.getOr(defaultCardNetworks)
+}
+
+let getPaymentExperienceTypeFromPML = (
+  ~paymentMethodList: paymentMethodList,
+  ~paymentMethodName,
+  ~paymentMethodType,
+) => {
+  paymentMethodList.payment_methods
+  ->Array.filter(paymentMethod => paymentMethod.payment_method === paymentMethodName)
+  ->Array.get(0)
+  ->Option.flatMap(method =>
+    method.payment_method_types
+    ->Array.filter(methodTypes => methodTypes.payment_method_type === paymentMethodType)
+    ->Array.get(0)
+  )
+  ->Option.flatMap(paymentMethodTypes =>
+    paymentMethodTypes.payment_experience
+    ->Array.map(paymentExperience => paymentExperience.payment_experience_type)
+    ->Some
+  )
+  ->Option.getOr([])
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removed Klarna Fallback in case of sessions call fail based on payment experience

## How did you test it?

1. When payment experience is invoke_sdk_client
    - Sessions Call contains Klarna - Klarna SDK should be rendered
    - Sessions Call does not contain Klarna - Klarna SDK should not be rendered
2. When payment experience is redirect_to_url
    - Sessions Call contains Klarna - Klarna Redirect should be rendered (in tabs)
    - Sessions Call does not contain Klarna - Klarna Redirect should be rendered (in tabs)
3. When payment experience is invoke_sdk_client and redirect_to_url
    - Sessions Call contains Klarna - Klarna SDK should be rendered
    - Sessions Call does not contain Klarna - Klarna Redirect should be rendered (in tabs)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
