### PR TITLE
fix: remove contact and password icon in safari

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,9 @@
     outline: transparent !important;
   }
 }
+
+/* Remove contact and password icon in safari */
+input::-webkit-credentials-auto-fill-button,
+input::-webkit-contacts-auto-fill-button {
+  width: 0 !important;
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Contact/Password icon appears in the input field when using safari browser.
So, to remove those icons I followed this reference -> https://stackoverflow.com/questions/38663578/how-to-hide-autofill-safari-icon-in-input-field

Before:
text input (using `type_="text"`)
<img width="1082" alt="Screenshot 2024-10-22 at 4 36 37 PM" src="https://github.com/user-attachments/assets/3bd3e02d-8b5a-4c9e-a551-8d00f08b4c68">

password input (using `type_="password"`)
<img width="749" alt="Screenshot 2024-10-23 at 4 43 24 PM" src="https://github.com/user-attachments/assets/6260dcc2-4cde-4502-82f5-25c1593faedf">

After:
<img width="1182" alt="Screenshot 2024-10-23 at 4 47 38 PM" src="https://github.com/user-attachments/assets/240edf09-f0b0-4965-9506-a06b6ffe9f33">

## How did you test it?

Tested via rendering the SDK in firefox ,safari and chrome

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
