### PR TITLE
fix(payout): handle tab order updates

### DIFF
--- a/src/CollectWidget.res
+++ b/src/CollectWidget.res
@@ -480,12 +480,16 @@ let make = (
   }
 
   let handleTabSelection = selectedPMT => {
-    if availablePaymentMethodTypes->Array.indexOf(selectedPMT) >= defaultOptionsLimitInTabLayout {
+    if (
+      availablePaymentMethodTypesOrdered->Array.indexOf(selectedPMT) >=
+        defaultOptionsLimitInTabLayout
+    ) {
       // Move the selected payment method at the last tab position
       let ordList = availablePaymentMethodTypes->Array.reduceWithIndex([], (acc, pmt, i) => {
         if i === defaultOptionsLimitInTabLayout - 1 {
           acc->Array.push(selectedPMT)
-        } else if pmt !== selectedPMT {
+        }
+        if pmt !== selectedPMT {
           acc->Array.push(pmt)
         }
         acc


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR fixes the logic of updating `availablePaymentMethodTypesOrdered` which is used for rendering the available PMTs in tab view.

## How did you test it?
Locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
