### PR TITLE
fix: added loader for netecetera when openurl_if_required is sent post otp submission

### DIFF
--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -680,6 +680,11 @@ let make = (
 
           switch eventDataObject->getOptionalJsonFromJson("openurl_if_required") {
           | Some(val) =>
+            messageParentWindow([
+              ("fullscreen", true->JSON.Encode.bool),
+              ("param", "paymentloader"->JSON.Encode.string),
+              ("iframeId", selectorString->JSON.Encode.string),
+            ])
             if redirect.contents === "always" {
               Window.Location.replace(val->JSON.Decode.string->Option.getOr(""))
               resolve(JSON.Encode.null)


### PR DESCRIPTION


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

added loader for netecetera when openurl_if_required is sent post otp submission

## How did you test it?

Modal will close and fullscreen loader should open in case the post message from backend is `openurl_if_required`.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
