### PR TITLE
chore: disable dynamic fields for saved card screen

### DIFF
--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -37,7 +37,6 @@ let make = (
   ~savedCardlength,
   ~cvcProps,
   ~paymentType,
-  ~setRequiredFieldsBody,
 ) => {
   let {themeObj, config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let {hideExpiredPaymentMethods, displayDefaultSavedPaymentIcon} = Recoil.useRecoilValueFromAtom(
@@ -208,14 +207,6 @@ let make = (
                 </div>
               </RenderIf>
               <RenderIf condition={isActive}>
-                <DynamicFields
-                  paymentType
-                  paymentMethod=paymentItem.paymentMethod
-                  paymentMethodType
-                  setRequiredFieldsBody
-                  isSavedCardFlow=true
-                  savedMethod=paymentItem
-                />
                 <Surcharge
                   paymentMethod=paymentItem.paymentMethod
                   paymentMethodType

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -16,7 +16,7 @@ let make = (
   let (showFields, setShowFields) = Recoil.useRecoilState(RecoilAtoms.showCardFieldsAtom)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(RecoilAtoms.areRequiredFieldsValid)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
-  let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
+  let (requiredFieldsBody, _) = React.useState(_ => Dict.make())
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
   let setUserError = message => {
     postFailedSubmitResponse(~errortype="validation_error", ~message)
@@ -60,7 +60,6 @@ let make = (
           savedCardlength
           cvcProps
           paymentType
-          setRequiredFieldsBody
         />
       )
       ->React.array}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removed Dynamic Fields for Saved Card Screen

## How did you test it?

Locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
