### PR TITLE
fix: extra scroll in safari

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -524,7 +524,7 @@ let make = (
                 | Email => <EmailPaymentInput paymentType />
                 | PhoneNumber => <PhoneNumberPaymentInput />
                 | StateAndCity =>
-                  <div className={`flex ${isSpacedInnerLayout ? "gap-4" : ""}`}>
+                  <div className={`flex ${isSpacedInnerLayout ? "gap-4" : ""} overflow-hidden`}>
                     <PaymentField
                       fieldName=localeString.cityLabel
                       setValue={setCity}


### PR DESCRIPTION
## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When billing details are rendered then an extra horizontal scroll bar was observed in safari.

Before:

https://github.com/user-attachments/assets/13c99d79-3b8f-44c7-8217-a9e07a87e2dc

After:

https://github.com/user-attachments/assets/8f7a1a98-c4d6-4ffc-89b9-0d2c6fe6f587

## How did you test it?

Tested via rendering the SDK in safari

## Checklist

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
