### PR TITLE
fix: passing customer acceptance if recurring_enabled is false in saved methods list

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -54,12 +54,6 @@ let make = (
     }
   }
 
-  let isCustomerAcceptanceRequired = useIsCustomerAcceptanceRequired(
-    ~displaySavedPaymentMethodsCheckbox,
-    ~isSaveCardsChecked,
-    ~isGuestCustomer,
-  )
-
   let bottomElement = {
     savedMethods
     ->Array.mapWithIndex((obj, i) => {
@@ -125,6 +119,8 @@ let make = (
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->JSON.parseExn
     let confirm = json->getDictFromJson->ConfirmType.itemToObjMapper
+
+    let isCustomerAcceptanceRequired = customerMethod.recurringEnabled->not
 
     let savedPaymentMethodBody = switch customerMethod.paymentMethod {
     | "card" =>
@@ -235,7 +231,6 @@ let make = (
     empty,
     complete,
     customerMethod,
-    isCustomerAcceptanceRequired,
     applePayToken,
     gPayToken,
     isManualRetryEnabled,

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -132,6 +132,7 @@ type customerMethods = {
   requiresCvv: bool,
   lastUsedAt: string,
   bank: bank,
+  recurringEnabled: bool,
 }
 type savedCardsLoadState =
   LoadingSavedCards | LoadedSavedCards(array<customerMethods>, bool) | NoResult(bool)
@@ -192,6 +193,7 @@ let defaultCustomerMethods = {
   requiresCvv: true,
   lastUsedAt: "",
   bank: {mask: ""},
+  recurringEnabled: false,
 }
 let defaultLayout = {
   defaultCollapsed: false,
@@ -883,6 +885,7 @@ let itemToCustomerObjMapper = customerDict => {
         requiresCvv: getBool(dict, "requires_cvv", true),
         lastUsedAt: getString(dict, "last_used_at", ""),
         bank: dict->getBank,
+        recurringEnabled: getBool(dict, "recurring_enabled", false),
       }
     })
 
@@ -919,6 +922,7 @@ let getCustomerMethods = (dict, str) => {
           requiresCvv: getBool(dict, "requires_cvv", true),
           lastUsedAt: getString(dict, "last_used_at", ""),
           bank: dict->getBank,
+          recurringEnabled: getBool(dict, "recurring_enabled", false),
         }
       })
     LoadedSavedCards(customerPaymentMethods, false)

--- a/src/orca-loader/PaymentSessionMethods.res
+++ b/src/orca-loader/PaymentSessionMethods.res
@@ -278,11 +278,16 @@ let getCustomerSavedPaymentMethods = (
           let paymentMethod = lastUsedPaymentMethod.paymentMethod
           let paymentMethodType = lastUsedPaymentMethod.paymentMethodType->Option.getOr("")
           let paymentType = paymentMethodType->PaymentHelpers.getPaymentType
+          let isCustomerAcceptanceRequired = lastUsedPaymentMethod.recurringEnabled->not
 
           let body = [
             ("payment_method", paymentMethod->JSON.Encode.string),
             ("payment_token", paymentToken->JSON.Encode.string),
           ]
+
+          if isCustomerAcceptanceRequired {
+            body->Array.push(("customer_acceptance", PaymentBody.customerAcceptanceBody))->ignore
+          }
 
           if paymentMethodType !== "" {
             body->Array.push(("payment_method_type", paymentMethodType->JSON.Encode.string))->ignore


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Passing customer acceptance in the confirm body for the saved payment methods if recurring_enabled is false in the customers payment method list

## How did you test it?

If recurring_enabled is false, pass customer_acceptance in the confirm body. If recurring_enabled is true, customer_acceptance should not be passed in the confirm body.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
