### PR TITLE
fix: added Env to disable sentry by default

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -95,7 +95,7 @@ module.exports = (publicPath = "auto") => {
     );
   }
 
-  if (process.env.SENTRY_AUTH_TOKEN) {
+  if (process.env.SENTRY_AUTH_TOKEN && process.env.IS_SENTRY_ENABLED === "true") {
     plugins.push(
       sentryWebpackPlugin({
         org: "sentry",
@@ -127,18 +127,18 @@ module.exports = (publicPath = "auto") => {
       sdkEnv === "local"
         ? {}
         : {
-            sideEffects: true,
-            minimize: true,
-            minimizer: [
-              new TerserPlugin({
-                terserOptions: {
-                  compress: {
-                    drop_console: false,
-                  },
+          sideEffects: true,
+          minimize: true,
+          minimizer: [
+            new TerserPlugin({
+              terserOptions: {
+                compress: {
+                  drop_console: false,
                 },
-              }),
-            ],
-          },
+              },
+            }),
+          ],
+        },
     plugins,
     module: {
       rules: [


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Disabling Sentry by Default

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
