### PR TITLE
fix: samsung pay button rendering fixed

### DIFF
--- a/src/Payments/SamsungPayComponent.res
+++ b/src/Payments/SamsungPayComponent.res
@@ -101,10 +101,11 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
     })
     None
   }, [isRenderSamsungPayButton])
-
-  <div
-    style={height: `${height->Int.toString}px`}
-    id="samsungpay-container"
-    className={`w-full flex flex-row justify-center rounded-md  [&>*]:w-full [&>button]:!bg-contain`}
-  />
+  <RenderIf condition={isRenderSamsungPayButton}>
+    <div
+      style={height: `${height->Int.toString}px`}
+      id="samsungpay-container"
+      className={`w-full flex flex-row justify-center rounded-md  [&>*]:w-full [&>button]:!bg-contain`}
+    />
+  </RenderIf>
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
The parent div of samsung pay button container was rendering when samsung pay was set as never, fixed it

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested via configuring samsung pay and checking it in SDK

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
