### PR TITLE
fix: add text overflow with ellipsis in dropdown

### DIFF
--- a/src/Components/DropdownField.res
+++ b/src/Components/DropdownField.res
@@ -119,6 +119,7 @@ let make = (
             background: disabled ? disbaledBG : themeObj.colorBackground,
             opacity: disabled ? "35%" : "",
             padding: themeObj.spacingUnit,
+            paddingRight: "22px",
             width: "100%",
           }
           name=""
@@ -126,7 +127,7 @@ let make = (
           disabled={readOnly || disabled}
           onChange=handleChange
           onFocus=handleFocus
-          className={`${inputClassStyles} ${className} w-full appearance-none outline-none ${cursorClass}`}>
+          className={`${inputClassStyles} ${className} w-full appearance-none outline-none overflow-hidden whitespace-nowrap text-ellipsis ${cursorClass}`}>
           {options
           ->Array.mapWithIndex((item, index) => {
             <option key={Int.toString(index)} value=item.value>

--- a/src/Components/PaymentDropDownField.res
+++ b/src/Components/PaymentDropDownField.res
@@ -88,7 +88,7 @@ let make = (
           style={
             background: disabled ? disbaledBG : themeObj.colorBackground,
             opacity: disabled ? "35%" : "",
-            padding: "11px 20px 11px 11px",
+            padding: "11px 22px 11px 11px",
             width: "100%",
           }
           name=""
@@ -96,7 +96,7 @@ let make = (
           disabled={readOnly || disabled}
           onFocus={handleFocus}
           onChange=handleChange
-          className={`${inputClassStyles} ${inputClass} ${className} w-full appearance-none outline-none ${cursorClass}`}>
+          className={`${inputClassStyles} ${inputClass} ${className} w-full appearance-none outline-none overflow-hidden whitespace-nowrap text-ellipsis ${cursorClass}`}>
           {options
           ->Array.mapWithIndex((item: string, i) => {
             <option key={Int.toString(i)} value=item> {React.string(item)} </option>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When billing details are rendered then text inside the dropdown is overflowing 

Before:
![Screenshot 2024-10-15 at 2 39 52 PM](https://github.com/user-attachments/assets/743125a0-2b87-42b4-9c51-b34e9e54f834)
<img width="687" alt="Screenshot 2024-10-21 at 4 33 52 PM" src="https://github.com/user-attachments/assets/306d2510-1144-4abf-ab60-2a703b084411">

After:
<img width="445" alt="Screenshot 2024-10-21 at 4 13 59 PM" src="https://github.com/user-attachments/assets/2abf1669-c6f6-4a02-985a-9732ba16bcf9">
<img width="440" alt="Screenshot 2024-10-21 at 4 14 23 PM" src="https://github.com/user-attachments/assets/d0b01f61-87bc-4c37-b315-aa8378082b7b">

## How did you test it?
Tested via rendering the SDK in safari and chrome

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
