### PR TITLE
chore: added prod env in samsung pay always

### DIFF
--- a/src/Payment.res
+++ b/src/Payment.res
@@ -11,14 +11,13 @@ let setUserError = message => {
 @react.component
 let make = (~paymentMode, ~integrateError, ~logger) => {
   let {localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-  let keys = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let cardScheme = Recoil.useRecoilValueFromAtom(cardBrand)
   let showFields = Recoil.useRecoilValueFromAtom(showCardFieldsAtom)
   let selectedOption = Recoil.useRecoilValueFromAtom(selectedOptionAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let paymentToken = Recoil.useRecoilValueFromAtom(paymentTokenAtom)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
-  let {iframeId} = keys
 
   let (cardNumber, setCardNumber) = React.useState(_ => "")
   let (cardExpiry, setCardExpiry) = React.useState(_ => "")

--- a/src/Payments/SamsungPayComponent.res
+++ b/src/Payments/SamsungPayComponent.res
@@ -24,7 +24,7 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
 
   let getSamsungPaymentsClient = _ =>
     SamsungPayType.samsung({
-      environment: publishableKey->String.startsWith("pk_prd_") ? "PRODUCTION" : "STAGE",
+      environment: "PRODUCTION",
     })
 
   let onSamsungPaymentButtonClick = _ => {

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -1162,9 +1162,7 @@ let make = (
 
                   try {
                     let samsungPayClient = SamsungPayType.samsung({
-                      environment: publishableKey->String.startsWith("pk_prd_")
-                        ? "PRODUCTION"
-                        : "STAGE",
+                      environment: "PRODUCTION",
                     })
                     samsungPayClient.isReadyToPay(payRequest)
                     ->then(res => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added Prod in Samsung Pay always

## How did you test it?

Via demo store

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
