### PR TITLE
fix: fixed the ui disparity for more payment methods text and use saved payment methods

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -296,11 +296,10 @@ let make = (
     </RenderIf>
     <RenderIf condition={!showFields}>
       <div
-        className="Label flex flex-row gap-3 items-end cursor-pointer"
+        className="Label flex flex-row gap-3 items-end cursor-pointer mt-4"
         style={
           fontSize: "14px",
           float: "left",
-          marginTop: "14px",
           fontWeight: "500",
           width: "fit-content",
           color: themeObj.colorPrimary,

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -391,7 +391,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     <RenderIf
       condition={displaySavedPaymentMethods && savedMethods->Array.length > 0 && showFields}>
       <div
-        className="Label flex flex-row gap-3 items-end cursor-pointer my-4"
+        className="Label flex flex-row gap-3 items-end cursor-pointer mt-4"
         style={
           fontSize: "14px",
           float: "left",


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed the ui disparity for more payment methods text and use saved payment methods

## How did you test it?

![Screenshot 2024-07-02 at 11 20 37 AM](https://github.com/juspay/hyperswitch-web/assets/121166031/48cbc5c5-4926-4719-8fcc-092331743305)
![Screenshot 2024-07-02 at 11 20 31 AM](https://github.com/juspay/hyperswitch-web/assets/121166031/490ef45e-edce-4344-8c17-3b080cd8174f)


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
