### PR TITLE
chore: emitting expiry via saved cards screen

### DIFF
--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -701,3 +701,6 @@ let getCardBrandInvalidError = (~cardNumber, ~localeString: LocaleStringTypes.lo
   | cardBrandValue => localeString.cardBrandConfiguredErrorText(cardBrandValue)
   }
 }
+
+let emitExpiryDate = formattedExpiry =>
+  Utils.messageParentWindow([("expiryDate", formattedExpiry->JSON.Encode.string)])

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -72,15 +72,26 @@ let make = (
     | None => ()
     }
   }
-  React.useEffect(() => {
-    isActive ? focusCVC() : ()
-    None
-  }, [isActive])
 
   let isCard = paymentItem.paymentMethod === "card"
   let isRenderCvv = isCard && paymentItem.requiresCvv
   let expiryMonth = paymentItem.card.expiryMonth
   let expiryYear = paymentItem.card.expiryYear
+
+  React.useEffect(() => {
+    open CardUtils
+
+    if isActive {
+      // * Focus CVC
+      focusCVC()
+
+      // * Sending card expiry to handle cases where the card expires before the use date.
+      `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
+      ->formatCardExpiryNumber
+      ->emitExpiryDate
+    }
+    None
+  }, [isActive])
 
   let expiryDate = Date.fromString(`${expiryYear}-${expiryMonth}`)
   expiryDate->Date.setMonth(expiryDate->Date.getMonth + 1)

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -113,7 +113,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       handleInputFocus(~currentRef=expiryRef, ~destinationRef=cvcRef)
 
       // * Sending card expiry to handle cases where the card expires before the use date.
-      Utils.messageParentWindow([("expiryDate", formattedExpiry->JSON.Encode.string)])
+      emitExpiryDate(formattedExpiry)
     }
     setExpiryValid(formattedExpiry, setIsExpiryValid)
     setCardExpiry(_ => formattedExpiry)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Emitting expiry date from the saved card list.

## How did you test it?
Tested in Hyperswitch-React-Demo-App


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
