### PR TITLE
fix: changed post message from parent window to current window

### DIFF
--- a/Hyperswitch-React-Demo-App/server.js
+++ b/Hyperswitch-React-Demo-App/server.js
@@ -54,6 +54,7 @@ const paymentData = {
   authentication_type: "three_ds",
   customer_id: "hyperswitch_sdk_demo_id",
   email: "hyperswitch_sdk_demo_id@gmail.com",
+  request_external_three_ds_authentication: false,
   description: "Hello this is description",
   shipping: {
     address: {
@@ -97,7 +98,7 @@ const paymentData = {
 }
 
 const profileId = process.env.PROFILE_ID;
-if(profileId) {
+if (profileId) {
   paymentData.profile_id = profileId;
 }
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1,8 +1,6 @@
 @val external document: 'a = "document"
-type window
-type parent
-@val external window: window = "window"
-@val @scope("window") external iframeParent: parent = "parent"
+@val external window: Dom.element = "window"
+@val @scope("window") external iframeParent: Dom.element = "parent"
 type event = {data: string}
 external dictToObj: Dict.t<'a> => {..} = "%identity"
 
@@ -15,10 +13,15 @@ type dateTimeFormat = {resolvedOptions: unit => options}
 
 @send external remove: Dom.element => unit = "remove"
 
-@send external postMessage: (parent, JSON.t, string) => unit = "postMessage"
+@send external postMessage: (Dom.element, JSON.t, string) => unit = "postMessage"
+
 open ErrorUtils
 let messageParentWindow = (~targetOrigin="*", messageArr) => {
   iframeParent->postMessage(messageArr->Dict.fromArray->JSON.Encode.object, targetOrigin)
+}
+
+let messageCurrentWindow = (~targetOrigin="*", messageArr) => {
+  window->postMessage(messageArr->Dict.fromArray->JSON.Encode.object, targetOrigin)
 }
 
 let handleOnFocusPostMessage = (~targetOrigin="*") => {

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -612,7 +612,7 @@ let make = (
           }
           switch eventDataObject->getOptionalJsonFromJson("poll_status") {
           | Some(val) => {
-              messageParentWindow([
+              messageCurrentWindow([
                 ("fullscreen", true->JSON.Encode.bool),
                 ("param", "paymentloader"->JSON.Encode.string),
                 ("iframeId", selectorString->JSON.Encode.string),
@@ -650,7 +650,7 @@ let make = (
                     )
                     resolve(JSON.Encode.null)
                   } else {
-                    messageParentWindow([
+                    messageCurrentWindow([
                       ("fullscreen", false->JSON.Encode.bool),
                       ("submitSuccessful", true->JSON.Encode.bool),
                       ("data", json),
@@ -662,7 +662,7 @@ let make = (
                   if redirect.contents === "always" {
                     Window.Location.replace(url)
                   }
-                  messageParentWindow([
+                  messageCurrentWindow([
                     ("submitSuccessful", false->JSON.Encode.bool),
                     ("error", err->Identity.anyTypeToJson),
                   ])
@@ -679,7 +679,7 @@ let make = (
 
           switch eventDataObject->getOptionalJsonFromJson("openurl_if_required") {
           | Some(val) =>
-            messageParentWindow([
+            messageCurrentWindow([
               ("fullscreen", true->JSON.Encode.bool),
               ("param", "paymentloader"->JSON.Encode.string),
               ("iframeId", selectorString->JSON.Encode.string),
@@ -696,17 +696,17 @@ let make = (
                 ~isForceSync=true,
               )
               ->then(json => {
-                messageParentWindow([("submitSuccessful", true->JSON.Encode.bool), ("data", json)])
+                messageCurrentWindow([("submitSuccessful", true->JSON.Encode.bool), ("data", json)])
                 resolve(json)
               })
               ->catch(err => {
-                messageParentWindow([
+                messageCurrentWindow([
                   ("submitSuccessful", false->JSON.Encode.bool),
                   ("error", err->Identity.anyTypeToJson),
                 ])
                 resolve(err->Identity.anyTypeToJson)
               })
-              ->finally(_ => messageParentWindow([("fullscreen", false->JSON.Encode.bool)]))
+              ->finally(_ => messageCurrentWindow([("fullscreen", false->JSON.Encode.bool)]))
             }->ignore
 
           | None => ()


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Changed Post message being sent to parent to current

## How did you test it?

Tested netcetera flow(challenge and frictionless) for both where our SDK is opening inside and iframe and on the top level with `capture_method` as `manual` and `redirect` as `if_required`

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
