### PR TITLE
feat: passing X-Merchant-Domain in the headers for Sessions Call

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -44,9 +44,10 @@ let make = () => {
             url.search,
             "hyperComponentName",
           )->Types.getHyperComponentNameFromStr
+        let merchantHostname = CardUtils.getQueryParamsDictforKey(url.search, "merchantHostname")
 
         <PreMountLoader
-          publishableKey sessionId clientSecret endpoint ephemeralKey hyperComponentName
+          publishableKey sessionId clientSecret endpoint ephemeralKey hyperComponentName merchantHostname
         />
       }
     | "achBankTransfer"

--- a/src/Payments/PreMountLoader.res
+++ b/src/Payments/PreMountLoader.res
@@ -6,6 +6,7 @@ let make = (
   ~endpoint,
   ~ephemeralKey,
   ~hyperComponentName: Types.hyperComponentName,
+  ~merchantHostname,
 ) => {
   open Utils
   let (paymentMethodsResponseSent, setPaymentMethodsResponseSent) = React.useState(_ => false)
@@ -63,6 +64,7 @@ let make = (
         ~optLogger=Some(logger),
         ~switchToCustomPod=false,
         ~endpoint,
+        ~merchantHostname,
         (),
       )
     | _ => JSON.Encode.null->Promise.resolve

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -1257,10 +1257,15 @@ let fetchSessions = (
   ~switchToCustomPod,
   ~endpoint,
   ~isPaymentSession=false,
+  ~merchantHostname=Window.Location.hostname,
   (),
 ) => {
   open Promise
-  let headers = [("Content-Type", "application/json"), ("api-key", publishableKey)]
+  let headers = [
+    ("Content-Type", "application/json"),
+    ("api-key", publishableKey),
+    ("X-Merchant-Domain", merchantHostname),
+  ]
   let paymentIntentID = clientSecret->getPaymentId
   let body =
     [

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -815,8 +815,6 @@ let getHeaders = (~uri=?, ~token=?, ~headers=Dict.make(), ()) => {
       ("X-Payment-Confirm-Source", "sdk"),
       ("X-Browser-Name", OrcaLogger.arrayOfNameAndVersion->Array.get(0)->Option.getOr("Others")),
       ("X-Browser-Version", OrcaLogger.arrayOfNameAndVersion->Array.get(1)->Option.getOr("0")),
-      ("browsername", OrcaLogger.arrayOfNameAndVersion->Array.get(0)->Option.getOr("Others")),
-      ("browserversion", OrcaLogger.arrayOfNameAndVersion->Array.get(1)->Option.getOr("0")),
       ("X-Client-Platform", "web"),
     ]->Dict.fromArray
 

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -57,6 +57,8 @@ let make = (
       ->Option.flatMap(JSON.Decode.bool)
       ->Option.getOr(false)
 
+    let merchantHostname = Window.Location.hostname
+
     let localSelectorString = "hyper-preMountLoader-iframe"
     let mountPreMountLoaderIframe = () => {
       if (
@@ -70,7 +72,7 @@ let make = (
            <iframe
            id ="orca-payment-element-iframeRef-${localSelectorString}"
            name="orca-payment-element-iframeRef-${localSelectorString}"
-          src="${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=${componentType}&publishableKey=${publishableKey}&clientSecret=${clientSecret}&sessionId=${sdkSessionId}&endpoint=${endpoint}"
+          src="${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=${componentType}&publishableKey=${publishableKey}&clientSecret=${clientSecret}&sessionId=${sdkSessionId}&endpoint=${endpoint}&merchantHostname=${merchantHostname}"
           allow="*"
           name="orca-payment"
         ></iframe>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

passing X-Merchant-Domain in the headers for Sessions Call

## How did you test it?

![Screenshot 2024-07-17 at 4 34 33 PM](https://github.com/user-attachments/assets/b963f5fe-f9d1-488f-b914-5137e05768df)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
