### PR TITLE
chore: added validations for card holder name

### DIFF
--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -152,4 +152,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `مفتاح Pix لا يمكن أن يكون فارغًا`,
   pixKeyPlaceholder: `أدخل مفتاح Pix`,
   pixKeyLabel: `مفتاح Pix`,
+  invalidCardHolderNameError: `اسم حامل البطاقة لا يمكن أن يحتوي على أرقام`,
+  invalidNickNameError: `لا يمكن أن يحتوي الاسم المستعار على أكثر من رقمين`,
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -151,4 +151,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `La clau Pix no pot estar buida`,
   pixKeyPlaceholder: `Introdueix la clau Pix`,
   pixKeyLabel: `Clau Pix`,
+  invalidCardHolderNameError: `El nom del titular de la targeta no pot contenir dígits`,
+  invalidNickNameError: `El sobrenom no pot contenir més de 2 dígits`,
 }

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -149,4 +149,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Pix 密钥不能为空`,
   pixKeyPlaceholder: `输入 Pix 密钥`,
   pixKeyLabel: `Pix 密钥`,
+  invalidCardHolderNameError: `持卡人姓名不能包含数字`,
+  invalidNickNameError: `昵称不能包含超过2个数字`,
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -150,4 +150,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Pix-Schlüssel darf nicht leer sein`,
   pixKeyPlaceholder: `Geben Sie den Pix-Schlüssel ein`,
   pixKeyLabel: `Pix-Schlüssel`,
+  invalidCardHolderNameError: `Der Name des Karteninhabers darf keine Ziffern enthalten`,
+  invalidNickNameError: `Der Spitzname darf nicht mehr als 2 Ziffern enthalten`,
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -149,4 +149,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Pix-sleutel mag niet leeg zijn`,
   pixKeyPlaceholder: `Voer Pix-sleutel in`,
   pixKeyLabel: `Pix-sleutel`,
+  invalidCardHolderNameError: `De naam van de kaarthouder mag geen cijfers bevatten`,
+  invalidNickNameError: `De bijnaam mag niet meer dan 2 cijfers bevatten`,
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -149,4 +149,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Pix key cannot be empty`,
   pixKeyPlaceholder: `Enter Pix key`,
   pixKeyLabel: `Pix key`,
+  invalidCardHolderNameError: `Cardholder's name cannot contain digits`,
+  invalidNickNameError: `Nickname cannot have more than 2 digits`,
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -149,4 +149,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Pix key cannot be empty`,
   pixKeyPlaceholder: `Enter Pix key`,
   pixKeyLabel: `Pix key`,
+  invalidCardHolderNameError: `Card Holder's name cannot have digits`,
+  invalidNickNameError: `Nickname cannot have more than 2 digits`,
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -151,4 +151,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `La clé Pix ne peut pas être vide`,
   pixKeyPlaceholder: `Entrez la clé Pix`,
   pixKeyLabel: `Clé Pix`,
+  invalidCardHolderNameError: `Le nom du titulaire de la carte ne peut pas contenir de chiffres`,
+  invalidNickNameError: `Le surnom ne peut pas contenir plus de 2 chiffres`,
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -151,4 +151,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `La clé Pix ne peut pas être vide`,
   pixKeyPlaceholder: `Entrez la clé Pix`,
   pixKeyLabel: `Clé Pix`,
+  invalidCardHolderNameError: `Le nom du titulaire de la carte ne peut pas contenir de chiffres`,
+  invalidNickNameError: `Le surnom ne peut pas contenir plus de 2 chiffres`,
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -150,4 +150,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `מפתח Pix לא יכול להיות ריק`,
   pixKeyPlaceholder: `הכנס מפתח Pix`,
   pixKeyLabel: `מפתח Pix`,
+  invalidCardHolderNameError: `שם בעל הכרטיס לא יכול לכלול ספרות`,
+  invalidNickNameError: `הכינוי לא יכול לכלול יותר משתי ספרות`,
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -151,4 +151,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `La chiave Pix non può essere vuota`,
   pixKeyPlaceholder: `Inserisci la chiave Pix`,
   pixKeyLabel: `Chiave Pix`,
+  invalidCardHolderNameError: `Il nome del titolare della carta non può contenere cifre`,
+  invalidNickNameError: `Il soprannome non può contenere più di 2 cifre`,
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -150,4 +150,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Pixキーは空にできません`,
   pixKeyPlaceholder: `Pixキーを入力`,
   pixKeyLabel: `Pixキー`,
+  invalidCardHolderNameError: `カード所有者の名前に数字を含めることはできません`,
+  invalidNickNameError: `ニックネームには2つ以上の数字を含めることはできません`,
 }

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -141,6 +141,8 @@ type localeStrings = {
   pixKeyEmptyText: string,
   pixKeyLabel: string,
   pixKeyPlaceholder: string,
+  invalidCardHolderNameError: string,
+  invalidNickNameError: string,
 }
 
 type constantStrings = {

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -150,4 +150,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Klucz Pix nie może być pusty`,
   pixKeyPlaceholder: `Wprowadź klucz Pix`,
   pixKeyLabel: `Klucz Pix`,
+  invalidCardHolderNameError: `Imię posiadacza karty nie może zawierać cyfr`,
+  invalidNickNameError: `Pseudonim nie może zawierać więcej niż 2 cyfry`,
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -150,4 +150,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `A chave Pix não pode estar vazia`,
   pixKeyPlaceholder: `Digite a chave Pix`,
   pixKeyLabel: `Chave Pix`,
+  invalidCardHolderNameError: `O nome do titular do cartão não pode conter dígitos`,
+  invalidNickNameError: `O apelido não pode conter mais de 2 dígitos`,
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -158,4 +158,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Ключ Pix не может быть пустым`,
   pixKeyPlaceholder: `Введите ключ Pix`,
   pixKeyLabel: `Ключ Pix`,
+  invalidCardHolderNameError: `Имя владельца карты не может содержать цифры`,
+  invalidNickNameError: `Псевдоним не может содержать более 2 цифр`,
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -150,4 +150,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `La clave Pix no puede estar vacía`,
   pixKeyPlaceholder: `Introduce la clave Pix`,
   pixKeyLabel: `Clave Pix`,
+  invalidCardHolderNameError: `El nombre del titular de la tarjeta no puede contener dígitos`,
+  invalidNickNameError: `El apodo no puede contener más de 2 dígitos`,
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -149,4 +149,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   pixKeyEmptyText: `Pix-nyckel kan inte vara tom`,
   pixKeyPlaceholder: `Ange Pix-nyckel`,
   pixKeyLabel: `Pix-nyckel`,
+  invalidCardHolderNameError: `Kortinnehavarens namn får inte innehålla siffror`,
+  invalidNickNameError: `Smeknamnet får inte innehålla mer än 2 siffror`,
 }

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -167,7 +167,9 @@ let useRequiredFieldsEmptyAndValid = (
       acc &&
       switch paymentMethodFields {
       | Email => email.isValid->Option.getOr(false)
-      | FullName => checkIfNameIsValid(requiredFields, paymentMethodFields, fullName)
+      | FullName =>
+        checkIfNameIsValid(requiredFields, paymentMethodFields, fullName) &&
+        fullName.isValid->Option.getOr(false)
       | Country => country !== "" || countryNames->Array.length === 0
       | AddressCountry(countryArr) => country !== "" || countryArr->Array.length === 0
       | BillingName => checkIfNameIsValid(requiredFields, paymentMethodFields, billingName)


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added validations for card holder name :- 
- card holder name cannot have digits

## How did you test it?

Tested via passing card holder name with digits and SDK throws an error

## Checklist

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
