### PR TITLE
fix: dynamic tax calculation fix

### DIFF
--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -128,7 +128,7 @@ let startApplePaySession = (
         ~paymentMethodType,
       )
       ->then(response => {
-        let taxCalculationResponse = response->getDictFromJson->taxResponseToObjMapper
+        let taxCalculationResponse = response->taxResponseToObjMapper
         let (netAmount, ordertaxAmount, shippingCost) = (
           taxCalculationResponse.net_amount,
           taxCalculationResponse.order_tax_amount,
@@ -136,23 +136,23 @@ let startApplePaySession = (
         )
         let newTotal: lineItem = {
           label: "Net Amount",
-          amount: netAmount->Int.toString,
+          amount: netAmount->Float.toString,
           \"type": "final",
         }
         let newLineItems: array<lineItem> = [
           {
             label: "Bag Subtotal",
-            amount: (netAmount - ordertaxAmount - shippingCost)->Int.toString,
+            amount: (netAmount -. ordertaxAmount -. shippingCost)->Float.toString,
             \"type": "final",
           },
           {
             label: "Order Tax Amount",
-            amount: ordertaxAmount->Int.toString,
+            amount: ordertaxAmount->Float.toString,
             \"type": "final",
           },
           {
             label: "Shipping Cost",
-            amount: shippingCost->Int.toString,
+            amount: shippingCost->Float.toString,
             \"type": "final",
           },
         ]

--- a/src/Utilities/TaxCalculation.res
+++ b/src/Utilities/TaxCalculation.res
@@ -2,19 +2,29 @@ open Utils
 
 type calculateTaxResponse = {
   payment_id: string,
-  net_amount: int,
-  order_tax_amount: int,
-  shipping_cost: int,
+  net_amount: float,
+  order_tax_amount: float,
+  shipping_cost: float,
 }
 
-let taxResponseToObjMapper = dict => {
-  payment_id: dict->getString("payment_id", ""),
-  net_amount: dict->getInt("net_amount", 0),
-  order_tax_amount: dict->getInt("order_tax_amount", 0),
-  shipping_cost: dict->getInt("shipping_cost", 0),
+let taxResponseToObjMapper = resp => {
+  let responseDict = resp->getDictFromJson
+  let displayAmountDict = responseDict->getDictFromDict("display_amount")
+  {
+    payment_id: responseDict->getString("payment_id", ""),
+    net_amount: displayAmountDict->getFloat("net_amount", 0.0),
+    order_tax_amount: displayAmountDict->getFloat("order_tax_amount", 0.0),
+    shipping_cost: displayAmountDict->getFloat("shipping_cost", 0.0),
+  }
 }
 
-let calculateTax = (~shippingAddress, ~logger, ~clientSecret, ~publishableKey, ~paymentMethodType) => {
+let calculateTax = (
+  ~shippingAddress,
+  ~logger,
+  ~clientSecret,
+  ~publishableKey,
+  ~paymentMethodType,
+) => {
   PaymentHelpers.calculateTax(
     ~clientSecret=clientSecret->JSON.Encode.string,
     ~apiKey=publishableKey,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Dynamic Tax response type changed from integer to float due to compatibility issues.
Sample tax api response:
`{
    "payment_id": "pay_D1KwskbRrHs2wZcXzi6w",
    "net_amount": 4190,
    "order_tax_amount": 190,
    "shipping_cost": 1000,
    "display_amount": {
        "net_amount": "41.90",
        "order_tax_amount": "1.90",
        "shipping_cost": "10.00"
    }
}`

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
