### PR TITLE
fix: cartes bancaires logo not appearing in firefox

### DIFF
--- a/public/icons/orca.svg
+++ b/public/icons/orca.svg
@@ -760,7 +760,27 @@ License)
       </clipPath>
     </defs>
   </symbol>
-  <symbol id="cartesbancaires-card" viewBox="0 0 24 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" class="p-Logo p-Logo--md p-CardBrandIcon"><defs><linearGradient id="sjs-ui91768" x1="84.571%" x2="20.485%" y1="-2.163%" y2="100%"><stop offset="0%" stop-color="#002253"></stop><stop offset="24.255%" stop-color="#0082B1"></stop><stop offset="100%" stop-color="#0E9641"></stop></linearGradient><clipPath id="sjs-ui91767" clipPathUnits="userSpaceOnUse"><rect width="24" height="16" fill="#00f" rx="2"></rect></clipPath></defs><g fill="none" fill-rule="evenodd" clip-path="url(#sjs-ui91767)"><path fill="url(#sjs-ui91768)" d="M0 0h32v32H0z"></path><path fill="#FFF" d="M13.06 3.506v4.206h6.714a2.103 2.103 0 0 0 0-4.206H13.06zm-.572 4.206c-.039-.827-.245-1.57-.593-2.2a4.174 4.174 0 0 0-1.65-1.65c-.701-.387-1.541-.599-2.483-.599h-.89c-.941 0-1.78.212-2.482.6a4.174 4.174 0 0 0-1.65 1.65c-.387.7-.6 1.54-.6 2.482 0 .942.213 1.781.6 2.482.387.701.95 1.264 1.65 1.65.701.388 1.54.6 2.483.6h.89c.94 0 1.78-.212 2.482-.6a4.174 4.174 0 0 0 1.65-1.65c.348-.63.554-1.371.593-2.199H7.479v-.566h5.009zm.572.566v4.206h6.714a2.103 2.103 0 0 0 0-4.206H13.06z"></path></g></symbol>
+  <symbol id="cartesbancaires-card" viewBox="0 0 24 16" width="28" height="28" fill="none"
+    xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false"
+    class="p-Logo p-Logo--md p-CardBrandIcon">
+
+    <g clip-path="url(#clip0_1_3)">
+      <rect width="24" height="16" fill="white" />
+      <mask id="mask0_1_3" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0"
+        width="24" height="16">
+        <path
+          d="M22 0H2C0.89543 0 0 0.89543 0 2V14C0 15.1046 0.89543 16 2 16H22C23.1046 16 24 15.1046 24 14V2C24 0.89543 23.1046 0 22 0Z"
+          fill="white" />
+      </mask>
+      <g mask="url(#mask0_1_3)">
+        <path d="M24 0H0V16H24V0Z" fill="#0082B1" />
+        <path
+          d="M13.06 3.506V7.712H19.774C20.3318 7.712 20.8667 7.49043 21.261 7.09605C21.6554 6.70166 21.877 6.16675 21.877 5.609C21.877 5.05125 21.6554 4.51634 21.261 4.12195C20.8667 3.72757 20.3318 3.506 19.774 3.506H13.06ZM12.488 7.712C12.449 6.885 12.243 6.142 11.895 5.512C11.513 4.81632 10.9407 4.24395 10.245 3.862C9.544 3.475 8.704 3.263 7.762 3.263H6.872C5.931 3.263 5.092 3.475 4.39 3.863C3.69432 4.24495 3.12195 4.81732 2.74 5.513C2.353 6.213 2.14 7.053 2.14 7.995C2.14 8.937 2.353 9.776 2.74 10.477C3.127 11.178 3.69 11.741 4.39 12.127C5.091 12.515 5.93 12.727 6.873 12.727H7.763C8.703 12.727 9.543 12.515 10.245 12.127C10.9407 11.745 11.513 11.1727 11.895 10.477C12.243 9.847 12.449 9.106 12.488 8.278H7.479V7.712H12.488ZM13.06 8.278V12.484H19.774C20.3318 12.484 20.8667 12.2624 21.261 11.868C21.6554 11.4737 21.877 10.9388 21.877 10.381C21.877 9.82325 21.6554 9.28834 21.261 8.89395C20.8667 8.49957 20.3318 8.278 19.774 8.278H13.06Z"
+          fill="white" />
+      </g>
+    </g>
+
+  </symbol>
 
   <symbol id="rupay-card" viewBox="0 0 41 10">
     <path
@@ -2483,42 +2503,42 @@ License)
     <defs>
       <style>
         .cls-1 {
-          isolation: isolate;
+        isolation: isolate;
         }
         .cls-2 {
-          fill: url(#linear-gradient);
+        fill: url(#linear-gradient);
         }
         .cls-3 {
-          fill: url(#linear-gradient-2);
+        fill: url(#linear-gradient-2);
         }
         .cls-11,
         .cls-4 {
-          mix-blend-mode: soft-light;
+        mix-blend-mode: soft-light;
         }
         .cls-5 {
-          fill: #e7e6e6;
+        fill: #e7e6e6;
         }
         .cls-6 {
-          fill: url(#linear-gradient-3);
+        fill: url(#linear-gradient-3);
         }
         .cls-7 {
-          fill: url(#linear-gradient-4);
+        fill: url(#linear-gradient-4);
         }
         .cls-8 {
-          mix-blend-mode: multiply;
-          opacity: 0.71;
-          fill: url(#linear-gradient-5);
+        mix-blend-mode: multiply;
+        opacity: 0.71;
+        fill: url(#linear-gradient-5);
         }
         .cls-9 {
-          fill: url(#linear-gradient-6);
+        fill: url(#linear-gradient-6);
         }
         .cls-10 {
-          fill: #1887b2;
-          mix-blend-mode: darken;
-          opacity: 0.57;
+        fill: #1887b2;
+        mix-blend-mode: darken;
+        opacity: 0.57;
         }
         .cls-11 {
-          fill: #fff;
+        fill: #fff;
         }
       </style>
       <linearGradient


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Cartes Bancaires logo was not appearing in firefox.

## How did you test it?
I have tested on Hyperswitch-React-Demo-App
<img width="1442" alt="Screenshot 2024-12-12 at 5 32 05 PM" src="https://github.com/user-attachments/assets/76363125-2a83-4e48-9df1-4d6598c187de" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
