### PR TITLE
feat: added apple pay support inside an iframe

### DIFF
--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -18,6 +18,8 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
   let (launchTime, setLaunchTime) = React.useState(_ => 0.0)
   let {showCardFormByDefault, paymentMethodOrder} = optionsPayment
   let (_, setPaymentMethodCollectOptions) = Recoil.useRecoilState(paymentMethodCollectOptionAtom)
+  let url = RescriptReactRouter.useUrl()
+  let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
 
   let divRef = React.useRef(Nullable.null)
 
@@ -148,7 +150,10 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
 
   React.useEffect0(() => {
     messageParentWindow([("iframeMounted", true->JSON.Encode.bool)])
-    messageParentWindow([("applePayMounted", true->JSON.Encode.bool)])
+    messageParentWindow([
+      ("applePayMounted", true->JSON.Encode.bool),
+      ("componentName", componentName->JSON.Encode.string),
+    ])
     logger.setLogInitiated()
     let updatedState: PaymentType.loadType = switch paymentMethodList {
     | Loading =>

--- a/src/Types/ApplePayTypes.res
+++ b/src/Types/ApplePayTypes.res
@@ -185,3 +185,21 @@ let getPaymentRequestFromSession = (~sessionObj, ~componentName) => {
 
   paymentRequest
 }
+
+let handleApplePayIframePostMessage = (msg, componentName, mountedIframeRef) => {
+  let isApplePayMessageSent = ref(false)
+
+  let iframes = Window.querySelectorAll("iframe")
+
+  iframes->Array.forEach(iframe => {
+    let iframeSrc = iframe->Window.getAttribute("src")->Option.getOr("")
+    if iframeSrc->String.includes(`componentName=${componentName}`) {
+      iframe->Js.Nullable.return->Window.iframePostMessage(msg)
+      isApplePayMessageSent := true
+    }
+  })
+
+  if !isApplePayMessageSent.contents {
+    mountedIframeRef->Window.iframePostMessage(msg)
+  }
+}

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -316,6 +316,7 @@ let rec intentCall = (
   ~counter,
   ~isPaymentSession=false,
   ~isCallbackUsedVal=?,
+  ~componentName="payment",
 ) => {
   open Promise
   let isConfirm = uri->String.includes("/confirm")
@@ -468,6 +469,7 @@ let rec intentCall = (
                 ~customPodUri,
                 ~sdkHandleOneClickConfirmPayment,
                 ~counter=counter + 1,
+                ~componentName,
               )
               ->then(
                 res => {
@@ -704,6 +706,7 @@ let rec intentCall = (
                 | "apple_pay" => [
                     ("applePayButtonClicked", true->JSON.Encode.bool),
                     ("applePayPresent", session_token->anyTypeToJson),
+                    ("componentName", componentName->JSON.Encode.string),
                   ]
                 | "google_pay" => [("googlePayThirdPartyFlow", session_token->anyTypeToJson)]
                 | "open_banking" => {
@@ -893,6 +896,7 @@ let rec intentCall = (
             ~sdkHandleOneClickConfirmPayment,
             ~counter=counter + 1,
             ~isPaymentSession,
+            ~componentName,
           )
           ->then(
             res => {
@@ -990,8 +994,8 @@ let usePaymentIntent = (optLogger, paymentType) => {
   open RecoilAtoms
   open Promise
   let url = RescriptReactRouter.useUrl()
-  let paymentTypeFromUrl =
-    CardUtils.getQueryParamsDictforKey(url.search, "componentName")->CardThemeType.getPaymentMode
+  let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
+  let paymentTypeFromUrl = componentName->CardThemeType.getPaymentMode
   let blockConfirm = Recoil.useRecoilValueFromAtom(isConfirmBlocked)
   let customPodUri = Recoil.useRecoilValueFromAtom(customPodUri)
   let paymentMethodList = Recoil.useRecoilValueFromAtom(paymentMethodList)
@@ -1091,6 +1095,7 @@ let usePaymentIntent = (optLogger, paymentType) => {
             ~sdkHandleOneClickConfirmPayment=keys.sdkHandleOneClickConfirmPayment,
             ~counter=0,
             ~isCallbackUsedVal,
+            ~componentName,
           )
           ->then(val => {
             intentCallback(val)

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1,6 +1,7 @@
 @val external document: 'a = "document"
 @val external window: Dom.element = "window"
 @val @scope("window") external iframeParent: Dom.element = "parent"
+@val @scope("window") external topParent: Dom.element = "top"
 type event = {data: string}
 external dictToObj: Dict.t<'a> => {..} = "%identity"
 
@@ -16,12 +17,21 @@ type dateTimeFormat = {resolvedOptions: unit => options}
 @send external postMessage: (Dom.element, JSON.t, string) => unit = "postMessage"
 
 open ErrorUtils
+
+let messageWindow = (window, ~targetOrigin="*", messageArr) => {
+  window->postMessage(messageArr->Dict.fromArray->JSON.Encode.object, targetOrigin)
+}
+
+let messageTopWindow = (~targetOrigin="*", messageArr) => {
+  topParent->messageWindow(~targetOrigin, messageArr)
+}
+
 let messageParentWindow = (~targetOrigin="*", messageArr) => {
-  iframeParent->postMessage(messageArr->Dict.fromArray->JSON.Encode.object, targetOrigin)
+  iframeParent->messageWindow(~targetOrigin, messageArr)
 }
 
 let messageCurrentWindow = (~targetOrigin="*", messageArr) => {
-  window->postMessage(messageArr->Dict.fromArray->JSON.Encode.object, targetOrigin)
+  window->messageWindow(~targetOrigin, messageArr)
 }
 
 let handleOnFocusPostMessage = (~targetOrigin="*") => {

--- a/src/Window.res
+++ b/src/Window.res
@@ -26,6 +26,7 @@ type style
 external querySelector: string => Nullable.t<Dom.element> = "querySelector"
 @val @scope("document")
 external querySelectorAll: string => array<Dom.element> = "querySelectorAll"
+@send external getAttribute: (Dom.element, string) => option<string> = "getAttribute"
 
 type eventData = {
   elementType: string,
@@ -44,6 +45,7 @@ external addEventListener: (string, _ => unit) => unit = "addEventListener"
 @val @scope("window")
 external removeEventListener: (string, 'ev => unit) => unit = "removeEventListener"
 @send external postMessage: (Dom.element, string, string) => unit = "postMessage"
+@send external postMessageJSON: (Dom.element, JSON.t, string) => unit = "postMessage"
 @send
 external getElementById: (document, string) => Nullable.t<Dom.element> = "getElementById"
 @get
@@ -60,6 +62,10 @@ external style: Dom.element => style = "style"
 
 let sendPostMessage = (element, message) => {
   element->postMessage(message->JSON.Encode.object->JSON.stringify, GlobalVars.targetOrigin)
+}
+
+let sendPostMessageJSON = (element, message) => {
+  element->postMessageJSON(message, GlobalVars.targetOrigin)
 }
 
 let iframePostMessage = (iframeRef: nullable<Dom.element>, message) => {

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -21,7 +21,6 @@ let make = (
   ~analyticsMetadata,
   ~customBackendUrl,
 ) => {
-  let applePaySessionRef = ref(Nullable.null)
   try {
     let iframeRef = []
     let logger = logger->Option.getOr(OrcaLogger.defaultLoggerConfig)
@@ -334,6 +333,7 @@ let make = (
         let handleApplePayMounted = (event: Types.event) => {
           let json = event.data->anyTypeToJson
           let dict = json->getDictFromJson
+          let componentName = getString(dict, "componentName", "payment")
 
           if dict->Dict.get("applePayMounted")->Option.isSome {
             if wallets.applePay === Auto {
@@ -341,8 +341,11 @@ let make = (
               | Some(session) =>
                 try {
                   if session.canMakePayments() {
-                    let msg = [("applePayCanMakePayments", true->JSON.Encode.bool)]->Dict.fromArray
-                    event.source->Window.sendPostMessage(msg)
+                    let msg = [
+                      ("hyperApplePayCanMakePayments", true->JSON.Encode.bool),
+                      ("componentName", componentName->JSON.Encode.string),
+                    ]
+                    messageTopWindow(msg)
                   } else {
                     Console.log("CANNOT MAKE PAYMENT USING APPLE PAY")
                     logger.setLogInfo(
@@ -373,6 +376,28 @@ let make = (
                 ~paymentMethod="APPLE_PAY",
                 ~logType=INFO,
               )
+            }
+          } else if dict->Dict.get("applePayCanMakePayments")->Option.isSome {
+            let applePayCanMakePayments = getBool(dict, "applePayCanMakePayments", false)
+
+            if applePayCanMakePayments {
+              try {
+                let msg = [("applePayCanMakePayments", true->JSON.Encode.bool)]->Dict.fromArray
+
+                handleApplePayIframePostMessage(msg, componentName, mountedIframeRef)
+              } catch {
+              | exn => {
+                  let exnString = exn->anyTypeToJson->JSON.stringify
+
+                  Console.log("CANNOT MAKE PAYMENT USING APPLE PAY: " ++ exnString)
+                  logger.setLogInfo(
+                    ~value=exnString,
+                    ~eventName=APPLE_PAY_FLOW,
+                    ~paymentMethod="APPLE_PAY",
+                    ~logType=ERROR,
+                  )
+                }
+              }
             }
           }
         }
@@ -792,6 +817,8 @@ let make = (
                   let handleApplePayMessages = (applePayEvent: Types.event) => {
                     let json = applePayEvent.data->Identity.anyTypeToJson
                     let dict = json->getDictFromJson
+                    let componentName = dict->getString("componentName", "payment")
+
                     switch (
                       dict->Dict.get("applePayButtonClicked"),
                       dict->Dict.get("applePayPaymentRequest"),
@@ -817,32 +844,44 @@ let make = (
                             ~paymentMethod="APPLE_PAY",
                           )
 
-                          let callBackFunc = payment => {
-                            let msg =
-                              [
-                                ("applePayProcessPayment", payment.token),
-                                ("applePayBillingContact", payment.billingContact),
-                                ("applePayShippingContact", payment.shippingContact),
-                              ]->Dict.fromArray
-                            applePayEvent.source->Window.sendPostMessage(msg)
-                          }
-
-                          ApplePayHelpers.startApplePaySession(
-                            ~paymentRequest,
-                            ~applePaySessionRef,
-                            ~applePayPresent,
-                            ~logger,
-                            ~applePayEvent=Some(applePayEvent),
-                            ~callBackFunc,
-                            ~clientSecret,
-                            ~publishableKey,
-                            ~isTaxCalculationEnabled,
-                          )
+                          let msg = [
+                            ("hyperApplePayButtonClicked", true->JSON.Encode.bool),
+                            ("paymentRequest", paymentRequest),
+                            ("applePayPresent", applePayPresent->Option.getOr(JSON.Encode.null)),
+                            ("clientSecret", clientSecret->JSON.Encode.string),
+                            ("publishableKey", publishableKey->JSON.Encode.string),
+                            ("isTaxCalculationEnabled", isTaxCalculationEnabled->JSON.Encode.bool),
+                            ("sdkSessionId", sdkSessionId->JSON.Encode.string),
+                            ("analyticsMetadata", analyticsMetadata),
+                            ("componentName", componentName->JSON.Encode.string),
+                          ]
+                          messageTopWindow(msg)
                         }
-                      } else {
-                        ()
                       }
                     | _ => ()
+                    }
+
+                    if dict->Dict.get("applePayPaymentToken")->Option.isSome {
+                      let token = dict->getJsonFromDict("applePayPaymentToken", JSON.Encode.null)
+                      let billingContact =
+                        dict->getJsonFromDict("applePayBillingContact", JSON.Encode.null)
+                      let shippingContact =
+                        dict->getJsonFromDict("applePayShippingContact", JSON.Encode.null)
+
+                      let msg =
+                        [
+                          ("applePayPaymentToken", token),
+                          ("applePayBillingContact", billingContact),
+                          ("applePayShippingContact", shippingContact),
+                        ]->Dict.fromArray
+
+                      handleApplePayIframePostMessage(msg, componentName, mountedIframeRef)
+                    }
+
+                    if dict->Dict.get("showApplePayButton")->Option.isSome {
+                      let msg = [("showApplePayButton", true->JSON.Encode.bool)]->Dict.fromArray
+
+                      handleApplePayIframePostMessage(msg, componentName, mountedIframeRef)
                     }
                   }
 

--- a/src/orca-loader/Hyper.res
+++ b/src/orca-loader/Hyper.res
@@ -60,6 +60,80 @@ let preloader = () => {
   preloadFile(~type_="script", ~href="https://js.braintreegateway.com/web/3.88.4/js/client.min.js")
 }
 
+let handleHyperApplePayMounted = (event: Types.event) => {
+  open ApplePayTypes
+  let json = event.data->anyTypeToJson
+  let dict = json->getDictFromJson
+  let applePaySessionRef = ref(Nullable.null)
+
+  let componentName = dict->getString("componentName", "payment")
+
+  if dict->Dict.get("hyperApplePayCanMakePayments")->Option.isSome {
+    let msg =
+      [
+        ("applePayCanMakePayments", true->JSON.Encode.bool),
+        ("componentName", componentName->JSON.Encode.string),
+      ]
+      ->Dict.fromArray
+      ->JSON.Encode.object
+    event.source->Window.sendPostMessageJSON(msg)
+  } else if dict->Dict.get("hyperApplePayButtonClicked")->Option.isSome {
+    let paymentRequest = dict->Dict.get("paymentRequest")->Option.getOr(JSON.Encode.null)
+    let applePayPresent = dict->Dict.get("applePayPresent")
+    let clientSecret = dict->getString("clientSecret", "")
+    let publishableKey = dict->getString("publishableKey", "")
+    let isTaxCalculationEnabled = dict->getBool("isTaxCalculationEnabled", false)
+    let sdkSessionId = dict->getString("sdkSessionId", "")
+    let analyticsMetadata = dict->getJsonFromDict("analyticsMetadata", JSON.Encode.null)
+
+    let logger = OrcaLogger.make(
+      ~sessionId=sdkSessionId,
+      ~source=Loader,
+      ~merchantId=publishableKey,
+      ~metadata=analyticsMetadata,
+      ~clientSecret,
+    )
+
+    let callBackFunc = payment => {
+      let msg =
+        [
+          ("applePayPaymentToken", payment.token),
+          ("applePayBillingContact", payment.billingContact),
+          ("applePayShippingContact", payment.shippingContact),
+          ("componentName", componentName->JSON.Encode.string),
+        ]
+        ->Dict.fromArray
+        ->JSON.Encode.object
+      event.source->Window.sendPostMessageJSON(msg)
+    }
+
+    let resolvePromise = _ => {
+      let msg =
+        [
+          ("showApplePayButton", true->JSON.Encode.bool),
+          ("componentName", componentName->JSON.Encode.string),
+        ]
+        ->Dict.fromArray
+        ->JSON.Encode.object
+      event.source->Window.sendPostMessageJSON(msg)
+    }
+
+    ApplePayHelpers.startApplePaySession(
+      ~paymentRequest,
+      ~applePaySessionRef,
+      ~applePayPresent,
+      ~logger,
+      ~callBackFunc,
+      ~clientSecret,
+      ~publishableKey,
+      ~isTaxCalculationEnabled,
+      ~resolvePromise,
+    )
+  }
+}
+
+addSmartEventListener("message", handleHyperApplePayMounted, "onHyperApplePayMount")
+
 let make = (publishableKey, options: option<JSON.t>, analyticsInfo: option<JSON.t>) => {
   try {
     let isPreloadEnabled =

--- a/src/orca-loader/PaymentSessionMethods.res
+++ b/src/orca-loader/PaymentSessionMethods.res
@@ -194,6 +194,7 @@ let getCustomerSavedPaymentMethods = (
         ~callBackFunc=processPayment,
         ~clientSecret,
         ~publishableKey,
+        ~resolvePromise,
       )
     }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Implemented support for initiating an ApplePay session within an iframe, provided that a HyperLoader script is present at the parent level.

## How did you test it?

- [x] Test ApplePay inside an iframe with HyperLoader script
- [x] Test with Cancelling ApplePay Payment inside an iframe
- [x] Test ApplePay inside an iframe without HyperLoader script
- [x] Test ApplePay at top level
- [x] Test with Cancelling ApplePay payment
- [x] Test ApplePay with Express Checkout Element and PaymentElement
- [x] Test ApplePay Headless

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
