### PR TITLE
fix: paze express checkout for multiple iframe

### DIFF
--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1435,7 +1435,7 @@ let mergeAndFlattenToTuples = (body, requiredFieldsBody) =>
   ->mergeTwoFlattenedJsonDicts(requiredFieldsBody)
   ->getArrayOfTupleFromDict
 
-let sendMessageToIframe = (~msg, ~componentName, ~eventSource=None, ~mountedIframeRef=None) => {
+let handleIframePostMessage = (msg, componentName, sendFallbackMessage) => {
   let isMessageSent = ref(false)
   let iframes = Window.querySelectorAll("iframe")
 
@@ -1448,18 +1448,14 @@ let sendMessageToIframe = (~msg, ~componentName, ~eventSource=None, ~mountedIfra
   })
 
   if !isMessageSent.contents {
-    switch (eventSource, mountedIframeRef) {
-    | (Some(source), _) => source->Window.sendPostMessage(msg)
-    | (None, Some(ref)) => ref->Window.iframePostMessage(msg)
-    | (None, None) => ()
-    }
+    sendFallbackMessage()
   }
 }
 
 let handleApplePayIframePostMessage = (msg, componentName, mountedIframeRef) => {
-  sendMessageToIframe(~msg, ~componentName, ~mountedIframeRef=Some(mountedIframeRef))
+  handleIframePostMessage(msg, componentName, _ => mountedIframeRef->Window.iframePostMessage(msg))
 }
 
-let handlePazeIframePostMessage = (msg, componentName, eventSource) => {
-  sendMessageToIframe(~msg, ~componentName, ~eventSource=Some(eventSource))
+let handlePazeIframePostMessage = (msg, componentName, source) => {
+  handleIframePostMessage(msg, componentName, _ => source->Window.sendPostMessage(msg))
 }

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1435,7 +1435,7 @@ let mergeAndFlattenToTuples = (body, requiredFieldsBody) =>
   ->mergeTwoFlattenedJsonDicts(requiredFieldsBody)
   ->getArrayOfTupleFromDict
 
-let handleIframePostMessage = (~msg, ~componentName, ~sendFallbackMessage) => {
+let handleIframePostMessageForWallets = (msg, componentName, mountedIframeRef) => {
   let isMessageSent = ref(false)
   let iframes = Window.querySelectorAll("iframe")
 
@@ -1448,16 +1448,6 @@ let handleIframePostMessage = (~msg, ~componentName, ~sendFallbackMessage) => {
   })
 
   if !isMessageSent.contents {
-    sendFallbackMessage()
+    mountedIframeRef->Window.iframePostMessage(msg)
   }
 }
-
-let handleApplePayIframePostMessage = (msg, componentName, mountedIframeRef) =>
-  handleIframePostMessage(~msg, ~componentName, ~sendFallbackMessage=_ =>
-    mountedIframeRef->Window.iframePostMessage(msg)
-  )
-
-let handlePazeIframePostMessage = (msg, componentName, source) =>
-  handleIframePostMessage(~msg, ~componentName, ~sendFallbackMessage=_ =>
-    source->Window.sendPostMessage(msg)
-  )

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1435,7 +1435,7 @@ let mergeAndFlattenToTuples = (body, requiredFieldsBody) =>
   ->mergeTwoFlattenedJsonDicts(requiredFieldsBody)
   ->getArrayOfTupleFromDict
 
-let handleIframePostMessage = (msg, componentName, sendFallbackMessage) => {
+let handleIframePostMessage = (~msg, ~componentName, ~sendFallbackMessage) => {
   let isMessageSent = ref(false)
   let iframes = Window.querySelectorAll("iframe")
 
@@ -1452,10 +1452,12 @@ let handleIframePostMessage = (msg, componentName, sendFallbackMessage) => {
   }
 }
 
-let handleApplePayIframePostMessage = (msg, componentName, mountedIframeRef) => {
-  handleIframePostMessage(msg, componentName, _ => mountedIframeRef->Window.iframePostMessage(msg))
-}
+let handleApplePayIframePostMessage = (msg, componentName, mountedIframeRef) =>
+  handleIframePostMessage(~msg, ~componentName, ~sendFallbackMessage=_ =>
+    mountedIframeRef->Window.iframePostMessage(msg)
+  )
 
-let handlePazeIframePostMessage = (msg, componentName, source) => {
-  handleIframePostMessage(msg, componentName, _ => source->Window.sendPostMessage(msg))
-}
+let handlePazeIframePostMessage = (msg, componentName, source) =>
+  handleIframePostMessage(~msg, ~componentName, ~sendFallbackMessage=_ =>
+    source->Window.sendPostMessage(msg)
+  )

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -129,13 +129,15 @@ let make = (
       }
     }
 
-    let onPazeCallback = (event: Types.event) => {
-      let json = event.data->Identity.anyTypeToJson
-      let dict = json->getDictFromJson
-      if dict->getBool("isPaze", false) {
-        let componentName = dict->getString("componentName", "payment")
-        let msg = [("data", json)]->Dict.fromArray
-        handlePazeIframePostMessage(msg, componentName, event.source)
+    let onPazeCallback = mountedIframeRef => {
+      (event: Types.event) => {
+        let json = event.data->Identity.anyTypeToJson
+        let dict = json->getDictFromJson
+        if dict->getBool("isPaze", false) {
+          let componentName = dict->getString("componentName", "payment")
+          let msg = [("data", json)]->Dict.fromArray
+          handleIframePostMessageForWallets(msg, componentName, mountedIframeRef)
+        }
       }
     }
 
@@ -148,7 +150,7 @@ let make = (
           isTaxCalculationEnabled.contents =
             dict->getDictFromDict("response")->getBool("is_tax_calculation_enabled", false)
           addSmartEventListener("message", onPlaidCallback(mountedIframeRef), "onPlaidCallback")
-          addSmartEventListener("message", onPazeCallback, "onPazeCallback")
+          addSmartEventListener("message", onPazeCallback(mountedIframeRef), "onPazeCallback")
 
           let json = dict->getJsonFromDict("response", JSON.Encode.null)
           let isApplePayPresent = PaymentMethodsRecord.getPaymentMethodTypeFromList(
@@ -401,7 +403,7 @@ let make = (
               try {
                 let msg = [("applePayCanMakePayments", true->JSON.Encode.bool)]->Dict.fromArray
 
-                handleApplePayIframePostMessage(msg, componentName, mountedIframeRef)
+                handleIframePostMessageForWallets(msg, componentName, mountedIframeRef)
               } catch {
               | exn => {
                   let exnString = exn->anyTypeToJson->JSON.stringify
@@ -895,13 +897,13 @@ let make = (
                           ("applePayShippingContact", shippingContact),
                         ]->Dict.fromArray
 
-                      handleApplePayIframePostMessage(msg, componentName, mountedIframeRef)
+                      handleIframePostMessageForWallets(msg, componentName, mountedIframeRef)
                     }
 
                     if dict->Dict.get("showApplePayButton")->Option.isSome {
                       let msg = [("showApplePayButton", true->JSON.Encode.bool)]->Dict.fromArray
 
-                      handleApplePayIframePostMessage(msg, componentName, mountedIframeRef)
+                      handleIframePostMessageForWallets(msg, componentName, mountedIframeRef)
                     }
                   }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

So need to fix one issue in the express checkout. It was throwing this error when I tried to combine two functions - `handleApplePayIframePostMessage` & `handlePazeIframePostMessage`

```
caml_option.js:24 Uncaught SecurityError: An attempt was made to break through the security policy of the user agent. at Module.handlePazeIframePostMessage (VM26169 Utils.bs.js:1367:170) at onPazeCallback (Elements.bs.js:118:7)
```


## How did you test it?

Reverted back and made some changes started working.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
