### PR TITLE
fix: Invalid shipping address and taxjar api failing case handle in apple pay

### DIFF
--- a/src/Utilities/TaxCalculation.res
+++ b/src/Utilities/TaxCalculation.res
@@ -2,20 +2,20 @@ open Utils
 
 type calculateTaxResponse = {
   payment_id: string,
-  net_amount: float,
-  order_tax_amount: float,
-  shipping_cost: float,
+  net_amount: int,
+  order_tax_amount: int,
+  shipping_cost: int,
 }
 
 let taxResponseToObjMapper = resp => {
-  let responseDict = resp->getDictFromJson
-  let displayAmountDict = responseDict->getDictFromDict("display_amount")
-  {
-    payment_id: responseDict->getString("payment_id", ""),
-    net_amount: displayAmountDict->getFloat("net_amount", 0.0),
-    order_tax_amount: displayAmountDict->getFloat("order_tax_amount", 0.0),
-    shipping_cost: displayAmountDict->getFloat("shipping_cost", 0.0),
-  }
+  resp
+  ->JSON.Decode.object
+  ->Option.map(dict => {
+    payment_id: dict->getString("payment_id", ""),
+    net_amount: dict->getInt("net_amount", 0),
+    order_tax_amount: dict->getInt("order_tax_amount", 0),
+    shipping_cost: dict->getInt("shipping_cost", 0),
+  })
 }
 
 let calculateTax = (

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1377,3 +1377,5 @@ let getFirstAndLastNameFromFullName = fullName => {
 }
 
 let checkIsTestCardWildcard = val => ["1111222233334444"]->Array.includes(val)
+
+let minorUnitToString = val => (val->Int.toFloat /. 100.)->Float.toString


### PR DESCRIPTION
Invalid shipping address and taxjar api failing case handle in apple pay

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Invalid shipping address and taxjar api failing case handle in apple pay. Aborting the apple pay session for invalid address selection and taxjar api failing.
<!-- Describe your changes in detail -->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
