### PR TITLE
fix: googlePay and applePay billing details not being passed in confirm call for saved methods

### DIFF
--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -38,12 +38,13 @@ let getApplePayFromResponse = (
   ~stateJson,
   ~connectors,
   ~isPaymentSession=false,
+  ~isSavedMethodsFlow=false,
 ) => {
   let billingContact = billingContactDict->ApplePayTypes.billingContactItemToObjMapper
 
   let shippingContact = shippingContactDict->ApplePayTypes.shippingContactItemToObjMapper
 
-  let requiredFieldsBody = if isPaymentSession {
+  let requiredFieldsBody = if isPaymentSession || isSavedMethodsFlow {
     DynamicFieldsUtils.getApplePayRequiredFields(
       ~billingContact,
       ~shippingContact,
@@ -183,6 +184,7 @@ let useHandleApplePayResponse = (
             ~requiredFields=paymentMethodTypes.required_fields,
             ~stateJson,
             ~connectors,
+            ~isSavedMethodsFlow,
           )
 
           processPayment(

--- a/src/Utilities/GooglePayHelpers.res
+++ b/src/Utilities/GooglePayHelpers.res
@@ -8,6 +8,7 @@ let getGooglePayBodyFromResponse = (
   ~requiredFields=[],
   ~stateJson,
   ~isPaymentSession=false,
+  ~isSavedMethodsFlow=false,
 ) => {
   let obj = gPayResponse->getDictFromJson->GooglePayType.itemToObjMapper
   let gPayBody = PaymentUtils.appendedCustomerAcceptance(
@@ -35,7 +36,7 @@ let getGooglePayBodyFromResponse = (
     ->getDictFromJson
     ->getString("email", "")
 
-  let requiredFieldsBody = if isPaymentSession {
+  let requiredFieldsBody = if isPaymentSession || isSavedMethodsFlow {
     DynamicFieldsUtils.getGooglePayRequiredFields(
       ~billingContact,
       ~shippingContact,
@@ -115,6 +116,7 @@ let useHandleGooglePayResponse = (~connectors, ~intent, ~isSavedMethodsFlow=fals
           ~connectors,
           ~requiredFields=paymentMethodTypes.required_fields,
           ~stateJson,
+          ~isSavedMethodsFlow,
         )
         processPayment(
           ~body,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

googlePay and applePay billing details not being passed in confirm call for saved methods

## How did you test it?

Billing Details should be passed in the confirm body for ApplePay and GooglePay in Saved Payment Methods Flow

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
