### PR TITLE
fix: added support to send post messages to parent iframe

### DIFF
--- a/src/Hooks/UtilityHooks.res
+++ b/src/Hooks/UtilityHooks.res
@@ -41,3 +41,23 @@ let useIsCustomerAcceptanceRequired = (
     displaySavedPaymentMethodsCheckbox,
   ))
 }
+
+let useSendEventsToParent = eventsToSendToParent => {
+  React.useEffect0(() => {
+    let handle = (ev: Window.event) => {
+      let eventDataObject = ev.data->Identity.anyTypeToJson
+      let eventsDict = eventDataObject->Utils.getDictFromJson
+
+      let events = eventsDict->Dict.keysToArray
+
+      let shouldSendToParent =
+        events->Array.some(event => eventsToSendToParent->Array.includes(event))
+
+      if shouldSendToParent {
+        Utils.messageParentWindow(eventsDict->Dict.toArray)
+      }
+    }
+    Window.addEventListener("message", handle)
+    Some(() => {Window.removeEventListener("message", handle)})
+  })
+}

--- a/src/ThreeDSAuth.res
+++ b/src/ThreeDSAuth.res
@@ -21,6 +21,10 @@ let make = () => {
     }
   }
 
+  let eventsToSendToParent = ["confirmParams", "poll_status", "openurl_if_required"]
+
+  eventsToSendToParent->UtilityHooks.useSendEventsToParent
+
   React.useEffect0(() => {
     messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
     let handle = (ev: Window.event) => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Post message events being sent on the top level were not working in scenarios where the SDK along with HyperLoader and event listeners is mounted inside an iframe.

Added support to listen to such events in the parent iframe and send these post messages on level above instead of directly sending it to the top parent.

## How did you test it?

https://github.com/user-attachments/assets/be9e7982-e210-4d0e-ae13-5aaa5573ed4d

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
