### PR TITLE
fix: closed loader before calling merchant callback

### DIFF
--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -529,6 +529,7 @@ let rec intentCall = (
                 }
               | _ =>
                 if isCallbackUsedVal->Option.getOr(false) {
+                  closePaymentLoaderIfAny()
                   Utils.handleOnCompleteDoThisMessage()
                 } else {
                   handleOpenUrl(url.href)


### PR DESCRIPTION
## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Closed loader if there is any before executing the merchant callback

## How did you test it?

By passing a onPaymentComplete callback and checking if the loader is getting closed or not

## Checklist

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
