### PR TITLE
fix: added suspense and error boundary for apple pay and google pay in tabs

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -328,24 +328,28 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
       | ApplePay =>
         switch applePayToken {
         | ApplePayTokenOptional(optToken) =>
-          <ApplePayLazy sessionObj=optToken walletOptions paymentType />
+          <ReusableReactSuspense loaderComponent={loader()} componentName="ApplePayLazy">
+            <ApplePayLazy sessionObj=optToken walletOptions paymentType />
+          </ReusableReactSuspense>
         | _ => React.null
         }
       | GooglePay =>
         <SessionPaymentWrapper type_={Wallet}>
           {switch gPayToken {
           | OtherTokenOptional(optToken) =>
-            switch googlePayThirdPartyToken {
-            | GooglePayThirdPartyTokenOptional(googlePayThirdPartyOptToken) =>
-              <GPayLazy
-                sessionObj=optToken
-                thirdPartySessionObj=googlePayThirdPartyOptToken
-                walletOptions
-                paymentType
-              />
-            | _ =>
-              <GPayLazy sessionObj=optToken thirdPartySessionObj=None walletOptions paymentType />
-            }
+            <ReusableReactSuspense loaderComponent={loader()} componentName="GPayLazy">
+              {switch googlePayThirdPartyToken {
+              | GooglePayThirdPartyTokenOptional(googlePayThirdPartyOptToken) =>
+                <GPayLazy
+                  sessionObj=optToken
+                  thirdPartySessionObj=googlePayThirdPartyOptToken
+                  walletOptions
+                  paymentType
+                />
+              | _ =>
+                <GPayLazy sessionObj=optToken thirdPartySessionObj=None walletOptions paymentType />
+              }}
+            </ReusableReactSuspense>
           | _ => React.null
           }}
         </SessionPaymentWrapper>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added Suspense and Error Boundary for ApplePay and GooglePay

## How did you test it?

Test ApplePay and GooglePay in tabs flow

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
