### PR TITLE
fix: manual retries

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -14,6 +14,7 @@ let make = (
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let (showFields, setShowFields) = Recoil.useRecoilState(RecoilAtoms.showCardFieldsAtom)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
   let setUserError = message => {
@@ -176,6 +177,7 @@ let make = (
               ->getArrayOfTupleFromDict,
               ~confirmParam=confirm.confirmParams,
               ~handleUserError=false,
+              ~manualRetry=isManualRetryEnabled,
               (),
             )
           }
@@ -193,6 +195,7 @@ let make = (
               ->getArrayOfTupleFromDict,
               ~confirmParam=confirm.confirmParams,
               ~handleUserError=false,
+              ~manualRetry=isManualRetryEnabled,
               (),
             )
           }
@@ -205,6 +208,7 @@ let make = (
             ->getArrayOfTupleFromDict,
             ~confirmParam=confirm.confirmParams,
             ~handleUserError=false,
+            ~manualRetry=isManualRetryEnabled,
             (),
           )
         }
@@ -233,6 +237,7 @@ let make = (
     isCustomerAcceptanceRequired,
     applePayToken,
     gPayToken,
+    isManualRetryEnabled,
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -15,6 +15,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   let cardScheme = Recoil.useRecoilValueFromAtom(cardBrand)
   let showFields = Recoil.useRecoilValueFromAtom(showCardFieldsAtom)
   let selectedOption = Recoil.useRecoilValueFromAtom(selectedOptionAtom)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let paymentToken = Recoil.useRecoilValueFromAtom(paymentTokenAtom)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
 
@@ -220,7 +221,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   }
 
   let submitAPICall = (body, confirmParam) => {
-    intent(~bodyArr=body, ~confirmParam, ~handleUserError=false, ())
+    intent(~bodyArr=body, ~confirmParam, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
   }
   React.useEffect(() => {
     setCvcNumber(_ => "")

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -221,7 +221,13 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   }
 
   let submitAPICall = (body, confirmParam) => {
-    intent(~bodyArr=body, ~confirmParam, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
+    intent(
+      ~bodyArr=body,
+      ~confirmParam,
+      ~handleUserError=false,
+      ~manualRetry=isManualRetryEnabled,
+      (),
+    )
   }
   React.useEffect(() => {
     setCvcNumber(_ => "")

--- a/src/Payments/ACHBankDebit.res
+++ b/src/Payments/ACHBankDebit.res
@@ -5,6 +5,7 @@ open PaymentModeType
 @react.component
 let make = (~paymentType: CardThemeType.mode) => {
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
+  let isManualRetryEnabled= Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
 
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
 
@@ -76,7 +77,7 @@ let make = (~paymentType: CardThemeType.mode) => {
             ~state=state.value,
             ~paymentType=paymentMethodListValue.payment_type,
           )
-          intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ())
+          intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
         | None => ()
         }
         ()
@@ -84,7 +85,7 @@ let make = (~paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, modalData, fullName))
+  }, (email, modalData, fullName,isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingGridColumn}>

--- a/src/Payments/ACHBankDebit.res
+++ b/src/Payments/ACHBankDebit.res
@@ -5,7 +5,7 @@ open PaymentModeType
 @react.component
 let make = (~paymentType: CardThemeType.mode) => {
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
-  let isManualRetryEnabled= Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
 
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
 
@@ -77,7 +77,13 @@ let make = (~paymentType: CardThemeType.mode) => {
             ~state=state.value,
             ~paymentType=paymentMethodListValue.payment_type,
           )
-          intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
+          intent(
+            ~bodyArr=body,
+            ~confirmParam=confirm.confirmParams,
+            ~handleUserError=false,
+            ~manualRetry=isManualRetryEnabled,
+            (),
+          )
         | None => ()
         }
         ()
@@ -85,7 +91,7 @@ let make = (~paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, modalData, fullName,isManualRetryEnabled))
+  }, (email, modalData, fullName, isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingGridColumn}>

--- a/src/Payments/ACHBankTransfer.res
+++ b/src/Payments/ACHBankTransfer.res
@@ -5,6 +5,7 @@ open Utils
 let make = (~paymentType: CardThemeType.mode) => {
   let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankTransfer)
   let (email, _) = Recoil.useLoggedRecoilState(userEmailAddress, "email", loggerState)
@@ -32,13 +33,14 @@ let make = (~paymentType: CardThemeType.mode) => {
           ~confirmParam=confirm.confirmParams,
           ~handleUserError=false,
           ~iframeId,
+          ~manualRetry=isManualRetryEnabled,
           (),
         )
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, [email])
+  }, (email,isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingTab}>

--- a/src/Payments/ACHBankTransfer.res
+++ b/src/Payments/ACHBankTransfer.res
@@ -40,7 +40,7 @@ let make = (~paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email,isManualRetryEnabled))
+  }, (email, isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingTab}>

--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -13,6 +13,7 @@ let make = (~sessionObj: option<JSON.t>) => {
   let (showApplePay, setShowApplePay) = React.useState(() => false)
   let (showApplePayLoader, setShowApplePayLoader) = React.useState(() => false)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Applepay)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let sync = PaymentHelpers.usePaymentSync(Some(loggerState), Applepay)
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let (applePayClicked, setApplePayClicked) = React.useState(_ => false)
@@ -228,6 +229,7 @@ let make = (~sessionObj: option<JSON.t>) => {
               ~intent,
               ~options,
               ~publishableKey,
+              ~isManualRetryEnabled,
             )
           } else {
             ApplePayHelpers.handleApplePayButtonClicked(~sessionObj, ~componentName)
@@ -241,6 +243,7 @@ let make = (~sessionObj: option<JSON.t>) => {
             ~intent,
             ~options,
             ~publishableKey,
+            ~isManualRetryEnabled,
           )
         }
       } else {

--- a/src/Payments/BacsBankDebit.res
+++ b/src/Payments/BacsBankDebit.res
@@ -89,7 +89,13 @@ let make = (~paymentType: CardThemeType.mode) => {
           ~country=getCountryCode(country.value).isoAlpha2,
           ~bankAccountHolderName=fullName.value,
         )
-        intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ~manualRetry=isManualRetryEnabled,())
+        intent(
+          ~bodyArr=body,
+          ~confirmParam=confirm.confirmParams,
+          ~handleUserError=false,
+          ~manualRetry=isManualRetryEnabled,
+          (),
+        )
         ()
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")

--- a/src/Payments/BacsBankDebit.res
+++ b/src/Payments/BacsBankDebit.res
@@ -23,7 +23,7 @@ let cleanSortCode = str => str->String.replaceRegExp(%re("/-/g"), "")
 @react.component
 let make = (~paymentType: CardThemeType.mode) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
-
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
 
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankDebits)
@@ -89,7 +89,7 @@ let make = (~paymentType: CardThemeType.mode) => {
           ~country=getCountryCode(country.value).isoAlpha2,
           ~bankAccountHolderName=fullName.value,
         )
-        intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ())
+        intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ~manualRetry=isManualRetryEnabled,())
         ()
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")

--- a/src/Payments/BacsBankTransfer.res
+++ b/src/Payments/BacsBankTransfer.res
@@ -5,6 +5,7 @@ let default = (paymentType: CardThemeType.mode) => {
   let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankTransfer)
   let (email, _) = Recoil.useLoggedRecoilState(userEmailAddress, "email", loggerState)
   let (fullName, _) = Recoil.useLoggedRecoilState(userFullName, "fullName", loggerState)
@@ -36,13 +37,14 @@ let default = (paymentType: CardThemeType.mode) => {
           ~confirmParam=confirm.confirmParams,
           ~handleUserError=false,
           ~iframeId,
+          ~manualRetry=isManualRetryEnabled,
           (),
         )
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, [email, fullName])
+  }, (isManualRetryEnabled,email, fullName))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingTab}>

--- a/src/Payments/BacsBankTransfer.res
+++ b/src/Payments/BacsBankTransfer.res
@@ -44,7 +44,7 @@ let default = (paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (isManualRetryEnabled,email, fullName))
+  }, (isManualRetryEnabled, email, fullName))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingTab}>

--- a/src/Payments/BecsBankDebit.res
+++ b/src/Payments/BecsBankDebit.res
@@ -69,7 +69,13 @@ let make = (~paymentType: CardThemeType.mode) => {
               ~postalCode=postalCode.value,
               ~state=state.value,
             )
-            intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
+            intent(
+              ~bodyArr=body,
+              ~confirmParam=confirm.confirmParams,
+              ~handleUserError=false,
+              ~manualRetry=isManualRetryEnabled,
+              (),
+            )
           }
         | None => ()
         }

--- a/src/Payments/BecsBankDebit.res
+++ b/src/Payments/BecsBankDebit.res
@@ -20,6 +20,7 @@ let make = (~paymentType: CardThemeType.mode) => {
   let (postalCode, _) = Recoil.useLoggedRecoilState(userAddressPincode, "postal_code", loggerState)
   let (state, _) = Recoil.useLoggedRecoilState(userAddressState, "state", loggerState)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankDebits)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
 
   let complete =
     email.value != "" &&
@@ -68,7 +69,7 @@ let make = (~paymentType: CardThemeType.mode) => {
               ~postalCode=postalCode.value,
               ~state=state.value,
             )
-            intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ())
+            intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
           }
         | None => ()
         }
@@ -76,7 +77,7 @@ let make = (~paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, modalData))
+  }, (email, fullName, modalData, isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingGridColumn}>

--- a/src/Payments/Boleto.res
+++ b/src/Payments/Boleto.res
@@ -71,7 +71,7 @@ let make = (~paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (socialSecurityNumber,isManualRetryEnabled))
+  }, (socialSecurityNumber, isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   let changeSocialSecurityNumber = ev => {

--- a/src/Payments/Boleto.res
+++ b/src/Payments/Boleto.res
@@ -27,7 +27,7 @@ let make = (~paymentType: CardThemeType.mode) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
-
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Other)
   let setComplete = Recoil.useSetRecoilState(fieldsComplete)
   let (socialSecurityNumber, setSocialSecurityNumber) = React.useState(_ => "")
@@ -64,13 +64,14 @@ let make = (~paymentType: CardThemeType.mode) => {
           ~confirmParam=confirm.confirmParams,
           ~handleUserError=false,
           ~iframeId,
+          ~manualRetry=isManualRetryEnabled,
           (),
         )
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, [socialSecurityNumber])
+  }, (socialSecurityNumber,isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   let changeSocialSecurityNumber = ev => {

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -15,6 +15,7 @@ let make = (
   open UtilityHooks
 
   let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let {innerLayout} = config.appearance
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
@@ -174,6 +175,7 @@ let make = (
           },
           ~confirmParam=confirm.confirmParams,
           ~handleUserError=false,
+          ~manualRetry=isManualRetryEnabled,
           (),
         )
       } else {
@@ -206,6 +208,7 @@ let make = (
     isCustomerAcceptanceRequired,
     nickname,
     isCardBrandValid,
+    isManualRetryEnabled
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -13,6 +13,7 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
   let {publishableKey, sdkHandleOneClickConfirmPayment} = Recoil.useRecoilValueFromAtom(keys)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Gpay)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let sync = PaymentHelpers.usePaymentSync(Some(loggerState), Gpay)
   let isGPayReady = Recoil.useRecoilValueFromAtom(isGooglePayReady)
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
@@ -105,6 +106,7 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
               ~intent,
               ~options,
               ~publishableKey,
+              ~isManualRetryEnabled,
             )
           } else {
             GooglePayHelpers.handleGooglePayClicked(
@@ -116,7 +118,13 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
           }
         } else {
           let bodyDict = PaymentBody.gpayRedirectBody(~connectors)
-          GooglePayHelpers.processPayment(~body=bodyDict, ~intent, ~options, ~publishableKey)
+          GooglePayHelpers.processPayment(
+            ~body=bodyDict,
+            ~intent,
+            ~options,
+            ~publishableKey,
+            ~isManualRetryEnabled,
+          )
         }
       }
       resolve()

--- a/src/Payments/KlarnaPayment.res
+++ b/src/Payments/KlarnaPayment.res
@@ -6,6 +6,7 @@ let make = (~paymentType) => {
   let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {fields} = Recoil.useRecoilValueFromAtom(optionAtom)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), KlarnaRedirect)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let setComplete = Recoil.useSetRecoilState(fieldsComplete)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
 
@@ -53,12 +54,12 @@ let make = (~paymentType) => {
     )
     if confirm.doSubmit {
       if complete {
-        intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ())
+        intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ~manualRetry=isManualRetryEnabled,())
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, country))
+  }, (email, fullName, country,isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div

--- a/src/Payments/KlarnaPayment.res
+++ b/src/Payments/KlarnaPayment.res
@@ -54,12 +54,18 @@ let make = (~paymentType) => {
     )
     if confirm.doSubmit {
       if complete {
-        intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ~manualRetry=isManualRetryEnabled,())
+        intent(
+          ~bodyArr=body,
+          ~confirmParam=confirm.confirmParams,
+          ~handleUserError=false,
+          ~manualRetry=isManualRetryEnabled,
+          (),
+        )
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, country,isManualRetryEnabled))
+  }, (email, fullName, country, isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div

--- a/src/Payments/KlarnaSDK.res
+++ b/src/Payments/KlarnaSDK.res
@@ -13,6 +13,7 @@ let make = (~sessionObj: SessionsType.token) => {
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(RecoilAtoms.isShowOrPayUsing)
   let {publishableKey, sdkHandleOneClickConfirmPayment} = Recoil.useRecoilValueFromAtom(keys)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Other)
   let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let status = CommonHooks.useScript("https://x.klarnacdn.net/kp/lib/v1/api.js") // Klarna SDK script
@@ -105,6 +106,7 @@ let make = (~sessionObj: SessionsType.token) => {
                               publishableKey,
                             },
                             ~handleUserError=false,
+                            ~manualRetry=isManualRetryEnabled,
                             (),
                           )
                         : handleCloseLoader()

--- a/src/Payments/PayPal.res
+++ b/src/Payments/PayPal.res
@@ -32,6 +32,7 @@ let make = () => {
   let (buttonColor, textColor) =
     options.wallets.style.theme == Light ? ("#0070ba", "#ffffff") : ("#ffc439", "#000000")
   let isGuestCustomer = UtilityHooks.useIsGuestCustomer()
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
 
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Paypal)
   let onPaypalClick = _ev => {
@@ -64,6 +65,7 @@ let make = () => {
             publishableKey,
           },
           ~handleUserError=true,
+          ~manualRetry=isManualRetryEnabled,
           (),
         )
       } else {

--- a/src/Payments/PaymentMethodsWrapper.res
+++ b/src/Payments/PaymentMethodsWrapper.res
@@ -9,6 +9,7 @@ let make = (~paymentType: CardThemeType.mode, ~paymentMethodName: string) => {
   let blikCode = Recoil.useRecoilValueFromAtom(userBlikCode)
   let phoneNumber = Recoil.useRecoilValueFromAtom(userPhoneNumber)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Other)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
   let optionPaymentMethodDetails =
@@ -92,6 +93,7 @@ let make = (~paymentType: CardThemeType.mode, ~paymentMethodName: string) => {
           ~confirmParam=confirm.confirmParams,
           ~handleUserError=false,
           ~iframeId,
+          ~manualRetry=isManualRetryEnabled,
           (),
         )
       } else {
@@ -104,6 +106,7 @@ let make = (~paymentType: CardThemeType.mode, ~paymentMethodName: string) => {
     country,
     blikCode,
     paymentMethodName,
+    isManualRetryEnabled,
     phoneNumber.value,
     (selectedBank, currency, requiredFieldsBody),
   ))

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -12,6 +12,7 @@ let make = (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) =
   let token = sessionObj.token
   let orderDetails = sessionObj.orderDetails->getOrderDetails(paymentType)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Paypal)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let completeAuthorize = PaymentHelpers.useCompleteAuthorize(Some(loggerState), Paypal)
   let checkoutScript =
     Window.document(Window.window)->Window.getElementById("braintree-checkout")->Nullable.toOption
@@ -75,6 +76,7 @@ let make = (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) =
         ~paymentMethodListValue,
         ~isGuestCustomer,
         ~intent,
+        ~isManualRetryEnabled,
         ~options,
         ~publishableKey,
         ~paymentMethodTypes,

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -113,6 +113,7 @@ let make = (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) =
               ~stateJson,
               ~handleCloseLoader,
               ~areOneClickWalletsRendered,
+              ~isManualRetryEnabled,
             )
           | _ => ()
           }

--- a/src/Payments/PaypalSDKHelpers.res
+++ b/src/Payments/PaypalSDKHelpers.res
@@ -138,6 +138,7 @@ let loadBraintreePaypalSdk = (
   ~areOneClickWalletsRendered: (
     RecoilAtoms.areOneClickWalletsRendered => RecoilAtoms.areOneClickWalletsRendered
   ) => unit,
+  ~isManualRetryEnabled,
 ) => {
   loggerState.setLogInfo(
     ~value="Paypal Braintree SDK Button Clicked",
@@ -215,6 +216,7 @@ let loadBraintreePaypalSdk = (
                                 publishableKey,
                               },
                               ~handleUserError=true,
+                              ~manualRetry=isManualRetryEnabled,
                               (),
                             )
                           },

--- a/src/Payments/PaypalSDKHelpers.res
+++ b/src/Payments/PaypalSDKHelpers.res
@@ -6,6 +6,7 @@ let loadPaypalSDK = (
   ~sdkHandleOneClickConfirmPayment,
   ~buttonStyle,
   ~iframeId,
+  ~isManualRetryEnabled,
   ~paymentMethodListValue,
   ~isGuestCustomer,
   ~intent: PaymentHelpers.paymentIntent,
@@ -58,6 +59,7 @@ let loadPaypalSDK = (
               ~handleUserError=true,
               ~intentCallback=val =>
                 val->Utils.getDictFromJson->Utils.getString("orderId", "")->resolve,
+              ~manualRetry=isManualRetryEnabled,
               (),
             )
           })

--- a/src/Payments/SepaBankDebit.res
+++ b/src/Payments/SepaBankDebit.res
@@ -6,6 +6,7 @@ open PaymentModeType
 @react.component
 let make = (~paymentType: CardThemeType.mode) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let {config} = Recoil.useRecoilValueFromAtom(configAtom)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankDebits)
 
@@ -64,7 +65,7 @@ let make = (~paymentType: CardThemeType.mode) => {
               ~postalCode=postalCode.value,
               ~state=state.value,
             )
-            intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false, ())
+            intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
           }
         | None => ()
         }
@@ -73,7 +74,7 @@ let make = (~paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, modalData))
+  }, (email, fullName, modalData,isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div

--- a/src/Payments/SepaBankDebit.res
+++ b/src/Payments/SepaBankDebit.res
@@ -65,7 +65,13 @@ let make = (~paymentType: CardThemeType.mode) => {
               ~postalCode=postalCode.value,
               ~state=state.value,
             )
-            intent(~bodyArr=body, ~confirmParam=confirm.confirmParams, ~handleUserError=false,~manualRetry=isManualRetryEnabled, ())
+            intent(
+              ~bodyArr=body,
+              ~confirmParam=confirm.confirmParams,
+              ~handleUserError=false,
+              ~manualRetry=isManualRetryEnabled,
+              (),
+            )
           }
         | None => ()
         }
@@ -74,7 +80,7 @@ let make = (~paymentType: CardThemeType.mode) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, modalData,isManualRetryEnabled))
+  }, (email, fullName, modalData, isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   <div

--- a/src/Payments/SepaBankTransfer.res
+++ b/src/Payments/SepaBankTransfer.res
@@ -8,6 +8,7 @@ let make = (~paymentType) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankTransfer)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let (country, setCountry) = React.useState(_ => "France")
   let (email, _) = Recoil.useLoggedRecoilState(userEmailAddress, "email", loggerState)
   let (fullName, _) = Recoil.useLoggedRecoilState(userFullName, "fullName", loggerState)
@@ -48,13 +49,14 @@ let make = (~paymentType) => {
           ~confirmParam=confirm.confirmParams,
           ~handleUserError=false,
           ~iframeId,
+          ~manualRetry=isManualRetryEnabled,
           (),
         )
       } else {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, country))
+  }, (email, fullName, country,isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   let updatedOptionsArrayForCountry =

--- a/src/Payments/SepaBankTransfer.res
+++ b/src/Payments/SepaBankTransfer.res
@@ -56,7 +56,7 @@ let make = (~paymentType) => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, country,isManualRetryEnabled))
+  }, (email, fullName, country, isManualRetryEnabled))
   useSubmitPaymentData(submitCallback)
 
   let updatedOptionsArrayForCountry =

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -9,6 +9,7 @@ let processPayment = (
   ~intent: PaymentHelpers.paymentIntent,
   ~options: PaymentType.options,
   ~publishableKey,
+  ~isManualRetryEnabled,
 ) => {
   let requestBody = PaymentUtils.appendedCustomerAcceptance(
     ~isGuestCustomer,
@@ -24,6 +25,7 @@ let processPayment = (
     },
     ~handleUserError=true,
     ~isThirdPartyFlow,
+    ~manualRetry=isManualRetryEnabled,
     (),
   )
 }
@@ -155,6 +157,8 @@ let useHandleApplePayResponse = (
     ~paymentMethodType="apple_pay",
   )
 
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
+
   React.useEffect(() => {
     let handleApplePayMessages = (ev: Window.event) => {
       let json = try {
@@ -189,6 +193,7 @@ let useHandleApplePayResponse = (
             ~intent,
             ~options,
             ~publishableKey,
+            ~isManualRetryEnabled,
           )
         } else if dict->Dict.get("showApplePayButton")->Option.isSome {
           setApplePayClicked(_ => false)
@@ -209,7 +214,7 @@ let useHandleApplePayResponse = (
         Window.removeEventListener("message", handleApplePayMessages)
       },
     )
-  }, (isInvokeSDKFlow, processPayment, stateJson))
+  }, (isInvokeSDKFlow, processPayment, stateJson, isManualRetryEnabled))
 }
 
 let handleApplePayButtonClicked = (~sessionObj, ~componentName) => {

--- a/src/Utilities/GooglePayHelpers.res
+++ b/src/Utilities/GooglePayHelpers.res
@@ -65,6 +65,7 @@ let processPayment = (
   ~intent: PaymentHelpers.paymentIntent,
   ~options: PaymentType.options,
   ~publishableKey,
+  ~isManualRetryEnabled,
 ) => {
   intent(
     ~bodyArr=body,
@@ -74,6 +75,7 @@ let processPayment = (
     },
     ~handleUserError=true,
     ~isThirdPartyFlow,
+    ~manualRetry=isManualRetryEnabled,
     (),
   )
 }
@@ -81,6 +83,7 @@ let processPayment = (
 let useHandleGooglePayResponse = (~connectors, ~intent, ~isSavedMethodsFlow=false) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let {publishableKey} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
 
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
   let isGuestCustomer = UtilityHooks.useIsGuestCustomer()
@@ -119,6 +122,7 @@ let useHandleGooglePayResponse = (~connectors, ~intent, ~isSavedMethodsFlow=fals
           ~intent,
           ~options: PaymentType.options,
           ~publishableKey,
+          ~isManualRetryEnabled,
         )
       }
       if dict->Dict.get("gpayError")->Option.isSome {
@@ -130,7 +134,7 @@ let useHandleGooglePayResponse = (~connectors, ~intent, ~isSavedMethodsFlow=fals
     }
     Window.addEventListener("message", handle)
     Some(() => {Window.removeEventListener("message", handle)})
-  }, (paymentMethodTypes, stateJson))
+  }, (paymentMethodTypes, stateJson, isManualRetryEnabled))
 }
 
 let handleGooglePayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly) => {

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -30,6 +30,7 @@ type paymentIntent = (
   ~iframeId: string=?,
   ~isThirdPartyFlow: bool=?,
   ~intentCallback: Core__JSON.t => unit=?,
+  ~manualRetry:bool=?,
   unit,
 ) => unit
 
@@ -1008,7 +1009,7 @@ let usePaymentIntent = (optLogger, paymentType) => {
   let paymentMethodList = Recoil.useRecoilValueFromAtom(paymentMethodList)
   let keys = Recoil.useRecoilValueFromAtom(keys)
 
-  let (isManualRetryEnabled, setIsManualRetryEnabled) = Recoil.useRecoilState(isManualRetryEnabled)
+  let setIsManualRetryEnabled = Recoil.useSetRecoilState(isManualRetryEnabled)
   (
     ~handleUserError=false,
     ~bodyArr: array<(string, JSON.t)>,
@@ -1016,6 +1017,7 @@ let usePaymentIntent = (optLogger, paymentType) => {
     ~iframeId=keys.iframeId,
     ~isThirdPartyFlow=false,
     ~intentCallback=_ => (),
+    ~manualRetry=false,
     (),
   ) => {
     switch keys.clientSecret {
@@ -1027,7 +1029,7 @@ let usePaymentIntent = (optLogger, paymentType) => {
         ("X-Client-Source", paymentTypeFromUrl->CardThemeType.getPaymentModeToStrMapper),
       ]
       let returnUrlArr = [("return_url", confirmParam.return_url->JSON.Encode.string)]
-      let manual_retry = isManualRetryEnabled
+      let manual_retry = manualRetry
         ? [("retry_action", "manual_retry"->JSON.Encode.string)]
         : []
       let body =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Manual Retries not working - intent function was a closure of the `usePaymentIntent` hook 
Hence it was not getting the updated value


## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
