### PR TITLE
feat: language preference for mifinity added

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -51,7 +51,9 @@ let make = () => {
             "hyperComponentName",
           )->Types.getHyperComponentNameFromStr
 
-        <PreMountLoader publishableKey sessionId clientSecret endpoint ephemeralKey hyperComponentName />
+        <PreMountLoader
+          publishableKey sessionId clientSecret endpoint ephemeralKey hyperComponentName
+        />
       }
     | "achBankTransfer"
     | "bacsBankTransfer"

--- a/src/CardTheme.res
+++ b/src/CardTheme.res
@@ -72,7 +72,7 @@ type recoilConfig = {
 let getLocaleObject = async string => {
   try {
     let locale = if string == "auto" {
-      navigator["language"]
+      Window.language
     } else {
       string
     }

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -483,6 +483,7 @@ let make = (
           | ShippingAddressPincode
           | ShippingAddressState
           | PhoneCountryCode
+          | LanguagePreference(_)
           | ShippingAddressCountry(_) => React.null
           }}
         </div>
@@ -767,6 +768,7 @@ let make = (
                 | DateOfBirth
                 | PhoneCountryCode
                 | VpaId
+                | LanguagePreference(_)
                 | None => React.null
                 }}
               </div>

--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -123,7 +123,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
       setConfig(_ => {
         config: {
           appearance,
-          locale: config.locale,
+          locale: config.locale === "auto" ? Window.language : config.locale,
           fonts: config.fonts,
           clientSecret: config.clientSecret,
           ephemeralKey: config.ephemeralKey,

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -208,7 +208,7 @@ let make = (
     isCustomerAcceptanceRequired,
     nickname,
     isCardBrandValid,
-    isManualRetryEnabled
+    isManualRetryEnabled,
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Types/CardThemeType.res
+++ b/src/Types/CardThemeType.res
@@ -2,7 +2,6 @@ type theme = Default | Brutal | Midnight | Soft | Charcoal | NONE
 
 type innerLayout = Spaced | Compressed
 
-@val external navigator: 'a = "navigator"
 type showLoader = Auto | Always | Never
 
 type mode =

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -400,6 +400,7 @@ let useSetInitialRequiredFields = (
           }
         | None => ()
         }
+      | LanguagePreference(_)
       | SpecialField(_)
       | InfoElement
       | CardNumber
@@ -433,6 +434,7 @@ let useRequiredFieldsBody = (
   ~isAllStoredCardsHaveName,
   ~setRequiredFieldsBody,
 ) => {
+  let configValue = Recoil.useRecoilValueFromAtom(configAtom)
   let email = Recoil.useRecoilValueFromAtom(userEmailAddress)
   let vpaId = Recoil.useRecoilValueFromAtom(userVpaId)
   let fullName = Recoil.useRecoilValueFromAtom(userFullName)
@@ -464,6 +466,12 @@ let useRequiredFieldsBody = (
     | PhoneCountryCode => phone.countryCode->Option.getOr("")
     | Currency(_) => currency
     | Country => country
+    | LanguagePreference(languageOptions) =>
+      languageOptions->Array.includes(
+        configValue.config.locale->String.toUpperCase->String.split("-")->Array.joinWith("_"),
+      )
+        ? configValue.config.locale
+        : "en"
     | Bank =>
       (
         Bank.getBanks(paymentMethodType)

--- a/src/Window.res
+++ b/src/Window.res
@@ -118,6 +118,9 @@ external userAgent: string = "userAgent"
 @val @scope("navigator")
 external sendBeacon: (string, string) => unit = "sendBeacon"
 
+@val @scope("navigator")
+external language: string = "language"
+
 @val @scope(("window", "location"))
 external hostname: string = "hostname"
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

added language preference for mifinity
if the language passed by merchant is supported by mifinity then we pass it as same, else if the language passed is auto then we take language from browser, else we pass "en".

## How did you test it?

tested by firstly passing supported language locale , the sdk was rendered in the provided language, then passed the locale as "auto", the sdk rendered in browser specified language, then passed an unsupported and empty locale, in this case the english language was shown.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
