### PR TITLE
fix: card brand update to prevent multiple error messages

### DIFF
--- a/src/Payment.res
+++ b/src/Payment.res
@@ -334,10 +334,11 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       ""
     } else if isCardSupported->Option.getOr(true) {
       localeString.inValidCardErrorText
-    } else if cardBrand == "" {
-      localeString.enterValidCardNumberErrorText
     } else {
-      localeString.cardBrandConfiguredErrorText(cardBrand)
+      switch cardNumber->CardUtils.getCardBrand {
+      | "" => localeString.inValidCardErrorText
+      | cardBrand_ => localeString.cardBrandConfiguredErrorText(cardBrand_)
+      }
     }
     setCardError(_ => cardError)
     None


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Card brand was not updating, leading to different error messages.

Before:

https://github.com/user-attachments/assets/cfc47542-5fce-4dc0-9cb6-9aefa4097b7b


After:

https://github.com/user-attachments/assets/d64d720c-cd2c-42cf-aa81-2471c6c5375c



## How did you test it?

Tested via rendering the SDK in chrome.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
