### PR TITLE
fix: fixed structure of billing details in payment body

### DIFF
--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -479,7 +479,7 @@ let paymentMethodsFields = [
     miniIcon: None,
   },
   {
-    paymentMethodName: "multibanco",
+    paymentMethodName: "multibanco_transfer",
     icon: Some(icon("multibanco", ~size=19)),
     displayName: "Multibanco",
     fields: [Email, InfoElement],

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -42,12 +42,12 @@ let isBillingAddressFieldType = (fieldType: PaymentMethodsRecord.paymentMethodsF
 
 let getBillingAddressPathFromFieldType = (fieldType: PaymentMethodsRecord.paymentMethodsFields) => {
   switch fieldType {
-  | AddressLine1 => "billing.address.line1"
-  | AddressLine2 => "billing.address.line2"
-  | AddressCity => "billing.address.city"
-  | AddressState => "billing.address.state"
-  | AddressCountry(_) => "billing.address.country"
-  | AddressPincode => "billing.address.zip"
+  | AddressLine1 => "payment_method_data.billing.address.line1"
+  | AddressLine2 => "payment_method_data.billing.address.line2"
+  | AddressCity => "payment_method_data.billing.address.city"
+  | AddressState => "payment_method_data.billing.address.state"
+  | AddressCountry(_) => "payment_method_data.billing.address.country"
+  | AddressPincode => "payment_method_data.billing.address.zip"
   | _ => ""
   }
 }
@@ -552,11 +552,11 @@ let useRequiredFieldsBody = (
         if item === BillingName {
           let arr = value->String.split(" ")
           acc->Dict.set(
-            "billing.address.first_name",
+            "payment_method_data.billing.address.first_name",
             arr->Array.get(0)->Option.getOr("")->JSON.Encode.string,
           )
           acc->Dict.set(
-            "billing.address.last_name",
+            "payment_method_data.billing.address.last_name",
             arr->Array.get(1)->Option.getOr("")->JSON.Encode.string,
           )
         } else {

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1355,3 +1355,16 @@ let checkIs18OrAbove = dateOfBirth => {
   let compareDate = Date.makeWithYMD(~year, ~month, ~date)
   dateOfBirth <= compareDate
 }
+
+let getFirstAndLastNameFromFullName = fullName => {
+  let nameStrings = fullName->String.split(" ")
+  let firstName =
+    nameStrings
+    ->Array.get(0)
+    ->Option.flatMap(x => Some(x->JSON.Encode.string))
+    ->Option.getOr(JSON.Encode.null)
+  let lastNameStr = nameStrings->Array.sliceToEnd(~start=1)->Array.joinWith(" ")->String.trim
+  let lastNameJson = lastNameStr === "" ? JSON.Encode.null : lastNameStr->JSON.Encode.string
+
+  (firstName, lastNameJson)
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed structure of billing details in payment body based on backend requirement [https://github.com/juspay/hyperswitch-cloud/issues/4144](https://github.com/juspay/hyperswitch-cloud/issues/4144)

## How did you test it?

Tested the  confirm payload for the following payment methods -

1. ach_bank_debit
2. sepa_bank_debit
3. bacs_bank_debit
4. becs_bank_debit
5. ach_bank_transfer
6. bacs_bank_transfer
7. sepa_bank_transfer
8. przelewy24
9. multibanco_bank_transfer

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
