### PR TITLE
refactor: replace if statements with switch in cardError code

### DIFF
--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -675,3 +675,13 @@ let getEligibleCoBadgedCardSchemes = (~matchedCardSchemes, ~enabledCardSchemes) 
 let getCardBrandFromStates = (cardBrand, cardScheme, showFields) => {
   !showFields ? cardScheme : cardBrand
 }
+
+let getCardBrandInvalidError = (
+  ~cardNumber,
+  ~localeString: OrcaPaymentPage.LocaleStringTypes.localeStrings,
+) => {
+  switch cardNumber->getCardBrand {
+  | "" => localeString.enterValidCardNumberErrorText
+  | cardBrandValue => localeString.cardBrandConfiguredErrorText(cardBrandValue)
+  }
+}

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -328,25 +328,17 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   }, (cardNumber, cvcNumber, cardExpiry, isCVCValid, isExpiryValid, isCardValid))
 
   React.useEffect(() => {
-    let cardError = if isCardValid == None || cardNumber->String.length == 0 {
-      ""
-    } else {
-      let isCardSupportedValue = isCardSupported->Option.getOr(true)
-      let isCardValidValue = isCardValid->Option.getOr(false)
-
-      if isCardSupportedValue && isCardValidValue {
-        ""
-      } else if isCardSupportedValue {
-        localeString.inValidCardErrorText
-      } else {
-        let cardBrand = cardNumber->CardUtils.getCardBrand
-        if cardBrand == "" {
-          localeString.enterValidCardNumberErrorText
-        } else {
-          localeString.cardBrandConfiguredErrorText(cardBrand)
-        }
-      }
+    let cardError = switch (
+      isCardSupported->Option.getOr(true),
+      isCardValid->Option.getOr(true),
+      cardNumber->String.length == 0,
+    ) {
+    | (_, _, true) => ""
+    | (true, true, _) => ""
+    | (true, _, _) => localeString.inValidCardErrorText
+    | (_, _, _) => CardUtils.getCardBrandInvalidError(~cardNumber, ~localeString)
     }
+    let cardError = isCardValid->Option.isSome ? cardError : ""
     setCardError(_ => cardError)
     None
   }, [isCardValid, isCardSupported])

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -328,20 +328,23 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   }, (cardNumber, cvcNumber, cardExpiry, isCVCValid, isExpiryValid, isCardValid))
 
   React.useEffect(() => {
-    let cardError = switch (
-      isCardValid,
-      isCardSupported->Option.getOr(true),
-      isCardValid->Option.getOr(true),
-      cardNumber->String.length == 0,
-    ) {
-    | (None, _, _, _) => ""
-    | (_, _, _, true) => ""
-    | (_, true, true, _) => ""
-    | (_, true, _, _) => localeString.inValidCardErrorText
-    | (_, _, _, _) =>
-      switch cardNumber->CardUtils.getCardBrand {
-      | "" => localeString.inValidCardErrorText
-      | cardBrandValue => localeString.cardBrandConfiguredErrorText(cardBrandValue)
+    let cardError = if isCardValid == None || cardNumber->String.length == 0 {
+      ""
+    } else {
+      let isCardSupportedValue = isCardSupported->Option.getOr(true)
+      let isCardValidValue = isCardValid->Option.getOr(false)
+
+      if isCardSupportedValue && isCardValidValue {
+        ""
+      } else if isCardSupportedValue {
+        localeString.inValidCardErrorText
+      } else {
+        let cardBrand = cardNumber->CardUtils.getCardBrand
+        if cardBrand == "" {
+          localeString.enterValidCardNumberErrorText
+        } else {
+          localeString.cardBrandConfiguredErrorText(cardBrand)
+        }
       }
     }
     setCardError(_ => cardError)

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -328,13 +328,17 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   }, (cardNumber, cvcNumber, cardExpiry, isCVCValid, isExpiryValid, isCardValid))
 
   React.useEffect(() => {
-    let cardError = if isCardValid == None || cardNumber->String.length == 0 {
-      ""
-    } else if isCardSupported->Option.getOr(true) && isCardValid->Option.getOr(true) {
-      ""
-    } else if isCardSupported->Option.getOr(true) {
-      localeString.inValidCardErrorText
-    } else {
+    let cardError = switch (
+      isCardValid,
+      isCardSupported->Option.getOr(true),
+      isCardValid->Option.getOr(true),
+      cardNumber->String.length == 0,
+    ) {
+    | (None, _, _, _) => ""
+    | (_, _, _, true) => ""
+    | (_, true, true, _) => ""
+    | (_, true, _, _) => localeString.inValidCardErrorText
+    | (_, _, _, _) =>
       switch cardNumber->CardUtils.getCardBrand {
       | "" => localeString.inValidCardErrorText
       | cardBrandValue => localeString.cardBrandConfiguredErrorText(cardBrandValue)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

replaced if statements with switch in cardError code.


## How did you test it?

By compiling code and also via rendering the SDK in chrome.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
