### PR TITLE
fix: fixed applePay for headless fow

### DIFF
--- a/src/Types/ApplePayTypes.res
+++ b/src/Types/ApplePayTypes.res
@@ -74,6 +74,16 @@ type paymentRequestData = {
   @optional merchantIdentifier: string,
 }
 
+type headlessApplePayToken = {
+  paymentRequestData: JSON.t,
+  sessionTokenData: option<JSON.t>,
+}
+
+let defaultHeadlessApplePayToken: headlessApplePayToken = {
+  paymentRequestData: JSON.Encode.null,
+  sessionTokenData: None,
+}
+
 let jsonToPaymentRequestDataType: Dict.t<JSON.t> => paymentRequestData = jsonDict => {
   let clientTimeZone = CardUtils.dateTimeFormat().resolvedOptions().timeZone
   let clientCountry = getClientCountry(clientTimeZone)

--- a/src/orca-loader/PaymentSessionMethods.res
+++ b/src/orca-loader/PaymentSessionMethods.res
@@ -35,7 +35,7 @@ let getCustomerSavedPaymentMethods = (
     customerPaymentMethods->Array.sort((a, b) => compareLogic(a.lastUsedAt, b.lastUsedAt))
 
     let customerPaymentMethodsRef = ref(customerPaymentMethods)
-    let applePayTokenRef = ref(JSON.Encode.null)
+    let applePayTokenRef = ref(defaultHeadlessApplePayToken)
     let googlePayTokenRef = ref(JSON.Encode.null)
 
     let isApplePayPresent =
@@ -187,9 +187,9 @@ let getCustomerSavedPaymentMethods = (
       }
 
       ApplePayHelpers.startApplePaySession(
-        ~paymentRequest=applePayTokenRef.contents,
+        ~paymentRequest=applePayTokenRef.contents.paymentRequestData,
         ~applePaySessionRef,
-        ~applePayPresent=Some(applePayTokenRef.contents),
+        ~applePayPresent=applePayTokenRef.contents.sessionTokenData,
         ~logger,
         ~callBackFunc=processPayment,
         ~clientSecret,
@@ -425,7 +425,10 @@ let getCustomerSavedPaymentMethods = (
               ~sessionObj=optToken,
               ~componentName,
             )
-            applePayTokenRef := paymentRequest
+            applePayTokenRef := {
+                paymentRequestData: paymentRequest,
+                sessionTokenData: optToken,
+              }
           }
         | _ => updateCustomerPaymentMethodsRef(~isFilterApplePay=true)
         }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

We were not passing `session_token_data` to **startApplePaySession**, `payment_request_data` was being passed

Sample response

```
{
  "session_token_data": {
    "epoch_timestamp": "PLACEHOLDER_TIMESTAMP",
    "expires_at": "PLACEHOLDER_EXPIRATION",
    "merchant_session_identifier": "PLACEHOLDER_MERCHANT_SESSION_ID",
    "nonce": "PLACEHOLDER_NONCE",
    "merchant_identifier": "PLACEHOLDER_MERCHANT_ID",
    "domain_name": "PLACEHOLDER_DOMAIN",
    "display_name": "PLACEHOLDER_DISPLAY_NAME",
    "signature": "PLACEHOLDER_SIGNATURE"
  },
  "payment_request_data": {
    "country_code": "PLACEHOLDER_COUNTRY_CODE",
    "currency_code": "PLACEHOLDER_CURRENCY_CODE",
    "total": {
      "label": "PLACEHOLDER_LABEL",
      "type": "PLACEHOLDER_TYPE",
      "amount": "PLACEHOLDER_AMOUNT"
    },
    "merchant_capabilities": [
      "PLACEHOLDER_CAPABILITY"
    ],
    "supported_networks": [
      "PLACEHOLDER_NETWORK"
    ],
    "merchant_identifier": "PLACEHOLDER_MERCHANT_ID",
    "required_billing_contact_fields": [
      "PLACEHOLDER_BILLING_CONTACT"
    ],
    "required_shipping_contact_fields": [
      "PLACEHOLDER_SHIPPING_CONTACT"
    ]
  }
}
```

## How did you test it?

Tested ApplePay Via Headless flow

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
