### PR TITLE
chore: added suport for adding email address in paze

### DIFF
--- a/src/Payments/PazeTypes.res
+++ b/src/Payments/PazeTypes.res
@@ -36,8 +36,9 @@ type complete = {
   transactionValue: transactionValue,
 }
 
+type canCheckoutReturnType = {consumerPresent: bool}
 type digitalWalletSdk = {
-  canCheckout: canCheckout => promise<JSON.t>,
+  canCheckout: canCheckout => promise<canCheckoutReturnType>,
   checkout: checkout => promise<JSON.t>,
   complete: complete => promise<JSON.t>,
   initialize: initialize => promise<JSON.t>,

--- a/src/Payments/PazeWallet.res
+++ b/src/Payments/PazeWallet.res
@@ -41,12 +41,12 @@ let make = () => {
 
               Console.log2("PAZE --- init completed", val)
 
-              let consumerPresent = await digitalWalletSdk.canCheckout({
+              let canCheckout = await digitalWalletSdk.canCheckout({
                 emailAddress: emailAddress,
               })
 
               Console.log("PAZE --- canCheckout completed")
-              Console.log2("PAZE --- consumerPresent: ", consumerPresent)
+              Console.log2("PAZE --- canCheckout: ", canCheckout.consumerPresent)
 
               let transactionValue = {
                 transactionAmount,
@@ -61,7 +61,7 @@ let make = () => {
 
               let checkoutResponse = await digitalWalletSdk.checkout({
                 acceptedPaymentCardNetworks: ["VISA", "MASTERCARD"],
-                emailAddress,
+                emailAddress: canCheckout.consumerPresent ? emailAddress : "",
                 sessionId,
                 actionCode: "START_FLOW",
                 transactionValue,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When email is not present with paze. We will send an empty emailAddress so customer can enter it's own email via paze.

## How did you test it?

Via locally sending empty email address

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
