### PR TITLE
chore: rename handlePostMessage to messageParentWindow

### DIFF
--- a/rescript.json
+++ b/rescript.json
@@ -14,7 +14,7 @@
   "namespace": true,
   "ppx-flags": [],
   "package-specs": {
-    "module": "es6",
+    "module": "esmodule",
     "in-source": true
   },
   "bs-dependencies": [

--- a/src/Components/AddBankAccount.res
+++ b/src/Components/AddBankAccount.res
@@ -36,7 +36,7 @@ let make = (~modalData, ~setModalData) => {
   let toolTipRef = React.useRef(Nullable.null)
 
   let openModal = () => {
-    handlePostMessage([
+    messageParentWindow([
       ("fullscreen", true->JSON.Encode.bool),
       ("iframeId", iframeId->JSON.Encode.string),
     ])

--- a/src/Components/AddressPaymentInput.res
+++ b/src/Components/AddressPaymentInput.res
@@ -7,7 +7,7 @@ type addressType = Line1 | Line2 | City | Postal | State | Country
 type dataModule = {states: JSON.t}
 
 @val
-external importStates: string => Promise.t<dataModule> = "import"
+external importStates: string => promise<dataModule> = "import"
 
 let getShowType = str => {
   switch str {

--- a/src/Components/FullScreenDivDriver.res
+++ b/src/Components/FullScreenDivDriver.res
@@ -1,7 +1,7 @@
 @react.component
 let make = () => {
   React.useEffect0(() => {
-    Utils.handlePostMessage([("driverMounted", true->JSON.Encode.bool)])
+    Utils.messageParentWindow([("driverMounted", true->JSON.Encode.bool)])
     None
   })
   <div />

--- a/src/Components/InputField.res
+++ b/src/Components/InputField.res
@@ -109,7 +109,7 @@ let make = (
   let concatString = Array.joinWith([cardEmpty, cardComplete, cardInvalid, cardFocused], "")
 
   React.useEffect(() => {
-    Utils.handlePostMessage([
+    Utils.messageParentWindow([
       ("id", iframeId->JSON.Encode.string),
       ("concatedString", concatString->JSON.Encode.string),
     ])

--- a/src/Components/Modal.res
+++ b/src/Components/Modal.res
@@ -1,7 +1,7 @@
 let close = setOpenModal => {
   setOpenModal(_ => false)
   setTimeout(() => {
-    Utils.handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+    Utils.messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
   }, 450)->ignore
 }
 
@@ -21,7 +21,7 @@ let make = (
     switch closeCallback {
     | Some(fn) => fn()
     | None => setTimeout(() => {
-        Utils.handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+        Utils.messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
       }, 450)->ignore
     }
   }

--- a/src/Components/PayNowButton.res
+++ b/src/Components/PayNowButton.res
@@ -39,7 +39,7 @@ let make = () => {
     setIsPayNowButtonDisable(_ => true)
     setShowLoader(_ => true)
     EventListenerManager.addSmartEventListener("message", handleMessage, "onSubmitSuccessful")
-    handlePostMessage([("handleSdkConfirm", confirmPayload)])
+    messageParentWindow([("handleSdkConfirm", confirmPayload)])
   }
 
   <div className="flex flex-col gap-1 h-auto w-full items-center">

--- a/src/Components/PaymentLoader.res
+++ b/src/Components/PaymentLoader.res
@@ -4,7 +4,7 @@ let make = () => {
   let (branding, setBranding) = React.useState(_ => "auto")
 
   React.useEffect0(() => {
-    handlePostMessage([("iframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->getDictFromJson

--- a/src/Components/SavedPaymentManagement.res
+++ b/src/Components/SavedPaymentManagement.res
@@ -18,7 +18,7 @@ let make = (~savedMethods: array<PaymentType.customerMethods>, ~setSavedMethods)
   }
 
   let handleDelete = (paymentItem: PaymentType.customerMethods) => {
-    handlePostMessage([
+    messageParentWindow([
       ("fullscreen", true->JSON.Encode.bool),
       ("param", "paymentloader"->JSON.Encode.string),
       ("iframeId", iframeId->JSON.Encode.string),
@@ -44,7 +44,7 @@ let make = (~savedMethods: array<PaymentType.customerMethods>, ~setSavedMethods)
       } else {
         logger.setLogError(~value=res->JSON.stringify, ~eventName=DELETE_SAVED_PAYMENT_METHOD)
       }
-      handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+      messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
       resolve()
     })
     ->catch(err => {
@@ -53,7 +53,7 @@ let make = (~savedMethods: array<PaymentType.customerMethods>, ~setSavedMethods)
         ~value=`Error Deleting Saved Payment Method: ${exceptionMessage}`,
         ~eventName=DELETE_SAVED_PAYMENT_METHOD,
       )
-      handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+      messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
       resolve()
     })
     ->ignore

--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -24,7 +24,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
   let {config} = configAtom
   let {iframeId} = keys
 
-  let handlePostMessage = data => handlePostMessage(data, ~targetOrigin=keys.parentURL)
+  let messageParentWindow = data => messageParentWindow(data, ~targetOrigin=keys.parentURL)
 
   let setUserFullName = Recoil.useLoggedSetRecoilState(userFullName, "fullName", logger)
   let setUserEmail = Recoil.useLoggedSetRecoilState(userEmailAddress, "email", logger)
@@ -141,8 +141,8 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
   }
 
   React.useEffect0(() => {
-    handlePostMessage([("iframeMounted", true->JSON.Encode.bool)])
-    handlePostMessage([("applePayMounted", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMounted", true->JSON.Encode.bool)])
+    messageParentWindow([("applePayMounted", true->JSON.Encode.bool)])
     logger.setLogInitiated()
     let updatedState: PaymentType.loadType = switch paymentMethodList {
     | Loading =>
@@ -553,7 +553,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
 
   React.useEffect(() => {
     let iframeHeight = divH->Float.equal(0.0) ? divH : divH +. 1.0
-    handlePostMessage([
+    messageParentWindow([
       ("iframeHeight", iframeHeight->JSON.Encode.float),
       ("iframeId", iframeId->JSON.Encode.string),
     ])

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -369,7 +369,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     let evalMethodsList = () =>
       switch paymentMethodList {
       | SemiLoaded | LoadError(_) | Loaded(_) =>
-        handlePostMessage([("ready", true->JSON.Encode.bool)])
+        messageParentWindow([("ready", true->JSON.Encode.bool)])
       | _ => ()
       }
     if !displaySavedPaymentMethods {
@@ -379,7 +379,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
       | LoadingSavedCards => ()
       | LoadedSavedCards(list, _) =>
         list->Array.length > 0
-          ? handlePostMessage([("ready", true->JSON.Encode.bool)])
+          ? messageParentWindow([("ready", true->JSON.Encode.bool)])
           : evalMethodsList()
       | NoResult(_) => evalMethodsList()
       }

--- a/src/Payments/AddBankDetails.res
+++ b/src/Payments/AddBankDetails.res
@@ -45,7 +45,7 @@ let make = (~paymentMethodType) => {
             ~optLogger=Some(logger),
           )
           ->then(_ => {
-            handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+            messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
             setShowFields(_ => false)
             JSON.Encode.null->resolve
           })

--- a/src/Payments/BankTransfersPopup.res
+++ b/src/Payments/BankTransfersPopup.res
@@ -44,11 +44,14 @@ let make = (~transferType) => {
       keys
       ->Array.map(item => `${item->snakeToTitleCase} : ${getKeyValue(json, item)}`)
       ->Array.joinWith(`\n`)
-    handlePostMessage([("copy", true->JSON.Encode.bool), ("copyDetails", text->JSON.Encode.string)])
+    messageParentWindow([
+      ("copy", true->JSON.Encode.bool),
+      ("copyDetails", text->JSON.Encode.string),
+    ])
     setIsCopied(_ => true)
   }
   React.useEffect0(() => {
-    handlePostMessage([("iframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->Utils.getDictFromJson

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -108,7 +108,7 @@ let make = (
       if result {
         if isInvokeSDKFlow {
           if isDelayedSessionToken {
-            handlePostMessage([
+            messageParentWindow([
               ("fullscreen", true->JSON.Encode.bool),
               ("param", "paymentloader"->JSON.Encode.string),
               ("iframeId", iframeId->JSON.Encode.string),

--- a/src/Payments/KlarnaSDK.res
+++ b/src/Payments/KlarnaSDK.res
@@ -30,7 +30,7 @@ let make = (~sessionObj: SessionsType.token) => {
   }
 
   let handleCloseLoader = () => {
-    Utils.handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+    Utils.messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
   }
 
   let paymentMethodTypes = DynamicFieldsUtils.usePaymentMethodTypeFromList(
@@ -69,7 +69,7 @@ let make = (~sessionObj: SessionsType.token) => {
               result => {
                 let result = result->JSON.Decode.bool->Option.getOr(false)
                 if result {
-                  Utils.handlePostMessage([
+                  Utils.messageParentWindow([
                     ("fullscreen", true->JSON.Encode.bool),
                     ("param", "paymentloader"->JSON.Encode.string),
                     ("iframeId", iframeId->JSON.Encode.string),

--- a/src/Payments/KlarnaSDKTypes.res
+++ b/src/Payments/KlarnaSDKTypes.res
@@ -37,7 +37,7 @@ type loadType = {
   payment_method_category?: string,
   theme?: string,
   shape?: string,
-  on_click?: authorize => Promise.t<unit>,
+  on_click?: authorize => promise<unit>,
 }
 type some = {
   init: token => unit,

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -42,7 +42,7 @@ let make = (~sessionObj: SessionsType.token, ~paymentType: CardThemeType.mode) =
     | _ => 48
     },
   }
-  let handleCloseLoader = () => Utils.handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+  let handleCloseLoader = () => Utils.messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
   let isGuestCustomer = UtilityHooks.useIsGuestCustomer()
 
   let paymentMethodTypes = DynamicFieldsUtils.usePaymentMethodTypeFromList(

--- a/src/Payments/PaypalSDKHelpers.res
+++ b/src/Payments/PaypalSDKHelpers.res
@@ -37,7 +37,7 @@ let loadPaypalSDK = (
         style: buttonStyle,
         fundingSource: paypal["FUNDING"]["PAYPAL"],
         createOrder: () => {
-          Utils.handlePostMessage([
+          Utils.messageParentWindow([
             ("fullscreen", true->JSON.Encode.bool),
             ("param", "paymentloader"->JSON.Encode.string),
             ("iframeId", iframeId->JSON.Encode.string),
@@ -169,7 +169,7 @@ let loadBraintreePaypalSdk = (
                   fundingSource: paypal["FUNDING"]["PAYPAL"],
                   createBillingAgreement: () => {
                     //Paypal Clicked
-                    Utils.handlePostMessage([
+                    Utils.messageParentWindow([
                       ("fullscreen", true->JSON.Encode.bool),
                       ("param", "paymentloader"->JSON.Encode.string),
                       ("iframeId", iframeId->JSON.Encode.string),

--- a/src/Payments/PlaidSDKIframe.res
+++ b/src/Payments/PlaidSDKIframe.res
@@ -31,7 +31,7 @@ let make = () => {
       }
     }
     Window.addEventListener("message", handle)
-    handlePostMessage([("iframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     Some(() => {Window.removeEventListener("message", handle)})
   })
 
@@ -80,7 +80,7 @@ let make = () => {
           ~message="Payment is processing. Try again later!",
         )
       }
-      handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+      messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
       resolve(json)
     })
     ->then(_ => {
@@ -101,7 +101,7 @@ let make = () => {
           logger.setLogInfo(~value="Plaid SDK Loaded", ~eventName=PLAID_SDK)
         },
         onSuccess: (publicToken, _) => {
-          handlePostMessage([
+          messageParentWindow([
             ("isPlaid", true->JSON.Encode.bool),
             ("publicToken", publicToken->JSON.Encode.string),
           ])
@@ -113,7 +113,7 @@ let make = () => {
           if isForceSync {
             callbackOnSuccessOfPlaidPaymentsFlow()
           } else {
-            handlePostMessage([
+            messageParentWindow([
               ("fullscreen", false->JSON.Encode.bool),
               ("isPlaid", true->JSON.Encode.bool),
               ("isExited", true->JSON.Encode.bool),

--- a/src/Payments/PreMountLoader.res
+++ b/src/Payments/PreMountLoader.res
@@ -91,7 +91,7 @@ let make = (
     open Promise
     promise
     ->then(res => {
-      handlePostMessage([("response", res), ("data", key->JSON.Encode.string)])
+      messageParentWindow([("response", res), ("data", key->JSON.Encode.string)])
       switch key {
       | "payment_methods" => setPaymentMethodsResponseSent(_ => true)
       | "session_tokens" => setSessionTokensResponseSent(_ => true)
@@ -102,7 +102,7 @@ let make = (
       resolve()
     })
     ->catch(_err => {
-      handlePostMessage([("response", JSON.Encode.null), ("data", key->JSON.Encode.string)])
+      messageParentWindow([("response", JSON.Encode.null), ("data", key->JSON.Encode.string)])
       resolve()
     })
     ->ignore
@@ -124,7 +124,7 @@ let make = (
 
   React.useEffect0(() => {
     Window.addEventListener("message", handle)
-    handlePostMessage([("preMountLoaderIframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("preMountLoaderIframeMountedCallback", true->JSON.Encode.bool)])
     Some(
       () => {
         Window.removeEventListener("message", handle)
@@ -134,7 +134,7 @@ let make = (
 
   React.useEffect4(() => {
     let handleUnmount = () => {
-      handlePostMessage([("preMountLoaderIframeUnMount", true->JSON.Encode.bool)])
+      messageParentWindow([("preMountLoaderIframeUnMount", true->JSON.Encode.bool)])
       Window.removeEventListener("message", handle)
     }
 

--- a/src/Payments/QRCodeDisplay.res
+++ b/src/Payments/QRCodeDisplay.res
@@ -19,7 +19,7 @@ let make = () => {
   let switchToCustomPod = Recoil.useRecoilValueFromAtom(RecoilAtoms.switchToCustomPod)
 
   React.useEffect0(() => {
-    handlePostMessage([("iframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->Utils.getDictFromJson

--- a/src/Payments/VoucherDisplay.res
+++ b/src/Payments/VoucherDisplay.res
@@ -21,7 +21,7 @@ let make = () => {
   }, [loader])
 
   React.useEffect0(() => {
-    handlePostMessage([("iframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->Utils.getDictFromJson

--- a/src/SingleLineCardPayment.res
+++ b/src/SingleLineCardPayment.res
@@ -106,7 +106,7 @@ let make = (
   let concatString = Array.joinWith([cardEmpty, cardComplete, cardInvalid, cardFocused], "")
 
   React.useEffect(() => {
-    Utils.handlePostMessage([
+    Utils.messageParentWindow([
       ("id", iframeId->JSON.Encode.string),
       ("concatedString", concatString->JSON.Encode.string),
     ])

--- a/src/ThreeDSAuth.res
+++ b/src/ThreeDSAuth.res
@@ -22,7 +22,7 @@ let make = () => {
   }
 
   React.useEffect0(() => {
-    handlePostMessage([("iframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->getDictFromJson
@@ -64,7 +64,7 @@ let make = () => {
           let dict = json->getDictFromJson
           if dict->Dict.get("error")->Option.isSome {
             let errorObj = PaymentError.itemToObjMapper(dict)
-            handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+            messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
             postFailedSubmitResponse(
               ~errortype=errorObj.error.type_,
               ~message=errorObj.error.message,

--- a/src/ThreeDSMethod.res
+++ b/src/ThreeDSMethod.res
@@ -19,7 +19,7 @@ let make = () => {
         ~value="Y",
         ~paymentMethod="CARD",
       )
-      handlePostMessage([
+      messageParentWindow([
         ("fullscreen", true->JSON.Encode.bool),
         ("param", `3dsAuth`->JSON.Encode.string),
         ("iframeId", iframeId->JSON.Encode.string),
@@ -54,7 +54,7 @@ let make = () => {
   }
 
   React.useEffect0(() => {
-    handlePostMessage([("iframeMountedCallback", true->JSON.Encode.bool)])
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->Utils.getDictFromJson
@@ -97,7 +97,7 @@ let make = () => {
             ~logType=ERROR,
           )
           metadata->Utils.getDictFromJson->Dict.set("3dsMethodComp", "N"->JSON.Encode.string)
-          handlePostMessage([
+          messageParentWindow([
             ("fullscreen", true->JSON.Encode.bool),
             ("param", `3dsAuth`->JSON.Encode.string),
             ("iframeId", iframeId->JSON.Encode.string),

--- a/src/Types/GooglePayType.res
+++ b/src/Types/GooglePayType.res
@@ -26,9 +26,9 @@ type document
 @val external document: document = "document"
 @send external getElementById: (document, string) => element = "getElementById"
 type client = {
-  isReadyToPay: JSON.t => Promise.t<JSON.t>,
+  isReadyToPay: JSON.t => promise<JSON.t>,
   createButton: JSON.t => Dom.element,
-  loadPaymentData: JSON.t => Promise.t<Fetch.Response.t>,
+  loadPaymentData: JSON.t => promise<Fetch.Response.t>,
 }
 @new external google: JSON.t => client = "google.payments.api.PaymentsClient"
 let getLabel = (var: PaymentType.googlePayStyleType) => {

--- a/src/Types/PaypalSDKTypes.res
+++ b/src/Types/PaypalSDKTypes.res
@@ -2,7 +2,7 @@ type clientErr = bool
 type clientInstance
 type paypalCheckoutErr = {message: string}
 type data
-type order = {get: unit => RescriptCore.Promise.t<JSON.t>}
+type order = {get: unit => promise<JSON.t>}
 type actions = {order: order}
 type err
 type vault = {vault: bool}
@@ -75,7 +75,7 @@ type buttons = {
   style: style,
   fundingSource: string,
   createBillingAgreement?: unit => unit,
-  createOrder?: unit => RescriptCore.Promise.t<string>,
+  createOrder?: unit => promise<string>,
   onApprove: (data, actions) => unit,
   onCancel: data => unit,
   onError?: err => unit,

--- a/src/Types/PostalCodeType.res
+++ b/src/Types/PostalCodeType.res
@@ -12,4 +12,4 @@ let defaultPostalCode = {
 type themeDataModule = {default: array<postalCodes>}
 
 @val
-external importPostalCode: string => Promise.t<themeDataModule> = "import"
+external importPostalCode: string => promise<themeDataModule> = "import"

--- a/src/Types/ThemeImporter.res
+++ b/src/Types/ThemeImporter.res
@@ -4,4 +4,4 @@ type themeDataModule = {
 }
 
 @val
-external importTheme: string => Promise.t<themeDataModule> = "import"
+external importTheme: string => promise<themeDataModule> = "import"

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -217,7 +217,7 @@ let useHandleApplePayResponse = (
     Window.addEventListener("message", handleApplePayMessages)
     Some(
       () => {
-        handlePostMessage([("applePaySessionAbort", true->JSON.Encode.bool)])
+        messageParentWindow([("applePaySessionAbort", true->JSON.Encode.bool)])
         Window.removeEventListener("message", handleApplePayMessages)
       },
     )
@@ -237,7 +237,7 @@ let handleApplePayButtonClicked = (~sessionObj, ~componentName) => {
     ("applePayButtonClicked", true->JSON.Encode.bool),
     ("applePayPaymentRequest", paymentRequest),
   ]
-  handlePostMessage(message)
+  messageParentWindow(message)
 }
 
 let useSubmitCallback = (~isWallet, ~sessionObj, ~componentName) => {

--- a/src/Utilities/GooglePayHelpers.res
+++ b/src/Utilities/GooglePayHelpers.res
@@ -140,7 +140,7 @@ let useHandleGooglePayResponse = (
         )
       }
       if dict->Dict.get("gpayError")->Option.isSome {
-        handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+        messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
         if isSavedMethodsFlow || !isWallet {
           postFailedSubmitResponse(~errortype="server_error", ~message="Something went wrong")
         }
@@ -153,13 +153,13 @@ let useHandleGooglePayResponse = (
 
 let handleGooglePayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly) => {
   let paymentDataRequest = GooglePayType.getPaymentDataFromSession(~sessionObj, ~componentName)
-  handlePostMessage([
+  messageParentWindow([
     ("fullscreen", true->JSON.Encode.bool),
     ("param", "paymentloader"->JSON.Encode.string),
     ("iframeId", iframeId->JSON.Encode.string),
   ])
   if !readOnly {
-    handlePostMessage([
+    messageParentWindow([
       ("GpayClicked", true->JSON.Encode.bool),
       ("GpayPaymentDataRequest", paymentDataRequest->Identity.anyTypeToJson),
     ])

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -313,7 +313,7 @@ let rec intentCall = (
     ~bodyStr: string=?,
     ~headers: Dict.t<string>=?,
     ~method: Fetch.method,
-  ) => Promise.t<Fetch.Response.t>,
+  ) => promise<Fetch.Response.t>,
   ~uri,
   ~headers,
   ~bodyStr,

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -21,7 +21,7 @@ let getPaymentType = paymentMethodType =>
   | _ => Other
   }
 
-let closePaymentLoaderIfAny = () => handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+let closePaymentLoaderIfAny = () => messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
 
 type paymentIntent = (
   ~handleUserError: bool=?,
@@ -267,7 +267,7 @@ let rec pollStatus = (
       if status === "completed" {
         resolve(json)
       } else if count === 0 {
-        handlePostMessage([("fullscreen", false->JSON.Encode.bool)])
+        messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
         openUrl(returnUrl)
       } else {
         delay(interval)
@@ -368,7 +368,7 @@ let rec intentCall = (
     let url = urlSearch(confirmParam.return_url)
     url.searchParams.set("payment_intent_client_secret", clientSecret)
     url.searchParams.set("status", "failed")
-    handlePostMessage([("confirmParams", confirmParam->Identity.anyTypeToJson)])
+    messageParentWindow([("confirmParams", confirmParam->Identity.anyTypeToJson)])
 
     if statusCode->String.charAt(0) !== "2" {
       res
@@ -557,7 +557,7 @@ let rec intentCall = (
                   ~paymentMethod,
                 )
                 if !isPaymentSession {
-                  handlePostMessage([
+                  messageParentWindow([
                     ("fullscreen", true->JSON.Encode.bool),
                     ("param", `${intent.payment_method_type}BankTransfer`->JSON.Encode.string),
                     ("iframeId", iframeId->JSON.Encode.string),
@@ -592,7 +592,7 @@ let rec intentCall = (
                   ~paymentMethod,
                 )
                 if !isPaymentSession {
-                  handlePostMessage([
+                  messageParentWindow([
                     ("fullscreen", true->JSON.Encode.bool),
                     ("param", `qrData`->JSON.Encode.string),
                     ("iframeId", iframeId->JSON.Encode.string),
@@ -639,7 +639,7 @@ let rec intentCall = (
                 )
 
                 if do3dsMethodCall {
-                  handlePostMessage([
+                  messageParentWindow([
                     ("fullscreen", true->JSON.Encode.bool),
                     ("param", `3ds`->JSON.Encode.string),
                     ("iframeId", iframeId->JSON.Encode.string),
@@ -647,7 +647,7 @@ let rec intentCall = (
                   ])
                 } else {
                   metaData->Dict.set("3dsMethodComp", "U"->JSON.Encode.string)
-                  handlePostMessage([
+                  messageParentWindow([
                     ("fullscreen", true->JSON.Encode.bool),
                     ("param", `3dsAuth`->JSON.Encode.string),
                     ("iframeId", iframeId->JSON.Encode.string),
@@ -681,7 +681,7 @@ let rec intentCall = (
                   ~eventName=DISPLAY_VOUCHER,
                   ~paymentMethod,
                 )
-                handlePostMessage([
+                messageParentWindow([
                   ("fullscreen", true->JSON.Encode.bool),
                   ("param", `voucherData`->JSON.Encode.string),
                   ("iframeId", iframeId->JSON.Encode.string),
@@ -724,7 +724,7 @@ let rec intentCall = (
                 }
 
                 if !isPaymentSession {
-                  handlePostMessage(message)
+                  messageParentWindow(message)
                 }
                 resolve(data)
               } else if intent.nextAction.type_ === "invoke_sdk_client" {
@@ -778,7 +778,7 @@ let rec intentCall = (
                 }
 
                 if !isPaymentSession {
-                  handlePostMessage(message)
+                  messageParentWindow(message)
                 }
               } else {
                 handleProcessingStatus(paymentType, sdkHandleOneClickConfirmPayment)
@@ -1713,7 +1713,7 @@ let callAuthLink = (
             ("isForceSync", false->JSON.Encode.bool),
           ]->getJsonFromArrayOfJson
 
-        handlePostMessage([
+        messageParentWindow([
           ("fullscreen", true->JSON.Encode.bool),
           ("param", "plaidSDK"->JSON.Encode.string),
           ("iframeId", iframeId->JSON.Encode.string),

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -17,27 +17,27 @@ type dateTimeFormat = {resolvedOptions: unit => options}
 
 @send external postMessage: (parent, JSON.t, string) => unit = "postMessage"
 open ErrorUtils
-let handlePostMessage = (~targetOrigin="*", messageArr) => {
+let messageParentWindow = (~targetOrigin="*", messageArr) => {
   iframeParent->postMessage(messageArr->Dict.fromArray->JSON.Encode.object, targetOrigin)
 }
 
 let handleOnFocusPostMessage = (~targetOrigin="*") => {
-  handlePostMessage([("focus", true->JSON.Encode.bool)], ~targetOrigin)
+  messageParentWindow([("focus", true->JSON.Encode.bool)], ~targetOrigin)
 }
 
 let handleOnBlurPostMessage = (~targetOrigin="*") => {
-  handlePostMessage([("blur", true->JSON.Encode.bool)], ~targetOrigin)
+  messageParentWindow([("blur", true->JSON.Encode.bool)], ~targetOrigin)
 }
 
 let handleOnClickPostMessage = (~targetOrigin="*", ev) => {
-  handlePostMessage(
+  messageParentWindow(
     [("clickTriggered", true->JSON.Encode.bool), ("event", ev->JSON.stringify->JSON.Encode.string)],
     ~targetOrigin,
   )
 }
 let handleOnConfirmPostMessage = (~targetOrigin="*", ~isOneClick=false) => {
   let message = isOneClick ? "oneClickConfirmTriggered" : "confirmTriggered"
-  handlePostMessage([(message, true->JSON.Encode.bool)], ~targetOrigin)
+  messageParentWindow([(message, true->JSON.Encode.bool)], ~targetOrigin)
 }
 let getOptionString = (dict, key) => {
   dict->Dict.get(key)->Option.flatMap(JSON.Decode.string)
@@ -281,13 +281,13 @@ let postFailedSubmitResponse = (~errortype, ~message) => {
       ("type", errortype->JSON.Encode.string),
       ("message", message->JSON.Encode.string),
     ]->Dict.fromArray
-  handlePostMessage([
+  messageParentWindow([
     ("submitSuccessful", false->JSON.Encode.bool),
     ("error", errorDict->JSON.Encode.object),
   ])
 }
 let postSubmitResponse = (~jsonData, ~url) => {
-  handlePostMessage([
+  messageParentWindow([
     ("submitSuccessful", true->JSON.Encode.bool),
     ("data", jsonData),
     ("url", url->JSON.Encode.string),
@@ -593,7 +593,7 @@ let generateStyleSheet = (classname, dict, id) => {
   }
 }
 let openUrl = url => {
-  handlePostMessage([("openurl", url->JSON.Encode.string)])
+  messageParentWindow([("openurl", url->JSON.Encode.string)])
 }
 
 let getArrofJsonString = (arr: array<string>) => {
@@ -678,7 +678,7 @@ let handlePostMessageEvents = (
       "Payment Data Filled" ++ (savedMethod ? ": Saved Payment Method" : ": New Payment Method")
     loggerState.setLogInfo(~value, ~eventName=PAYMENT_DATA_FILLED, ~paymentMethod=paymentType)
   }
-  handlePostMessage([
+  messageParentWindow([
     ("elementType", "payment"->JSON.Encode.string),
     ("complete", complete->JSON.Encode.bool),
     ("empty", empty->JSON.Encode.bool),

--- a/src/libraries/Promise.res
+++ b/src/libraries/Promise.res
@@ -1,4 +1,4 @@
-type t<+'a> = Promise.t<'a>
+type t<+'a> = promise<'a>
 
 exception JsError(Exn.t)
 

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -6,8 +6,8 @@ open EventListenerManager
 open ApplePayTypes
 
 type trustPayFunctions = {
-  finishApplePaymentV2: (string, paymentRequestData) => Promise.t<JSON.t>,
-  executeGooglePayment: (string, GooglePayType.paymentDataRequest) => Promise.t<JSON.t>,
+  finishApplePaymentV2: (string, paymentRequestData) => promise<JSON.t>,
+  executeGooglePayment: (string, GooglePayType.paymentDataRequest) => promise<JSON.t>,
 }
 @new external trustPayApi: JSON.t => trustPayFunctions = "TrustPayApi"
 

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -613,7 +613,7 @@ let make = (
           }
           switch eventDataObject->getOptionalJsonFromJson("poll_status") {
           | Some(val) => {
-              handlePostMessage([
+              messageParentWindow([
                 ("fullscreen", true->JSON.Encode.bool),
                 ("param", "paymentloader"->JSON.Encode.string),
                 ("iframeId", selectorString->JSON.Encode.string),
@@ -651,7 +651,7 @@ let make = (
                     )
                     resolve(JSON.Encode.null)
                   } else {
-                    handlePostMessage([
+                    messageParentWindow([
                       ("fullscreen", false->JSON.Encode.bool),
                       ("submitSuccessful", true->JSON.Encode.bool),
                       ("data", json),
@@ -663,7 +663,7 @@ let make = (
                   if redirect.contents === "always" {
                     Window.Location.replace(url)
                   }
-                  handlePostMessage([
+                  messageParentWindow([
                     ("submitSuccessful", false->JSON.Encode.bool),
                     ("error", err->Identity.anyTypeToJson),
                   ])
@@ -692,17 +692,17 @@ let make = (
                 ~isForceSync=true,
               )
               ->then(json => {
-                handlePostMessage([("submitSuccessful", true->JSON.Encode.bool), ("data", json)])
+                messageParentWindow([("submitSuccessful", true->JSON.Encode.bool), ("data", json)])
                 resolve(json)
               })
               ->catch(err => {
-                handlePostMessage([
+                messageParentWindow([
                   ("submitSuccessful", false->JSON.Encode.bool),
                   ("error", err->Identity.anyTypeToJson),
                 ])
                 resolve(err->Identity.anyTypeToJson)
               })
-              ->finally(_ => handlePostMessage([("fullscreen", false->JSON.Encode.bool)]))
+              ->finally(_ => messageParentWindow([("fullscreen", false->JSON.Encode.bool)]))
             }->ignore
 
           | None => ()

--- a/src/orca-loader/LoaderPaymentElement.res
+++ b/src/orca-loader/LoaderPaymentElement.res
@@ -4,7 +4,7 @@ open EventListenerManager
 open Identity
 
 @val @scope(("navigator", "clipboard"))
-external writeText: string => Promise.t<'a> = "writeText"
+external writeText: string => promise<'a> = "writeText"
 
 let make = (
   componentType,

--- a/src/orca-loader/Types.res
+++ b/src/orca-loader/Types.res
@@ -13,7 +13,7 @@ type eventData = {
 type event = {key: string, data: eventData, source: Dom.element}
 type eventParam = Event(event) | EventData(eventData) | Empty
 type eventHandler = option<JSON.t> => unit
-@send external onload: (Dom.element, unit => Promise.t<'a>) => Promise.t<'a> = "onload"
+@send external onload: (Dom.element, unit => promise<'a>) => promise<'a> = "onload"
 module This = {
   type t
   @get
@@ -35,25 +35,25 @@ type paymentElement = {
 type element = {
   getElement: string => option<paymentElement>,
   update: JSON.t => unit,
-  fetchUpdates: unit => Promise.t<JSON.t>,
+  fetchUpdates: unit => promise<JSON.t>,
   create: (string, JSON.t) => paymentElement,
 }
 
 type getCustomerSavedPaymentMethods = {
   getCustomerDefaultSavedPaymentMethodData: unit => JSON.t,
   getCustomerLastUsedPaymentMethodData: unit => JSON.t,
-  confirmWithCustomerDefaultPaymentMethod: JSON.t => Promise.t<JSON.t>,
-  confirmWithLastUsedPaymentMethod: JSON.t => Promise.t<JSON.t>,
+  confirmWithCustomerDefaultPaymentMethod: JSON.t => promise<JSON.t>,
+  confirmWithLastUsedPaymentMethod: JSON.t => promise<JSON.t>,
 }
 
 type getPaymentManagementMethods = {
-  getSavedPaymentManagementMethodsList: unit => Promise.t<JSON.t>,
-  deleteSavedPaymentMethod: JSON.t => Promise.t<JSON.t>,
+  getSavedPaymentManagementMethodsList: unit => promise<JSON.t>,
+  deleteSavedPaymentMethod: JSON.t => promise<JSON.t>,
 }
 
 type initPaymentSession = {
-  getCustomerSavedPaymentMethods: unit => Promise.t<JSON.t>,
-  getPaymentManagementMethods: unit => Promise.t<JSON.t>,
+  getCustomerSavedPaymentMethods: unit => promise<JSON.t>,
+  getPaymentManagementMethods: unit => promise<JSON.t>,
 }
 
 type confirmParams = {return_url: string}
@@ -64,11 +64,11 @@ type confirmPaymentParams = {
 }
 
 type hyperInstance = {
-  confirmOneClickPayment: (JSON.t, bool) => Promise.t<JSON.t>,
-  confirmPayment: JSON.t => Promise.t<JSON.t>,
+  confirmOneClickPayment: (JSON.t, bool) => promise<JSON.t>,
+  confirmPayment: JSON.t => promise<JSON.t>,
   elements: JSON.t => element,
-  confirmCardPayment: (string, option<JSON.t>, option<JSON.t>) => Promise.t<JSON.t>,
-  retrievePaymentIntent: string => Promise.t<JSON.t>,
+  confirmCardPayment: (string, option<JSON.t>, option<JSON.t>) => promise<JSON.t>,
+  retrievePaymentIntent: string => promise<JSON.t>,
   widgets: JSON.t => element,
   paymentRequest: JSON.t => JSON.t,
   initPaymentSession: JSON.t => initPaymentSession,

--- a/src/orca-log-catcher/ErrorBoundary.res
+++ b/src/orca-log-catcher/ErrorBoundary.res
@@ -184,7 +184,7 @@ module ErrorCard = {
     React.useEffect(() => {
       switch level {
       | Top =>
-        Utils.handlePostMessage([
+        Utils.messageParentWindow([
           ("iframeHeight", (divH +. 1.0)->JSON.Encode.float),
           ("iframeId", iframeId->JSON.Encode.string),
         ])


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
`handlePostMessage` doesn't actually "handle" a message that was posted by someone. Instead the method actually just posts a message to the parent window. So renaming it to `messageParentWindow` makes more sense.


## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
