### PR TITLE
fix(payout): on change handler for dropdown

### DIFF
--- a/src/CollectWidget.res
+++ b/src/CollectWidget.res
@@ -152,8 +152,12 @@ let make = (
               fieldName={field->getPaymentMethodDataFieldLabel(localeString)}
               value
               setValue={getVal => {
-                let isValid = calculateValidity(field, getVal(), ~default=Some(false))
+                let updatedValue = getVal()
+                let isValid = calculateValidity(field, updatedValue, ~default=Some(false))
                 setValidityDictVal(key, isValid)
+                if isValid->Option.getOr(false) {
+                  setFormData(key, updatedValue)
+                }
               }}
               options={countries->DropdownField.updateArrayOfStringToOptionsTypeArray}
               disabled=false

--- a/src/FormViewTabs.res
+++ b/src/FormViewTabs.res
@@ -226,8 +226,10 @@ let make = (
           {payoutDynamicFields.payoutMethodData->renderPayoutMethodForm->React.array}
           {payoutDynamicFields.address
           ->Option.map(addressFields => {
-            let formFields = addressFields->renderAddressForm
-            if formFields->Array.length > 0 {
+            let fieldsToCollect =
+              addressFields->Array.filter(addressField => addressField.value == None)
+            if fieldsToCollect->Array.length > 0 {
+              let formFields = addressFields->renderAddressForm
               <>
                 <div className={`mb-2.5 ${contentHeaderClasses}`}>
                   {React.string(localeString.billingDetailsText)}

--- a/src/PaymentMethodCollectElement.res
+++ b/src/PaymentMethodCollectElement.res
@@ -192,7 +192,7 @@ let make = (~integrateError, ~logger) => {
 
   let renderCollectWidget = () =>
     <div className="flex flex-row overflow-scroll lg:w-6/10">
-      <div className="relative w-full h-auto lg:w-auto lg:mx-12 lg:mt-20 lg-mb-10">
+      <div className="relative w-full h-min lg:w-auto lg:mx-12 lg:mt-20 lg-mb-10">
         {loader
           ? <div className="absolute h-full w-full bg-jp-gray-600 bg-opacity-80" />
           : {React.null}}

--- a/src/Types/PaymentMethodCollectTypes.res
+++ b/src/Types/PaymentMethodCollectTypes.res
@@ -252,9 +252,15 @@ let getFieldOptions = dict => {
       obj
       ->Dict.get("options")
       ->Option.flatMap(JSON.Decode.array)
-      ->Option.map(options => BillingAddress(
-        AddressCountry(options->Array.filterMap(option => option->JSON.Decode.string)),
-      ))
+      ->Option.map(options => {
+        let countries = options->Array.filterMap(option => option->JSON.Decode.string)
+        countries->Array.sort(
+          (c1, c2) =>
+            (c1->String.charCodeAt(0)->Float.toInt - c2->String.charCodeAt(0)->Float.toInt)
+              ->Int.toFloat,
+        )
+        BillingAddress(AddressCountry(countries))
+      })
     )
   | _ => None
   }

--- a/src/Utilities/PaymentMethodCollectUtils.res
+++ b/src/Utilities/PaymentMethodCollectUtils.res
@@ -521,7 +521,7 @@ let defaultPaypalFields = [
   {
     pmdMap: "payout_method_data.wallet.telephone_number",
     displayName: "user_phone_number",
-    fieldType: SepaIban,
+    fieldType: PaypalMobNumber,
     value: None,
   },
 ]

--- a/src/Utilities/PaymentMethodCollectUtils.res
+++ b/src/Utilities/PaymentMethodCollectUtils.res
@@ -565,12 +565,12 @@ let defaultEnabledPaymentMethods: array<paymentMethodType> = [
   Wallet(Paypal),
 ]
 let defaultEnabledPaymentMethodsWithDynamicFields: array<paymentMethodTypeWithDynamicFields> = [
-  Card((Credit, defaultPayoutDynamicFields())),
-  Card((Debit, defaultPayoutDynamicFields())),
-  BankTransfer((ACH, defaultPayoutDynamicFields())),
-  BankTransfer((Bacs, defaultPayoutDynamicFields())),
-  BankTransfer((Sepa, defaultPayoutDynamicFields())),
-  Wallet((Paypal, defaultPayoutDynamicFields())),
+  Card((Credit, defaultPayoutDynamicFields(~pmt=Card(Credit)))),
+  Card((Debit, defaultPayoutDynamicFields(~pmt=Card(Debit)))),
+  BankTransfer((ACH, defaultPayoutDynamicFields(~pmt=BankTransfer(ACH)))),
+  BankTransfer((Bacs, defaultPayoutDynamicFields(~pmt=BankTransfer(Bacs)))),
+  BankTransfer((Sepa, defaultPayoutDynamicFields(~pmt=BankTransfer(Sepa)))),
+  Wallet((Paypal, defaultPayoutDynamicFields(~pmt=Wallet(Paypal)))),
 ]
 let defaultPaymentMethodCollectOptions = {
   enabledPaymentMethods: defaultEnabledPaymentMethods,
@@ -696,6 +696,11 @@ let calculateValidity = (key, value, ~default=None) => {
     } else {
       Some(false)
     }
+  | PayoutMethodData(SepaIban) => Some(value->String.length > 13 && value->String.length < 34)
+
+  // Sepa BIC is optional
+  | PayoutMethodData(SepaBic) => Some(true)
+
   // Defaults
   | PayoutMethodData(_)
   | BillingAddress(_) =>

--- a/src/Utilities/PaymentMethodCollectUtils.res
+++ b/src/Utilities/PaymentMethodCollectUtils.res
@@ -289,7 +289,7 @@ let getPaymentMethodDataFieldCharacterPattern = (key): option<Js.Re.t> =>
   | PayoutMethodData(PaypalMobNumber) => Some(%re("/^[0-9]{1,12}$/"))
   | PayoutMethodData(SepaBic) => Some(%re("/^([A-Z0-9]| ){1,8}$/"))
   | PayoutMethodData(SepaIban) => Some(%re("/^([A-Z0-9]| ){1,34}$/"))
-  | BillingAddress(AddressPincode) => Some(%re("/^[0-9]{1,8}$/"))
+  | BillingAddress(AddressPincode) => Some(%re("/^([0-9A-Z]| ){1,10}$/"))
   | BillingAddress(PhoneNumber) => Some(%re("/^[0-9]{1,12}$/"))
   | BillingAddress(PhoneCountryCode) => Some(%re("/^[0-9]{1,2}$/"))
   | _ => None


### PR DESCRIPTION
make SEPA BIC optional
populate default requiredFields in case backend returns an empty response

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR contains below fixes

- update form value on change in dropdown fields (country code not updating)
- use default fields for payment method data form in case backend returns an empty response
- add validation for IBAN and make BIC optional


## How did you test it?
Locally.

[Screencast from 16-09-24 03:30:14 PM IST.webm](https://github.com/user-attachments/assets/2573117f-58ab-4710-997e-69923e7645bf)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
