### PR TITLE
chore: loader after closing paze full screen iframe

### DIFF
--- a/src/Payments/PazeButton.res
+++ b/src/Payments/PazeButton.res
@@ -45,6 +45,11 @@ let make = (~token: SessionsType.token) => {
       let dict = json->Utils.getDictFromJson->getDictFromDict("data")
       if dict->getBool("isPaze", false) {
         setShowLoader(_ => false)
+        messageParentWindow([
+          ("fullscreen", true->JSON.Encode.bool),
+          ("param", "paymentloader"->JSON.Encode.string),
+          ("iframeId", iframeId->JSON.Encode.string),
+        ])
         if dict->getOptionString("completeResponse")->Option.isSome {
           let completeResponse = dict->getString("completeResponse", "")
           intent(


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Added full screen loader after paze modal gets closed

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
tested via demo store

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
