### PR TITLE
fix: transforming billing and shipping country code to touppercase for applepay

### DIFF
--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -818,6 +818,9 @@ let getApplePayRequiredFields = (
       addressLines->Array.get(index)->Option.getOr("")
     }
 
+    let billingCountryCode = billingContact.countryCode->String.toUpperCase
+    let shippingCountryCode = shippingContact.countryCode->String.toUpperCase
+
     let fieldVal = switch item.field_type {
     | FullName
     | BillingName =>
@@ -833,11 +836,10 @@ let getApplePayRequiredFields = (
       Utils.getStateNameFromStateCodeAndCountry(
         statesList,
         billingContact.administrativeArea,
-        billingContact.countryCode,
+        billingCountryCode,
       )
     | Country
-    | AddressCountry(_) =>
-      billingContact.countryCode
+    | AddressCountry(_) => billingCountryCode
     | AddressPincode => billingContact.postalCode
     | Email => shippingContact.emailAddress
     | PhoneNumber => shippingContact.phoneNumber
@@ -849,9 +851,9 @@ let getApplePayRequiredFields = (
       Utils.getStateNameFromStateCodeAndCountry(
         statesList,
         shippingContact.administrativeArea,
-        shippingContact.countryCode,
+        shippingCountryCode,
       )
-    | ShippingAddressCountry(_) => shippingContact.countryCode
+    | ShippingAddressCountry(_) => shippingCountryCode
     | ShippingAddressPincode => shippingContact.postalCode
     | _ => ""
     }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Country Code Fix for ApplePay

## How did you test it?

Billing and Shipping countryCode coming from Apple are transformed to UpperCase before passing to Backend in the confirmCall

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
