### PR TITLE
fix: remove blue border of iframe in firefox

### DIFF
--- a/src/ThreeDSAuth.res
+++ b/src/ThreeDSAuth.res
@@ -145,7 +145,13 @@ let make = () => {
     <div className="backdrop-blur-xl">
       <div id="threeDsAuthDiv" className="hidden" />
       <iframe
-        id="threeDsAuthFrame" name="threeDsAuthFrame" style={minHeight: "500px"} width="100%"
+        id="threeDsAuthFrame"
+        name="threeDsAuthFrame"
+        style={
+          minHeight: "500px",
+          outline: "none",
+        }
+        width="100%"
       />
     </div>
   </Modal>

--- a/src/ThreeDSMethod.res
+++ b/src/ThreeDSMethod.res
@@ -140,6 +140,7 @@ let make = () => {
       name="threeDsInvisibleIframe"
       className="h-96 invisible"
       ref={divRef->ReactDOM.Ref.domRef}
+      style={outline: "none"}
       onLoad={handleOnLoad}
     />
   </>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,14 @@
+/* Remove blue outline of input, button in firefox */
+@-moz-document url-prefix() {
+  *:focus,
+  *:focus-visible,
+  *:focus-within,
+  *:active,
+  *:visited {
+    outline: none !important;
+  }
+}
+
 /* Remove contact and password icon in safari */
 input::-webkit-credentials-auto-fill-button,
 input::-webkit-contacts-auto-fill-button {

--- a/src/orca-loader/Elements.res
+++ b/src/orca-loader/Elements.res
@@ -72,6 +72,7 @@ let make = (
               name="orca-payment-element-iframeRef-${localSelectorString}"
               src="${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=${componentType}&publishableKey=${publishableKey}&clientSecret=${clientSecret}&sessionId=${sdkSessionId}&endpoint=${endpoint}&merchantHostname=${merchantHostname}&customPodUri=${customPodUri}"              allow="*"
               name="orca-payment"
+              style="outline: none;"
             ></iframe>
           </div>`
         let iframeDiv = Window.createElement("div")

--- a/src/orca-loader/LoaderPaymentElement.res
+++ b/src/orca-loader/LoaderPaymentElement.res
@@ -385,7 +385,7 @@ let make = (
           src="${ApiEndpoint.sdkDomainUrl}/index.html?componentName=${componentType}"
           allow="payment *"
           name="orca-payment"
-          style="border: 0px; ${additionalIframeStyle}"
+          style="border: 0px; ${additionalIframeStyle} outline: none;"
           width="100%"
         ></iframe>
         </div>`

--- a/src/orca-loader/PaymentMethodsManagementElements.res
+++ b/src/orca-loader/PaymentMethodsManagementElements.res
@@ -56,6 +56,7 @@ let make = (
           src="${ApiEndpoint.sdkDomainUrl}/index.html?fullscreenType=${componentType}&publishableKey=${publishableKey}&ephemeralKey=${ephemeralKey}&sessionId=${sdkSessionId}&endpoint=${endpoint}&hyperComponentName=${hyperComponentName->getStrFromHyperComponentName}"
           allow="*"
           name="orca-payment"
+          style="outline: none;"
         ></iframe>
         </div>`
         let iframeDiv = Window.createElement("div")


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
When clicking on the button, or active iframe in Firefox, a blue border appears. This is caused by default browser behavior.
To resolve this, I have made every tags outline none when they are in focus and active state. The CSS change is applied specifically for Firefox to avoid affecting other browsers. For iframe, I have added inline styles as other ways of adding styles were not working.

Before:

https://github.com/user-attachments/assets/7ce64e1d-fde3-4b94-b209-e4ba470ceaca


After:

https://github.com/user-attachments/assets/7fc70ed4-838f-4c27-8f22-0049f60182aa


## How did you test it?

Tested via rendering the SDK in firefox, safari and chrome. (Also used ngrok for temporary deployment)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible


