### PR TITLE
feat: added support for collecting_billing_details_from_wallets

### DIFF
--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -1,7 +1,7 @@
 open Utils
 open Promise
 @react.component
-let make = (~sessionObj: option<JSON.t>) => {
+let make = (~sessionObj: option<JSON.t>, ~walletOptions, ~paymentType: CardThemeType.mode) => {
   let url = RescriptReactRouter.useUrl()
   let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
@@ -20,6 +20,17 @@ let make = (~sessionObj: option<JSON.t>) => {
   let isApplePaySDKFlow = sessionObj->Option.isSome
   let areOneClickWalletsRendered = Recoil.useSetRecoilState(RecoilAtoms.areOneClickWalletsRendered)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
+
+  let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
+  let areRequiredFieldsEmpty = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsEmpty)
+  let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
+  let isWallet = walletOptions->Array.includes("apple_pay")
+
+  UtilityHooks.useHandlePostMessages(
+    ~complete=areRequiredFieldsValid,
+    ~empty=areRequiredFieldsEmpty,
+    ~paymentType="apple_pay",
+  )
 
   let applePayPaymentMethodType = React.useMemo(() => {
     switch PaymentMethodsRecord.getPaymentMethodTypeFromList(
@@ -260,12 +271,15 @@ let make = (~sessionObj: option<JSON.t>) => {
     ~setApplePayClicked,
     ~syncPayment,
     ~isInvokeSDKFlow,
+    ~isWallet,
+    ~requiredFieldsBody,
   )
 
   React.useEffect(() => {
     if (
       (isInvokeSDKFlow || paymentExperience == PaymentMethodsRecord.RedirectToURL) &&
-        isApplePayReady
+      isApplePayReady &&
+      isWallet
     ) {
       setShowApplePay(_ => true)
       areOneClickWalletsRendered(prev => {
@@ -275,26 +289,35 @@ let make = (~sessionObj: option<JSON.t>) => {
       setIsShowOrPayUsing(_ => true)
     }
     None
-  }, (isApplePayReady, isInvokeSDKFlow, paymentExperience))
+  }, (isApplePayReady, isInvokeSDKFlow, paymentExperience, isWallet))
 
-  <RenderIf condition={showApplePay}>
-    <div>
-      <style> {React.string(css)} </style>
-      {if showApplePayLoader {
-        <div className="apple-pay-loader-div">
-          <div className="apple-pay-loader" />
-        </div>
-      } else {
-        <button
-          disabled=applePayClicked
-          className="apple-pay-button-with-text apple-pay-button-black-with-text"
-          onClick={_ => onApplePayButtonClicked()}>
-          <span className="text"> {React.string("Pay with")} </span>
-          <span className="logo" />
-        </button>
-      }}
-    </div>
-  </RenderIf>
+  let submitCallback = ApplePayHelpers.useSubmitCallback(~isWallet, ~sessionObj, ~componentName)
+  useSubmitPaymentData(submitCallback)
+
+  if isWallet {
+    <RenderIf condition={showApplePay}>
+      <div>
+        <style> {React.string(css)} </style>
+        {if showApplePayLoader {
+          <div className="apple-pay-loader-div">
+            <div className="apple-pay-loader" />
+          </div>
+        } else {
+          <button
+            disabled=applePayClicked
+            className="apple-pay-button-with-text apple-pay-button-black-with-text"
+            onClick={_ => onApplePayButtonClicked()}>
+            <span className="text"> {React.string("Pay with")} </span>
+            <span className="logo" />
+          </button>
+        }}
+      </div>
+    </RenderIf>
+  } else {
+    <DynamicFields
+      paymentType paymentMethod="wallet" paymentMethodType="apple_pay" setRequiredFieldsBody
+    />
+  }
 }
 
 let default = make

--- a/src/Payments/ApplePay.resi
+++ b/src/Payments/ApplePay.resi
@@ -1,2 +1,6 @@
 @react.component
-let default: (~sessionObj: option<JSON.t>) => React.element
+let default: (
+  ~sessionObj: option<JSON.t>,
+  ~walletOptions: array<string>,
+  ~paymentType: CardThemeType.mode,
+) => React.element

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -5,7 +5,12 @@ open GooglePayType
 open Promise
 
 @react.component
-let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: option<JSON.t>) => {
+let make = (
+  ~sessionObj: option<SessionsType.token>,
+  ~thirdPartySessionObj: option<JSON.t>,
+  ~walletOptions,
+  ~paymentType: CardThemeType.mode,
+) => {
   let url = RescriptReactRouter.useUrl()
   let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
@@ -27,6 +32,17 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
 
   let areOneClickWalletsRendered = Recoil.useSetRecoilState(RecoilAtoms.areOneClickWalletsRendered)
+
+  let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
+  let areRequiredFieldsEmpty = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsEmpty)
+  let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
+  let isWallet = walletOptions->Array.includes("google_pay")
+
+  UtilityHooks.useHandlePostMessages(
+    ~complete=areRequiredFieldsValid,
+    ~empty=areRequiredFieldsEmpty,
+    ~paymentType="google_pay",
+  )
 
   let googlePayPaymentMethodType = switch PaymentMethodsRecord.getPaymentMethodTypeFromList(
     ~paymentMethodListValue,
@@ -58,7 +74,7 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
     ->Option.getOr(false)
   }, [thirdPartySessionObj])
 
-  GooglePayHelpers.useHandleGooglePayResponse(~connectors, ~intent)
+  GooglePayHelpers.useHandleGooglePayResponse(~connectors, ~intent, ~isWallet, ~requiredFieldsBody)
 
   let (_, buttonType, _) = options.wallets.style.type_
   let (_, heightType, _, _) = options.wallets.style.height
@@ -155,9 +171,10 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
   React.useEffect(() => {
     if (
       status == "ready" &&
-        (isGPayReady ||
-        isDelayedSessionToken ||
-        paymentExperience == PaymentMethodsRecord.RedirectToURL)
+      (isGPayReady ||
+      isDelayedSessionToken ||
+      paymentExperience == PaymentMethodsRecord.RedirectToURL) &&
+      isWallet
     ) {
       setIsShowOrPayUsing(_ => true)
       addGooglePayButton()
@@ -190,7 +207,9 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
   })
 
   let isRenderGooglePayButton =
-    isGPayReady || paymentExperience == PaymentMethodsRecord.RedirectToURL || isDelayedSessionToken
+    (isGPayReady ||
+    paymentExperience == PaymentMethodsRecord.RedirectToURL ||
+    isDelayedSessionToken) && isWallet
 
   React.useEffect(() => {
     areOneClickWalletsRendered(prev => {
@@ -200,13 +219,22 @@ let make = (~sessionObj: option<SessionsType.token>, ~thirdPartySessionObj: opti
     None
   }, [isRenderGooglePayButton])
 
-  <RenderIf condition={isRenderGooglePayButton}>
-    <div
-      style={height: `${height->Int.toString}px`}
-      id="google-pay-button"
-      className={`w-full flex flex-row justify-center rounded-md`}
+  let submitCallback = GooglePayHelpers.useSubmitCallback(~isWallet, ~sessionObj, ~componentName)
+  useSubmitPaymentData(submitCallback)
+
+  if isWallet {
+    <RenderIf condition={isRenderGooglePayButton}>
+      <div
+        style={height: `${height->Int.toString}px`}
+        id="google-pay-button"
+        className={`w-full flex flex-row justify-center rounded-md`}
+      />
+    </RenderIf>
+  } else {
+    <DynamicFields
+      paymentType paymentMethod="wallet" paymentMethodType="google_pay" setRequiredFieldsBody
     />
-  </RenderIf>
+  }
 }
 
 let default = make

--- a/src/Payments/GPay.resi
+++ b/src/Payments/GPay.resi
@@ -2,4 +2,6 @@
 let default: (
   ~sessionObj: option<SessionsType.token>,
   ~thirdPartySessionObj: option<JSON.t>,
+  ~walletOptions: array<string>,
+  ~paymentType: CardThemeType.mode,
 ) => React.element

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -802,6 +802,7 @@ type paymentMethodList = {
   mandate_payment: option<mandate>,
   payment_type: payment_type,
   merchant_name: string,
+  collect_billing_details_from_wallets: bool,
 }
 
 let defaultPaymentMethodType = {
@@ -823,6 +824,7 @@ let defaultList = {
   mandate_payment: None,
   payment_type: NONE,
   merchant_name: "",
+  collect_billing_details_from_wallets: true,
 }
 let getMethod = str => {
   switch str {
@@ -1030,6 +1032,11 @@ let itemToObjMapper = dict => {
     mandate_payment: getMandate(dict, "mandate_payment"),
     payment_type: getString(dict, "payment_type", "")->paymentTypeMapper,
     merchant_name: getString(dict, "merchant_name", ""),
+    collect_billing_details_from_wallets: getBool(
+      dict,
+      "collect_billing_details_from_wallets",
+      true,
+    ),
   }
 }
 

--- a/src/Payments/PaymentRequestButtonElement.res
+++ b/src/Payments/PaymentRequestButtonElement.res
@@ -77,9 +77,15 @@ let make = (~sessions, ~walletOptions, ~paymentType) => {
                   switch googlePayThirdPartyToken {
                   | GooglePayThirdPartyTokenOptional(googlePayThirdPartyOptToken) =>
                     <GPayLazy
-                      sessionObj=optToken thirdPartySessionObj=googlePayThirdPartyOptToken
+                      sessionObj=optToken
+                      thirdPartySessionObj=googlePayThirdPartyOptToken
+                      walletOptions
+                      paymentType
                     />
-                  | _ => <GPayLazy sessionObj=optToken thirdPartySessionObj=None />
+                  | _ =>
+                    <GPayLazy
+                      sessionObj=optToken thirdPartySessionObj=None walletOptions paymentType
+                    />
                   }
                 | _ => React.null
                 }}
@@ -97,7 +103,8 @@ let make = (~sessions, ~walletOptions, ~paymentType) => {
               </SessionPaymentWrapper>
             | ApplePayWallet =>
               switch applePayToken {
-              | ApplePayTokenOptional(optToken) => <ApplePayLazy sessionObj=optToken />
+              | ApplePayTokenOptional(optToken) =>
+                <ApplePayLazy sessionObj=optToken walletOptions paymentType />
               | _ => React.null
               }
             | KlarnaWallet =>

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -580,20 +580,22 @@ let useRequiredFieldsBody = (
         | FullName => getName(item, fullName)
         | _ => item.field_type->getFieldValueFromFieldType
         }
-        if (
-          isSavedCardFlow &&
-          (item.field_type === BillingName || item.field_type === FullName) &&
-          item.display_name === "card_holder_name" &&
-          item.required_field === "payment_method_data.card.card_holder_name"
-        ) {
-          if !isAllStoredCardsHaveName {
-            acc->Dict.set(
-              "payment_method_data.card_token.card_holder_name",
-              value->JSON.Encode.string,
-            )
+        if value != "" {
+          if (
+            isSavedCardFlow &&
+            (item.field_type === BillingName || item.field_type === FullName) &&
+            item.display_name === "card_holder_name" &&
+            item.required_field === "payment_method_data.card.card_holder_name"
+          ) {
+            if !isAllStoredCardsHaveName {
+              acc->Dict.set(
+                "payment_method_data.card_token.card_holder_name",
+                value->JSON.Encode.string,
+              )
+            }
+          } else {
+            acc->Dict.set(item.required_field, value->JSON.Encode.string)
           }
-        } else {
-          acc->Dict.set(item.required_field, value->JSON.Encode.string)
         }
         acc
       })
@@ -820,22 +822,6 @@ let usePaymentMethodTypeFromList = (
       ),
     )->Option.getOr(PaymentMethodsRecord.defaultPaymentMethodType)
   }, (paymentMethodListValue, paymentMethod, paymentMethodType))
-}
-
-let useAreAllRequiredFieldsPrefilled = (
-  ~paymentMethodListValue,
-  ~paymentMethod,
-  ~paymentMethodType,
-) => {
-  let paymentMethodTypes = usePaymentMethodTypeFromList(
-    ~paymentMethodListValue,
-    ~paymentMethod,
-    ~paymentMethodType,
-  )
-
-  paymentMethodTypes.required_fields->Array.reduce(true, (acc, requiredField) => {
-    acc && requiredField.value != ""
-  })
 }
 
 let removeRequiredFieldsDuplicates = (

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -7,6 +7,10 @@ let paymentListLookupNew = (
   ~isShowKlarnaOneClick,
   ~isKlarnaSDKFlow,
   ~paymentMethodListValue: PaymentMethodsRecord.paymentMethodList,
+  ~areAllApplePayRequiredFieldsPrefilled,
+  ~areAllGooglePayRequiredFieldsPrefilled,
+  ~isApplePayReady,
+  ~isGooglePayReady,
 ) => {
   let pmList = list->PaymentMethodsRecord.buildFromPaymentList
   let walletsList = []
@@ -28,6 +32,22 @@ let paymentListLookupNew = (
     "mifinity",
   ]
   let otherPaymentList = []
+
+  if (
+    !paymentMethodListValue.collect_billing_details_from_wallets &&
+    !areAllApplePayRequiredFieldsPrefilled &&
+    isApplePayReady
+  ) {
+    walletToBeDisplayedInTabs->Array.push("apple_pay")
+  }
+
+  if (
+    !paymentMethodListValue.collect_billing_details_from_wallets &&
+    !areAllGooglePayRequiredFieldsPrefilled &&
+    isGooglePayReady
+  ) {
+    walletToBeDisplayedInTabs->Array.push("google_pay")
+  }
 
   pmList->Array.forEach(item => {
     if walletToBeDisplayedInTabs->Array.includes(item.paymentMethodName) {
@@ -303,6 +323,23 @@ let useGetPaymentMethodList = (~paymentOptions, ~paymentType, ~sessions) => {
 
   let isKlarnaSDKFlow = getIsKlarnaSDKFlow(sessions)
 
+  let paymentMethodListValue = Recoil.useRecoilValueFromAtom(paymentMethodListValue)
+
+  let areAllApplePayRequiredFieldsPrefilled = useAreAllRequiredFieldsPrefilled(
+    ~paymentMethodListValue,
+    ~paymentMethod="wallet",
+    ~paymentMethodType="apple_pay",
+  )
+
+  let areAllGooglePayRequiredFieldsPrefilled = useAreAllRequiredFieldsPrefilled(
+    ~paymentMethodListValue,
+    ~paymentMethod="wallet",
+    ~paymentMethodType="google_pay",
+  )
+
+  let isApplePayReady = Recoil.useRecoilValueFromAtom(RecoilAtoms.isApplePayReady)
+  let isGooglePayReady = Recoil.useRecoilValueFromAtom(RecoilAtoms.isGooglePayReady)
+
   React.useMemo(() => {
     switch methodslist {
     | Loaded(paymentlist) =>
@@ -316,6 +353,10 @@ let useGetPaymentMethodList = (~paymentOptions, ~paymentType, ~sessions) => {
           ~isShowKlarnaOneClick=optionAtomValue.wallets.klarna === Auto,
           ~isKlarnaSDKFlow,
           ~paymentMethodListValue=plist,
+          ~areAllApplePayRequiredFieldsPrefilled,
+          ~areAllGooglePayRequiredFieldsPrefilled,
+          ~isApplePayReady,
+          ~isGooglePayReady,
         )
 
       let klarnaPaymentMethodExperience = PaymentMethodsRecord.getPaymentExperienceTypeFromPML(
@@ -353,6 +394,10 @@ let useGetPaymentMethodList = (~paymentOptions, ~paymentType, ~sessions) => {
     optionAtomValue.wallets.klarna,
     paymentType,
     isKlarnaSDKFlow,
+    areAllApplePayRequiredFieldsPrefilled,
+    areAllGooglePayRequiredFieldsPrefilled,
+    isApplePayReady,
+    isGooglePayReady,
   ))
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added Support for `collecting_billing_details_from_wallets` to decide whether to collect billing details for wallets (ApplePay and GooglePay) from SDK or from the Wallet SDK.

## How did you test it?

case `collecting_billing_details_from_wallets` true:
1. ApplePay and GooglePay billing details should be collected from Wallet SDK and passed correctly in the confirm body

case `collecting_billing_details_from_wallets` false:
1. ApplePay and GooglePay billing details should be collected from SDK instead of the Wallet and passed correctly in the confirm body
2. If all details are prefilled, do not put ApplePay and GooglePay in the tabs
3. ApplePay should not be visible in Chrome
4. If you cancel ApplePay or GooglePay error message should be sent to the merchant

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
