### PR TITLE
feat: dockerize the hyperswitch-web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-alpine
+
+# Set the working directory
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json to install dependencies
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install --ignore-scripts
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the rescript code
+RUN npm run re:build
+
+# Build the application
+RUN npm run build
+
+# Expose the port that the Webpack dev server will run on
+EXPOSE 9050
+
+# Start the Webpack dev server
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Dockerize the hyperswitch-web which will serve the HyperLoader.js at 9050 port.

## How did you test it?

via running these commands.

1.  docker build -t hyperswitch-web .
2. docker run -p 9050:9050 hyperswitch-web
3. hit the url - http://localhost:9050/HyperLoader.js (the url will be accessible)


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
