### PR TITLE
fix: google pay button border

### DIFF
--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -221,7 +221,7 @@ let make = (
       <div
         style={height: `${height->Int.toString}px`}
         id="google-pay-button"
-        className={`w-full flex flex-row justify-center rounded-md border-2 border-white`}
+        className={`w-full flex flex-row justify-center rounded-md`}
       />
     </RenderIf>
   } else {

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -221,7 +221,7 @@ let make = (
       <div
         style={height: `${height->Int.toString}px`}
         id="google-pay-button"
-        className={`w-full flex flex-row justify-center rounded-md`}
+        className={`w-full flex flex-row justify-center rounded-md border-2 border-white`}
       />
     </RenderIf>
   } else {

--- a/src/RenderPaymentMethods.res
+++ b/src/RenderPaymentMethods.res
@@ -60,6 +60,7 @@ let make = (
       background: "transparent",
       marginLeft: "4px",
       marginRight: "4px",
+      marginTop: "4px",
       fontFamily: themeObj.fontFamily,
       fontSize: themeObj.fontSizeBase,
       filter: blur,


### PR DESCRIPTION
## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

fixed the top border of google pay button
Before:-
<img width="502" alt="image" src="https://github.com/user-attachments/assets/a8002de7-8e05-41be-840d-803852962cc1">
After:-
<img width="495" alt="image" src="https://github.com/user-attachments/assets/69940602-67cc-4103-9648-3f4d025c2d85">


## How did you test it?

by rendering the sdk and checking the UI of google pay button

## Checklist

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
