### PR TITLE
feat: pass email and phone number to confirm call

### DIFF
--- a/src/Payments/PaypalSDKHelpers.res
+++ b/src/Payments/PaypalSDKHelpers.res
@@ -75,7 +75,6 @@ let loadPaypalSDK = (
                 ->Array.get(0)
                 ->Option.flatMap(JSON.Decode.object)
                 ->Option.getOr(Dict.make())
-              let details = purchaseUnit->paypalShippingDetails
               let payerDetails =
                 val
                 ->Utils.getDictFromJson
@@ -83,9 +82,10 @@ let loadPaypalSDK = (
                 ->Option.flatMap(JSON.Decode.object)
                 ->Option.getOr(Dict.make())
                 ->PaymentType.itemToPayerDetailsObjectMapper
+
+              let details = purchaseUnit->paypalShippingDetails(payerDetails)
               let requiredFieldsBody = DynamicFieldsUtils.getPaypalRequiredFields(
                 ~details,
-                ~payerDetails,
                 ~paymentMethodTypes,
                 ~statesList=stateJson,
               )

--- a/src/Payments/PaypalSDKHelpers.res
+++ b/src/Payments/PaypalSDKHelpers.res
@@ -76,8 +76,16 @@ let loadPaypalSDK = (
                 ->Option.flatMap(JSON.Decode.object)
                 ->Option.getOr(Dict.make())
               let details = purchaseUnit->paypalShippingDetails
+              let payerDetails =
+                val
+                ->Utils.getDictFromJson
+                ->Dict.get("payer")
+                ->Option.flatMap(JSON.Decode.object)
+                ->Option.getOr(Dict.make())
+                ->PaymentType.itemToPayerDetailsObjectMapper
               let requiredFieldsBody = DynamicFieldsUtils.getPaypalRequiredFields(
                 ~details,
+                ~payerDetails,
                 ~paymentMethodTypes,
                 ~statesList=stateJson,
               )

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -173,6 +173,12 @@ type options = {
   displayDefaultSavedPaymentIcon: bool,
   hideCardNicknameField: bool,
 }
+
+type payerDetails = {
+  email: option<string>,
+  phone: option<string>,
+}
+
 let defaultCardDetails = {
   scheme: None,
   last4Digits: "",
@@ -311,6 +317,12 @@ let defaultOptions = {
   displayDefaultSavedPaymentIcon: true,
   hideCardNicknameField: false,
 }
+
+let defaultPayerDetails = {
+  email: None,
+  phone: None,
+}
+
 let getLayout = (str, logger) => {
   switch str {
   | "tabs" => Tabs
@@ -1060,4 +1072,15 @@ type loadType = Loading | Loaded(JSON.t) | SemiLoaded | LoadError(JSON.t)
 
 let getIsStoredPaymentMethodHasName = (savedMethod: customerMethods) => {
   savedMethod.card.cardHolderName->Option.getOr("")->String.length > 0
+}
+
+let itemToPayerDetailsObjectMapper = dict => {
+  email: dict->Dict.get("email_address")->Option.flatMap(JSON.Decode.string),
+  phone: dict
+  ->Dict.get("phone")
+  ->Option.flatMap(JSON.Decode.object)
+  ->Option.flatMap(Dict.get(_, "phone_number"))
+  ->Option.flatMap(JSON.Decode.object)
+  ->Option.flatMap(Dict.get(_, "national_number"))
+  ->Option.flatMap(JSON.Decode.string),
 }

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -318,11 +318,6 @@ let defaultOptions = {
   hideCardNicknameField: false,
 }
 
-let defaultPayerDetails = {
-  email: None,
-  phone: None,
-}
-
 let getLayout = (str, logger) => {
   switch str {
   | "tabs" => Tabs

--- a/src/Types/PaypalSDKTypes.res
+++ b/src/Types/PaypalSDKTypes.res
@@ -125,9 +125,8 @@ let getShippingDetails = shippingAddressOverrideObj => {
   }
 }
 
-let paypalShippingDetails = purchaseUnit => {
+let paypalShippingDetails = (purchaseUnit, payerDetails: PaymentType.payerDetails) => {
   let shippingAddress = purchaseUnit->Utils.getDictFromDict("shipping")
-  let payee = purchaseUnit->Utils.getDictFromDict("payee")
 
   let address = shippingAddress->Utils.getDictFromDict("address")
   let name = shippingAddress->Utils.getDictFromDict("name")
@@ -139,10 +138,7 @@ let paypalShippingDetails = purchaseUnit => {
   let countryCode = address->Utils.getOptionString("country_code")
   let postalCode = address->Utils.getOptionString("postal_code")
   let state = address->Utils.getOptionString("admin_area_1")
-  let email = payee->Utils.getString("email_address", "")
-
-  let payeePhone = payee->Utils.getOptionString("phone")
-  let shippingAddressPhone = address->Utils.getOptionString("phone")
+  let email = payerDetails.email->Option.getOr("")
 
   {
     email,
@@ -154,9 +150,9 @@ let paypalShippingDetails = purchaseUnit => {
       countryCode,
       postalCode,
       state,
-      phone: shippingAddressPhone,
+      phone: payerDetails.phone,
     },
-    phone: payeePhone,
+    phone: payerDetails.phone,
   }
 }
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1286,21 +1286,21 @@ let getStateNameFromStateCodeAndCountry = (list: JSON.t, stateCode: string, coun
     list
     ->getDictFromJson
     ->getOptionalArrayFromDict(country)
-    ->Option.getOr([])
 
-  let val = options->Array.find(item =>
-    item
-    ->getDictFromJson
-    ->getString("code", "") === stateCode
+  options
+  ->Option.flatMap(
+    Array.find(_, item =>
+      item
+      ->getDictFromJson
+      ->getString("code", "") === stateCode
+    ),
   )
-
-  switch val {
-  | Some(stateObj) =>
+  ->Option.flatMap(stateObj =>
     stateObj
     ->getDictFromJson
-    ->getString("name", stateCode)
-  | None => stateCode
-  }
+    ->getOptionString("name")
+  )
+  ->Option.getOr(stateCode)
 }
 
 let removeHyphen = str => str->String.replaceRegExp(%re("/-/g"), "")


### PR DESCRIPTION
Pass email and phone number to confirm call

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Passing email address and phone number for paypal in confirm call, for apple pay and klarna it is already getting passed.

<!-- Describe your changes in detail -->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
