### PR TITLE
refactor(payout): remove error code and error message from status page

### DIFF
--- a/src/PaymentMethodCollectElement.res
+++ b/src/PaymentMethodCollectElement.res
@@ -214,25 +214,6 @@ let make = (~integrateError, ~logger) => {
       {key: localeString.infoCardRefId, value: options.payoutId},
     ]
 
-    statusInfo.code
-    ->Option.flatMap(code => {
-      statusInfoFields->Array.push({key: localeString.infoCardErrCode, value: code})
-      None
-    })
-    ->ignore
-    statusInfo.errorMessage
-    ->Option.flatMap(errorMessage => {
-      statusInfoFields->Array.push({key: localeString.infoCardErrMsg, value: errorMessage})
-      None
-    })
-    ->ignore
-    statusInfo.reason
-    ->Option.flatMap(reason => {
-      statusInfoFields->Array.push({key: localeString.infoCardErrReason, value: reason})
-      None
-    })
-    ->ignore
-
     <div
       style={
         color: themeObj.colorText,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR removes error code and message from the status UI for payout widget. This is being done as a part of localisation for now. Once localisation support is added in our APIs, this change will be reverted (or not, let's see).

## How did you test it?
Locally.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
