### PR TITLE
fix: sdk pay now redirect fix

### DIFF
--- a/src/orca-loader/Hyper.res
+++ b/src/orca-loader/Hyper.res
@@ -316,11 +316,13 @@ let make = (publishableKey, options: option<JSON.t>, analyticsInfo: option<JSON.
                 }
                 postSubmitMessage(dict)
 
-                if isSdkButton {
+                let submitSuccessfulValue = val->JSON.Decode.bool->Option.getOr(false)
+
+                if isSdkButton && submitSuccessfulValue {
                   Window.replaceRootHref(returnUrl)
-                } else if val->JSON.Decode.bool->Option.getOr(false) && redirect === "always" {
+                } else if submitSuccessfulValue && redirect === "always" {
                   Window.replaceRootHref(returnUrl)
-                } else if !(val->JSON.Decode.bool->Option.getOr(false)) {
+                } else if !submitSuccessfulValue {
                   resolve1(json)
                 } else {
                   resolve1(data)


### PR DESCRIPTION
## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

SDK was redirecting everytime in case of SDK pay now button was clicked, fixed it by adding a condition of only redirect when submit successfull is true.

## How did you test it?

by trying to click on pay now without providing all fields

## Checklist

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
