### PR TITLE
fix: added support for customPodUri instead of switchToCustomPod

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -45,6 +45,7 @@ let make = () => {
             "hyperComponentName",
           )->Types.getHyperComponentNameFromStr
         let merchantHostname = CardUtils.getQueryParamsDictforKey(url.search, "merchantHostname")
+        let customPodUri = CardUtils.getQueryParamsDictforKey(url.search, "customPodUri")
 
         <PreMountLoader
           publishableKey
@@ -54,6 +55,7 @@ let make = () => {
           ephemeralKey
           hyperComponentName
           merchantHostname
+          customPodUri
         />
       }
     | "achBankTransfer"

--- a/src/Components/SavedPaymentManagement.res
+++ b/src/Components/SavedPaymentManagement.res
@@ -5,7 +5,7 @@ let make = (~savedMethods: array<PaymentType.customerMethods>, ~setSavedMethods)
 
   let {iframeId} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
   let {config} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let switchToCustomPod = Recoil.useRecoilValueFromAtom(RecoilAtoms.switchToCustomPod)
+  let customPodUri = Recoil.useRecoilValueFromAtom(RecoilAtoms.customPodUri)
   let logger = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
 
   let removeSavedMethod = (
@@ -28,7 +28,7 @@ let make = (~savedMethods: array<PaymentType.customerMethods>, ~setSavedMethods)
       ~ephemeralKey=config.ephemeralKey,
       ~paymentMethodId=paymentItem.paymentMethodId,
       ~logger,
-      ~switchToCustomPod,
+      ~customPodUri,
     )
     ->then(res => {
       let dict = res->getDictFromJson

--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -11,7 +11,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
   let (optionsPayment, setOptionsPayment) = Recoil.useRecoilState(optionAtom)
   let setSessionId = Recoil.useSetRecoilState(sessionId)
   let setBlockConfirm = Recoil.useSetRecoilState(isConfirmBlocked)
-  let setSwitchToCustomPod = Recoil.useSetRecoilState(switchToCustomPod)
+  let setCustomPodUri = Recoil.useSetRecoilState(customPodUri)
   let setIsGooglePayReady = Recoil.useSetRecoilState(isGooglePayReady)
   let setIsApplePayReady = Recoil.useSetRecoilState(isApplePayReady)
   let (divH, setDivH) = React.useState(_ => 0.0)
@@ -231,8 +231,8 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
               logger.setSessionId(sdkSessionId)
               if Window.isInteg {
                 setBlockConfirm(_ => dict->getBool("blockConfirm", false))
-                setSwitchToCustomPod(_ => dict->getBool("switchToCustomPod", false))
               }
+              setCustomPodUri(_ => dict->getString("customPodUri", ""))
               updateOptions(dict)
               setSessionId(_ => {
                 sdkSessionId

--- a/src/PaymentMethodCollectElement.res
+++ b/src/PaymentMethodCollectElement.res
@@ -100,7 +100,7 @@ let make = (~integrateError, ~logger) => {
           ~clientSecret=keys.clientSecret->Option.getOr(""),
           ~publishableKey=keys.publishableKey,
           ~logger,
-          ~switchToCustomPod=false,
+          ~customPodUri="",
           ~uri,
           ~body=pmdBody,
         )
@@ -171,7 +171,7 @@ let make = (~integrateError, ~logger) => {
         ~clientSecret=keys.clientSecret->Option.getOr(""),
         ~publishableKey=keys.publishableKey,
         ~logger,
-        ~switchToCustomPod=false,
+        ~customPodUri="",
         ~endpoint=ApiEndpoint.getApiEndPoint(),
         ~body=pmdBody,
       )
@@ -296,8 +296,13 @@ let make = (~integrateError, ~logger) => {
                       className="font-bold text-5xl mt-5 lg:mt-0 lg:text-3xl flex justify-center items-center">
                       <p> {React.string(`${options.currency} ${options.amount}`)} </p>
                     </div>
-                    <div className="flex items-center justify-center h-12 w-auto bg-white rounded-sm">
-                      <img className="max-h-12 w-auto max-w-21 h-auto w-auto" src={merchantLogo} alt="O" />
+                    <div
+                      className="flex items-center justify-center h-12 w-auto bg-white rounded-sm">
+                      <img
+                        className="max-h-12 w-auto max-w-21 h-auto w-auto"
+                        src={merchantLogo}
+                        alt="O"
+                      />
                     </div>
                   </div>
                   <div className="lg:mx-5">

--- a/src/Payments/PlaidSDKIframe.res
+++ b/src/Payments/PlaidSDKIframe.res
@@ -57,7 +57,7 @@ let make = () => {
       clientSecret,
       headers,
       ~optLogger=Some(logger),
-      ~switchToCustomPod=false,
+      ~customPodUri="",
       ~isForceSync=true,
     )
     ->then(json => {

--- a/src/Payments/PreMountLoader.res
+++ b/src/Payments/PreMountLoader.res
@@ -7,6 +7,7 @@ let make = (
   ~ephemeralKey,
   ~hyperComponentName: Types.hyperComponentName,
   ~merchantHostname,
+  ~customPodUri,
 ) => {
   open Utils
   let (paymentMethodsResponseSent, setPaymentMethodsResponseSent) = React.useState(_ => false)
@@ -37,7 +38,7 @@ let make = (
         ~clientSecret,
         ~publishableKey,
         ~logger,
-        ~switchToCustomPod=false,
+        ~customPodUri,
         ~endpoint,
       )
     | _ => JSON.Encode.null->Promise.resolve
@@ -49,7 +50,7 @@ let make = (
         ~clientSecret,
         ~publishableKey,
         ~optLogger=Some(logger),
-        ~switchToCustomPod=false,
+        ~customPodUri,
         ~endpoint,
       )
     | _ => JSON.Encode.null->Promise.resolve
@@ -61,7 +62,7 @@ let make = (
         ~clientSecret,
         ~publishableKey,
         ~optLogger=Some(logger),
-        ~switchToCustomPod=false,
+        ~customPodUri,
         ~endpoint,
         ~merchantHostname,
       )
@@ -73,7 +74,7 @@ let make = (
       PaymentHelpers.fetchSavedPaymentMethodList(
         ~ephemeralKey,
         ~optLogger=Some(logger),
-        ~switchToCustomPod=false,
+        ~customPodUri,
         ~endpoint,
       )
     | _ => JSON.Encode.null->Promise.resolve

--- a/src/Payments/QRCodeDisplay.res
+++ b/src/Payments/QRCodeDisplay.res
@@ -16,7 +16,7 @@ let make = () => {
   let (clientSecret, setClientSecret) = React.useState(_ => "")
   let (headers, setHeaders) = React.useState(_ => [])
   let logger = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
-  let switchToCustomPod = Recoil.useRecoilValueFromAtom(RecoilAtoms.switchToCustomPod)
+  let customPodUri = Recoil.useRecoilValueFromAtom(RecoilAtoms.customPodUri)
 
   React.useEffect0(() => {
     messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
@@ -55,7 +55,7 @@ let make = () => {
           paymentIntentId,
           headers->Dict.toArray,
           ~optLogger=Some(logger),
-          ~switchToCustomPod,
+          ~customPodUri,
         )
         ->then(res => {
           Modal.close(setOpenModal)
@@ -88,7 +88,7 @@ let make = () => {
       clientSecret,
       headers,
       ~optLogger=Some(logger),
-      ~switchToCustomPod,
+      ~customPodUri,
     )
     ->then(json => {
       let dict = json->getDictFromJson

--- a/src/Utilities/ApiEndpoint.res
+++ b/src/Utilities/ApiEndpoint.res
@@ -18,14 +18,11 @@ let getApiEndPoint = (~publishableKey="", ~isConfirmCall=false) => {
   }
 }
 
-let addCustomPodHeader = (arr: array<(string, string)>, ~switchToCustomPod=?) => {
-  let customPod = switch switchToCustomPod {
-  | Some(val) => val
-  | None => false
+let addCustomPodHeader = (arr: array<(string, string)>, ~customPodUri=?) => {
+  switch customPodUri {
+  | Some("")
+  | None => ()
+  | Some(customPodVal) => arr->Array.push(("x-feature", customPodVal))
   }
-  if customPod {
-    arr->Array.concat([("x-feature", "router-custom-dbd")])->Dict.fromArray
-  } else {
-    arr->Dict.fromArray
-  }
+  arr->Dict.fromArray
 }

--- a/src/Utilities/RecoilAtoms.res
+++ b/src/Utilities/RecoilAtoms.res
@@ -10,7 +10,7 @@ let paymentMethodList = Recoil.atom("paymentMethodList", PaymentType.Loading)
 let loggerAtom = Recoil.atom("component", OrcaLogger.defaultLoggerConfig)
 let sessionId = Recoil.atom("sessionId", "")
 let isConfirmBlocked = Recoil.atom("isConfirmBlocked", false)
-let switchToCustomPod = Recoil.atom("switchToCustomPod", false)
+let customPodUri = Recoil.atom("customPodUri", "")
 let selectedOptionAtom = Recoil.atom("selectedOption", "")
 let paymentTokenAtom = Recoil.atom(
   "paymentToken",

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -49,13 +49,12 @@ let make = (
       ->Option.flatMap(x => x->Dict.get("blockConfirm"))
       ->Option.flatMap(JSON.Decode.bool)
       ->Option.getOr(false)
-    let switchToCustomPod =
-      GlobalVars.isInteg &&
+    let customPodUri =
       options
       ->JSON.Decode.object
-      ->Option.flatMap(x => x->Dict.get("switchToCustomPod"))
-      ->Option.flatMap(JSON.Decode.bool)
-      ->Option.getOr(false)
+      ->Option.flatMap(x => x->Dict.get("customPodUri"))
+      ->Option.flatMap(JSON.Decode.string)
+      ->Option.getOr("")
 
     let merchantHostname = Window.Location.hostname
 
@@ -72,7 +71,7 @@ let make = (
            <iframe
            id ="orca-payment-element-iframeRef-${localSelectorString}"
            name="orca-payment-element-iframeRef-${localSelectorString}"
-          src="${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=${componentType}&publishableKey=${publishableKey}&clientSecret=${clientSecret}&sessionId=${sdkSessionId}&endpoint=${endpoint}&merchantHostname=${merchantHostname}"
+          src="${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=${componentType}&publishableKey=${publishableKey}&clientSecret=${clientSecret}&sessionId=${sdkSessionId}&endpoint=${endpoint}&merchantHostname=${merchantHostname}&customPodUri=${customPodUri}"
           allow="*"
           name="orca-payment"
         ></iframe>
@@ -313,7 +312,7 @@ let make = (
             ("endpoint", endpoint->JSON.Encode.string),
             ("sdkSessionId", sdkSessionId->JSON.Encode.string),
             ("blockConfirm", blockConfirm->JSON.Encode.bool),
-            ("switchToCustomPod", switchToCustomPod->JSON.Encode.bool),
+            ("customPodUri", customPodUri->JSON.Encode.string),
             ("sdkHandleOneClickConfirmPayment", sdkHandleOneClickConfirmPayment->JSON.Encode.bool),
             ("parentURL", "*"->JSON.Encode.string),
             ("analyticsMetadata", analyticsMetadata),
@@ -418,7 +417,7 @@ let make = (
                           clientSecret,
                           headers,
                           ~optLogger=Some(logger),
-                          ~switchToCustomPod,
+                          ~customPodUri,
                           ~isForceSync=true,
                         )
                       )
@@ -626,7 +625,7 @@ let make = (
               let url = dict->getString("return_url_with_query_params", "")
               PaymentHelpers.pollStatus(
                 ~headers,
-                ~switchToCustomPod,
+                ~customPodUri,
                 ~pollId,
                 ~interval,
                 ~count,
@@ -638,7 +637,7 @@ let make = (
                   clientSecret,
                   headers,
                   ~optLogger=Some(logger),
-                  ~switchToCustomPod,
+                  ~customPodUri,
                   ~isForceSync=true,
                 )
                 ->then(json => {
@@ -688,7 +687,7 @@ let make = (
                 clientSecret,
                 headers,
                 ~optLogger=Some(logger),
-                ~switchToCustomPod,
+                ~customPodUri,
                 ~isForceSync=true,
               )
               ->then(json => {

--- a/src/orca-loader/PaymentMethodsManagementElements.res
+++ b/src/orca-loader/PaymentMethodsManagementElements.res
@@ -33,13 +33,12 @@ let make = (
       ->Option.getOr([])
       ->JSON.Encode.array
 
-    let switchToCustomPod =
-      GlobalVars.isInteg &&
+    let customPodUri =
       options
       ->JSON.Decode.object
-      ->Option.flatMap(x => x->Dict.get("switchToCustomPod"))
-      ->Option.flatMap(JSON.Decode.bool)
-      ->Option.getOr(false)
+      ->Option.flatMap(x => x->Dict.get("customPodUri"))
+      ->Option.flatMap(JSON.Decode.string)
+      ->Option.getOr("")
 
     let localSelectorString = "hyper-preMountLoader-iframe"
     let mountPreMountLoaderIframe = () => {
@@ -190,7 +189,7 @@ let make = (
             ("publishableKey", publishableKey->JSON.Encode.string),
             ("endpoint", endpoint->JSON.Encode.string),
             ("sdkSessionId", sdkSessionId->JSON.Encode.string),
-            ("switchToCustomPod", switchToCustomPod->JSON.Encode.bool),
+            ("customPodUri", customPodUri->JSON.Encode.string),
             ("parentURL", "*"->JSON.Encode.string),
             ("analyticsMetadata", analyticsMetadata),
             ("launchTime", launchTime->JSON.Encode.float),

--- a/src/orca-loader/PaymentSession.res
+++ b/src/orca-loader/PaymentSession.res
@@ -8,13 +8,12 @@ let make = (
   ~ephemeralKey,
 ) => {
   let logger = logger->Option.getOr(OrcaLogger.defaultLoggerConfig)
-  let switchToCustomPod =
-    GlobalVars.isInteg &&
+  let customPodUri =
     options
     ->JSON.Decode.object
-    ->Option.flatMap(x => x->Dict.get("switchToCustomPod"))
-    ->Option.flatMap(JSON.Decode.bool)
-    ->Option.getOr(false)
+    ->Option.flatMap(x => x->Dict.get("customPodUri"))
+    ->Option.flatMap(JSON.Decode.string)
+    ->Option.getOr("")
   let endpoint = ApiEndpoint.getApiEndPoint(~publishableKey)
 
   let defaultInitPaymentSession = {
@@ -24,13 +23,13 @@ let make = (
         ~publishableKey,
         ~endpoint,
         ~logger,
-        ~switchToCustomPod,
+        ~customPodUri,
       ),
     getPaymentManagementMethods: _ =>
       PaymentSessionMethods.getPaymentManagementMethods(
         ~ephemeralKey,
         ~logger,
-        ~switchToCustomPod,
+        ~customPodUri,
         ~endpoint,
       ),
   }

--- a/src/orca-loader/PaymentSessionMethods.res
+++ b/src/orca-loader/PaymentSessionMethods.res
@@ -7,7 +7,7 @@ let getCustomerSavedPaymentMethods = (
   ~publishableKey,
   ~endpoint,
   ~logger,
-  ~switchToCustomPod,
+  ~customPodUri,
 ) => {
   open ApplePayTypes
   open GooglePayType
@@ -17,7 +17,7 @@ let getCustomerSavedPaymentMethods = (
     ~clientSecret,
     ~publishableKey,
     ~endpoint,
-    ~switchToCustomPod,
+    ~customPodUri,
     ~optLogger=Some(logger),
     ~isPaymentSession=true,
   )
@@ -114,6 +114,7 @@ let getCustomerSavedPaymentMethods = (
             ~publishableKey,
             ~clientSecret,
             ~logger,
+            ~customPodUri,
           )
         }
       | None =>
@@ -161,6 +162,7 @@ let getCustomerSavedPaymentMethods = (
             ~publishableKey,
             ~clientSecret,
             ~logger,
+            ~customPodUri,
           )->then(val => {
             val->resolvePromise
             resolve()
@@ -225,6 +227,7 @@ let getCustomerSavedPaymentMethods = (
             ~publishableKey,
             ~clientSecret,
             ~logger,
+            ~customPodUri,
           )
         }
 
@@ -298,6 +301,7 @@ let getCustomerSavedPaymentMethods = (
             ~publishableKey,
             ~clientSecret,
             ~logger,
+            ~customPodUri,
           )
         }
       | None =>
@@ -331,7 +335,7 @@ let getCustomerSavedPaymentMethods = (
         ~clientSecret,
         ~publishableKey,
         ~optLogger=Some(logger),
-        ~switchToCustomPod=false,
+        ~customPodUri,
         ~endpoint,
       )
       ->then(sessionDetails => {
@@ -464,12 +468,12 @@ let getCustomerSavedPaymentMethods = (
   })
 }
 
-let getPaymentManagementMethods = (~ephemeralKey, ~logger, ~switchToCustomPod, ~endpoint) => {
+let getPaymentManagementMethods = (~ephemeralKey, ~logger, ~customPodUri, ~endpoint) => {
   let getSavedPaymentManagementMethodsList = _ => {
     PaymentHelpers.fetchSavedPaymentMethodList(
       ~ephemeralKey,
       ~optLogger=Some(logger),
-      ~switchToCustomPod=false,
+      ~customPodUri,
       ~endpoint,
     )
     ->then(response => {
@@ -486,7 +490,7 @@ let getPaymentManagementMethods = (~ephemeralKey, ~logger, ~switchToCustomPod, ~
       ~ephemeralKey,
       ~paymentMethodId={paymentMethodId->JSON.Decode.string->Option.getOr("")},
       ~logger,
-      ~switchToCustomPod,
+      ~customPodUri,
     )
     ->then(response => {
       response->resolve


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

added support for customPodValue instead of switchToCustomPod

## How did you test it?

`x-feature` value, if passed in options should be present in the request header for all the api calls made from the SDK.

<img width="985" alt="Screenshot 2024-08-30 at 3 02 02 AM" src="https://github.com/user-attachments/assets/b7c2aa73-214e-476b-9a8e-700983dcb38e">

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
