### PR TITLE
refactor: sdk pay now always enabled

### DIFF
--- a/.github/workflows/pr-title-spell-check.yml
+++ b/.github/workflows/pr-title-spell-check.yml
@@ -26,3 +26,15 @@ jobs:
         uses: crate-ci/typos@master
         with:
           files: ./pr_title.txt
+
+      - name: Assign to author
+        run: |
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/assignees \
+          -d '{"assignees":["${{ github.event.pull_request.user.login }}"]}'

--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -16,6 +16,7 @@ let make = () => {
   let (showLoader, setShowLoader) = React.useState(() => false)
   let {themeObj, localeString} = configAtom->Recoil.useRecoilValueFromAtom
   let {sdkHandleConfirmPayment} = optionAtom->Recoil.useRecoilValueFromAtom
+  let (isPayNowButtonDisable, setIsPayNowButtonDisable) = payNowButtonDisable->Recoil.useRecoilState
 
   let confirmPayload = sdkHandleConfirmPayment->PaymentBody.confirmPayloadForSDKButton
   let buttonText = sdkHandleConfirmPayment.buttonText->Option.getOr(localeString.payNowButton)
@@ -27,6 +28,7 @@ let make = () => {
     switch dict->Dict.get("submitSuccessful") {
     | Some(submitSuccessfulVal) =>
       if !(submitSuccessfulVal->JSON.Decode.bool->Option.getOr(false)) {
+        setIsPayNowButtonDisable(_ => false)
         setShowLoader(_ => false)
       }
     | None => ()
@@ -34,6 +36,7 @@ let make = () => {
   }
 
   let handleOnClick = _ => {
+    setIsPayNowButtonDisable(_ => true)
     setShowLoader(_ => true)
     EventListenerManager.addSmartEventListener("message", handleMessage, "onSubmitSuccessful")
     handlePostMessage([("handleSdkConfirm", confirmPayload)])
@@ -41,14 +44,15 @@ let make = () => {
 
   <div className="flex flex-col gap-1 h-auto w-full items-center">
     <button
+      disabled=isPayNowButtonDisable
       onClick=handleOnClick
       className={`w-full flex flex-row justify-center items-center`}
       style={
         borderRadius: themeObj.buttonBorderRadius,
         backgroundColor: themeObj.buttonBackgroundColor,
         height: themeObj.buttonHeight,
-        cursor: "pointer",
-        opacity: "1",
+        cursor: {isPayNowButtonDisable ? "not-allowed" : "pointer"},
+        opacity: {isPayNowButtonDisable ? "0.6" : "1"},
         width: themeObj.buttonWidth,
         border: `${themeObj.buttonBorderWidth} solid ${themeObj.buttonBorderColor}`,
       }>

--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -16,15 +16,10 @@ let make = () => {
   let (showLoader, setShowLoader) = React.useState(() => false)
   let {themeObj, localeString} = configAtom->Recoil.useRecoilValueFromAtom
   let {sdkHandleConfirmPayment} = optionAtom->Recoil.useRecoilValueFromAtom
-  let (isPayNowButtonDisable, setIsPayNowButtonDisable) = payNowButtonDisable->Recoil.useRecoilState
 
   let confirmPayload = sdkHandleConfirmPayment->PaymentBody.confirmPayloadForSDKButton
   let buttonText = sdkHandleConfirmPayment.buttonText->Option.getOr(localeString.payNowButton)
 
-  React.useEffect1(() => {
-    setIsPayNowButtonDisable(_ => !sdkHandleConfirmPayment.allowButtonBeforeValidation)
-    None
-  }, [sdkHandleConfirmPayment.allowButtonBeforeValidation])
 
   let handleMessage = (event: Types.event) => {
     let json = event.data->Identity.anyTypeToJson->getStringFromJson("")->safeParse
@@ -32,7 +27,6 @@ let make = () => {
     switch dict->Dict.get("submitSuccessful") {
     | Some(submitSuccessfulVal) =>
       if !(submitSuccessfulVal->JSON.Decode.bool->Option.getOr(false)) {
-        setIsPayNowButtonDisable(_ => false)
         setShowLoader(_ => false)
       }
     | None => ()
@@ -40,7 +34,6 @@ let make = () => {
   }
 
   let handleOnClick = _ => {
-    setIsPayNowButtonDisable(_ => true)
     setShowLoader(_ => true)
     EventListenerManager.addSmartEventListener("message", handleMessage, "onSubmitSuccessful")
     handlePostMessage([("handleSdkConfirm", confirmPayload)])
@@ -48,15 +41,14 @@ let make = () => {
 
   <div className="flex flex-col gap-1 h-auto w-full items-center">
     <button
-      disabled=isPayNowButtonDisable
       onClick=handleOnClick
       className={`w-full flex flex-row justify-center items-center`}
       style={
         borderRadius: themeObj.buttonBorderRadius,
         backgroundColor: themeObj.buttonBackgroundColor,
         height: themeObj.buttonHeight,
-        cursor: {isPayNowButtonDisable ? "not-allowed" : "pointer"},
-        opacity: {isPayNowButtonDisable ? "0.6" : "1"},
+        cursor: "pointer",
+        opacity: "1",
         width: themeObj.buttonWidth,
         border: `${themeObj.buttonBorderWidth} solid ${themeObj.buttonBorderColor}`,
       }>

--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -14,9 +14,9 @@ let make = () => {
   open RecoilAtoms
   open Utils
   let (showLoader, setShowLoader) = React.useState(() => false)
+  let (isPayNowButtonDisable, setIsPayNowButtonDisable) = React.useState(() => false)
   let {themeObj, localeString} = configAtom->Recoil.useRecoilValueFromAtom
   let {sdkHandleConfirmPayment} = optionAtom->Recoil.useRecoilValueFromAtom
-  let (isPayNowButtonDisable, setIsPayNowButtonDisable) = payNowButtonDisable->Recoil.useRecoilState
 
   let confirmPayload = sdkHandleConfirmPayment->PaymentBody.confirmPayloadForSDKButton
   let buttonText = sdkHandleConfirmPayment.buttonText->Option.getOr(localeString.payNowButton)

--- a/src/Hooks/UtilityHooks.res
+++ b/src/Hooks/UtilityHooks.res
@@ -14,14 +14,8 @@ let useHandlePostMessages = (~complete, ~empty, ~paymentType, ~savedMethod=false
   open RecoilAtoms
 
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
-  let setIsPayNowButtonDisable = Recoil.useSetRecoilState(payNowButtonDisable)
-  let {sdkHandleConfirmPayment} = Recoil.useRecoilValueFromAtom(optionAtom)
 
   React.useEffect(() => {
-    if !sdkHandleConfirmPayment.allowButtonBeforeValidation {
-      let isCompletelyFilled = complete && paymentType !== ""
-      setIsPayNowButtonDisable(_ => !isCompletelyFilled)
-    }
     Utils.handlePostMessageEvents(~complete, ~empty, ~paymentType, ~loggerState, ~savedMethod)
     None
   }, (complete, empty, paymentType))

--- a/src/TabCard.res
+++ b/src/TabCard.res
@@ -4,8 +4,6 @@ let make = (~paymentOption: PaymentMethodsRecord.paymentFieldsInfo, ~isActive: b
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {readOnly, customMethodNames} = Recoil.useRecoilValueFromAtom(optionAtom)
   let setSelectedOption = Recoil.useSetRecoilState(selectedOptionAtom)
-  let {sdkHandleConfirmPayment} = optionAtom->Recoil.useRecoilValueFromAtom
-  let setIsPayNowButtonDisable = Recoil.useSetRecoilState(payNowButtonDisable)
   let (tabClass, tabLabelClass, tabIconClass) = React.useMemo(
     () => isActive ? ("Tab--selected", "TabLabel--selected", "TabIcon--selected") : ("", "", ""),
     [isActive],
@@ -17,7 +15,6 @@ let make = (~paymentOption: PaymentMethodsRecord.paymentFieldsInfo, ~isActive: b
     paymentOption.icon,
   )
   let onClick = _ => {
-    setIsPayNowButtonDisable(_ => !sdkHandleConfirmPayment.allowButtonBeforeValidation)
     setSelectedOption(_ => paymentOption.paymentMethodName)
   }
   <button

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -146,7 +146,6 @@ type sdkHandleConfirmPayment = {
   handleConfirm: bool,
   buttonText?: string,
   confirmParams: ConfirmType.confirmParams,
-  allowButtonBeforeValidation: bool,
 }
 
 type options = {
@@ -287,7 +286,6 @@ let defaultBillingAddress = {
 let defaultSdkHandleConfirmPayment = {
   handleConfirm: false,
   confirmParams: ConfirmType.defaultConfirm,
-  allowButtonBeforeValidation: false,
 }
 
 let defaultOptions = {
@@ -985,7 +983,6 @@ let getSdkHandleConfirmPaymentProps = dict => {
   handleConfirm: dict->getBool("handleConfirm", false),
   buttonText: ?dict->getOptionString("buttonText"),
   confirmParams: dict->getDictFromDict("confirmParams")->getConfirmParams,
-  allowButtonBeforeValidation: dict->getBool("allowButtonBeforeValidation", false),
 }
 
 let itemToObjMapper = (dict, logger) => {

--- a/src/Utilities/RecoilAtoms.res
+++ b/src/Utilities/RecoilAtoms.res
@@ -22,6 +22,7 @@ let paymentTokenAtom = Recoil.atom(
 let showCardFieldsAtom = Recoil.atom("showCardFields", false)
 let phoneJson = Recoil.atom("phoneJson", Loading)
 let cardBrand = Recoil.atom("cardBrand", "")
+let payNowButtonDisable = Recoil.atom("payNowButtonDisable", false)
 let paymentMethodCollectOptionAtom = Recoil.atom(
   "paymentMethodCollectOptions",
   PaymentMethodCollectUtils.defaultPaymentMethodCollectOptions,

--- a/src/Utilities/RecoilAtoms.res
+++ b/src/Utilities/RecoilAtoms.res
@@ -22,7 +22,6 @@ let paymentTokenAtom = Recoil.atom(
 let showCardFieldsAtom = Recoil.atom("showCardFields", false)
 let phoneJson = Recoil.atom("phoneJson", Loading)
 let cardBrand = Recoil.atom("cardBrand", "")
-let payNowButtonDisable = Recoil.atom("payNowButtonDisable", true)
 let paymentMethodCollectOptionAtom = Recoil.atom(
   "paymentMethodCollectOptions",
   PaymentMethodCollectUtils.defaultPaymentMethodCollectOptions,

--- a/src/Utilities/RecoilAtoms.res
+++ b/src/Utilities/RecoilAtoms.res
@@ -22,7 +22,6 @@ let paymentTokenAtom = Recoil.atom(
 let showCardFieldsAtom = Recoil.atom("showCardFields", false)
 let phoneJson = Recoil.atom("phoneJson", Loading)
 let cardBrand = Recoil.atom("cardBrand", "")
-let payNowButtonDisable = Recoil.atom("payNowButtonDisable", false)
 let paymentMethodCollectOptionAtom = Recoil.atom(
   "paymentMethodCollectOptions",
   PaymentMethodCollectUtils.defaultPaymentMethodCollectOptions,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

SDK pay now button will always remain enabled.

## How did you test it?

rendering the SDK and checking whether SDK pay now button is enabled for all payment methods or not.

## Checklist

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
