### PR TITLE
fix: added customization for padding inside accordion item rule

### DIFF
--- a/src/BrutalTheme.res
+++ b/src/BrutalTheme.res
@@ -138,6 +138,7 @@ let brutalRules = (theme: CardThemeType.themeClass) =>
       "color": theme.colorBackgroundText,
       "transition": "height 1s ease",
       "borderColor": `#000000 !important`,
+      "padding": "20px",
     },
     ".AccordionMore": {
       "backgroundColor": theme.colorBackground,

--- a/src/CharcoalTheme.res
+++ b/src/CharcoalTheme.res
@@ -137,6 +137,7 @@ let charcoalRules = theme =>
       "backgroundColor": theme.colorBackground,
       "color": theme.colorTextSecondary,
       "transition": "height 1s ease",
+      "padding": "20px",
     },
     ".AccordionMore": {
       "backgroundColor": theme.colorBackground,

--- a/src/Components/Accordion.res
+++ b/src/Components/Accordion.res
@@ -39,7 +39,6 @@ let make = (
     style={
       minHeight: "60px",
       width: "-webkit-fill-available",
-      padding: "20px",
       cursor: "pointer",
       marginBottom: layoutClass.spacedAccordionItems ? themeObj.spacingAccordionItem : "",
       border: `1px solid ${themeObj.borderColor}`,

--- a/src/Components/AccordionContainer.res
+++ b/src/Components/AccordionContainer.res
@@ -34,7 +34,6 @@ module Loader = {
             },
             borderTopStyle: {i == 0 && !layoutClass.spacedAccordionItems ? "hidden" : "solid"},
             width: "100%",
-            paddingLeft: "25px",
             marginBottom: layoutClass.spacedAccordionItems ? themeObj.spacingAccordionItem : "",
             cursor: "pointer",
           }>

--- a/src/DefaultTheme.res
+++ b/src/DefaultTheme.res
@@ -147,6 +147,7 @@ let defaultRules = theme =>
       "color": theme.colorTextSecondary,
       "transition": "height 1s ease",
       "boxShadow": "0px 1px 1px rgb(0 0 0 / 3%), 0px 3px 6px rgb(0 0 0 / 2%)",
+      "padding": "20px",
     },
     ".AccordionMore": {
       "backgroundColor": theme.colorBackground,

--- a/src/MidnightTheme.res
+++ b/src/MidnightTheme.res
@@ -154,6 +154,7 @@ let midnightRules = theme =>
       "transition": "height 1s ease",
       "color": "#e0e0e0",
       "boxShadow": "0px 2px 4px rgb(0 0 0 / 50%), 0px 1px 6px rgb(0 0 0 / 25%)",
+      "padding": "20px",
     },
     ".AccordionItem:hover": {
       "color": theme.colorTextSecondary,

--- a/src/SoftTheme.res
+++ b/src/SoftTheme.res
@@ -136,6 +136,7 @@ let softRules = theme =>
       "color": theme.colorTextSecondary,
       "transition": "background .15s ease, border .15s ease, box-shadow .15s ease",
       "boxShadow": `4px 4px 5px #353637, -4px -4px 5px #434445`,
+      "padding": "20px",
     },
     ".AccordionItem--selected": {
       "color": theme.colorPrimary,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added customization support for padding inside .AccordionItem rule

[Issue Link](https://github.com/orgs/juspay/projects/22/views/2?pane=issue&itemId=76559442)

## How did you test it?

Before - 
<img width="569" alt="Screenshot 2024-09-03 at 5 16 20 AM" src="https://github.com/user-attachments/assets/58ca2809-7344-4ac5-b02f-fec927d4102d">

After -
<img width="567" alt="Screenshot 2024-09-03 at 5 17 57 AM" src="https://github.com/user-attachments/assets/827a15f2-e0c4-4180-8b49-e6fcaacd1fa3">

The card tab will look the same since the value of padding is same. There is slight change in the loader icon for Accordion

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
