### PR TITLE
feat: add functionality for removing any beforeunload listeners once payment form is submitted

### DIFF
--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -324,7 +324,7 @@ let rec intentCall = (
   )
   let handleOpenUrl = url => {
     if isPaymentSession {
-      Window.replaceRootHref(url, shouldUseTopRedirection)
+      Utils.replaceRootHref(url, shouldUseTopRedirection)
     } else {
       openUrl(url)
     }

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -60,6 +60,11 @@ let handleOnConfirmPostMessage = (~targetOrigin="*", ~isOneClick=false) => {
   let message = isOneClick ? "oneClickConfirmTriggered" : "confirmTriggered"
   messageParentWindow([(message, true->JSON.Encode.bool)], ~targetOrigin)
 }
+
+let handleBeforeRedirectPostMessage = (~targetOrigin="*") => {
+  messageTopWindow([("disableBeforeUnloadEventListener", true->JSON.Encode.bool)], ~targetOrigin)
+}
+
 let getOptionString = (dict, key) => {
   dict->Dict.get(key)->Option.flatMap(JSON.Decode.string)
 }
@@ -1455,5 +1460,28 @@ let isDigitLimitExceeded = (val, ~digit) => {
   switch val->String.match(%re("/\d/g")) {
   | Some(matches) => matches->Array.length > digit
   | None => false
+  }
+}
+
+/* Redirect Handling */
+let replaceRootHref = (href: string, shouldUseTopRedirection: bool) => {
+  switch shouldUseTopRedirection {
+  | true =>
+    try {
+      handleBeforeRedirectPostMessage()
+      setTimeout(() => {
+        Window.Top.Location.replace(href)
+      }, 100)->ignore
+    } catch {
+    | e => {
+        Js.Console.error3(
+          "Failed to redirect root document",
+          e,
+          `Using [window.location.replace] for redirection`,
+        )
+        Window.Location.replace(href)
+      }
+    }
+  | false => Window.Location.replace(href)
   }
 }

--- a/src/Window.res
+++ b/src/Window.res
@@ -203,23 +203,3 @@ let getRootHostName = () =>
     }
   | false => Location.hostname
   }
-
-/* Redirect Handling */
-let replaceRootHref = (href: string, shouldUseTopRedirection: bool) => {
-  switch shouldUseTopRedirection {
-  | true =>
-    try {
-      Top.Location.replace(href)
-    } catch {
-    | e => {
-        Js.Console.error3(
-          "Failed to redirect root document",
-          e,
-          `Using [window.location.replace] for redirection`,
-        )
-        Location.replace(href)
-      }
-    }
-  | false => Location.replace(href)
-  }
-}

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -675,7 +675,7 @@ let make = (
             let returnUrl = dict->getString("return_url", "")
             let redirectUrl = `${returnUrl}?payment_intent_client_secret=${clientSecret}&status=${status}`
             if redirect.contents === "always" {
-              Window.replaceRootHref(redirectUrl, shouldUseTopRedirection)
+              Utils.replaceRootHref(redirectUrl, shouldUseTopRedirection)
               resolve(JSON.Encode.null)
             } else {
               messageCurrentWindow([
@@ -703,7 +703,7 @@ let make = (
 
               let handleErrorResponse = err => {
                 if redirect.contents === "always" {
-                  Window.replaceRootHref(url, shouldUseTopRedirection)
+                  Utils.replaceRootHref(url, shouldUseTopRedirection)
                 }
                 messageCurrentWindow([
                   ("submitSuccessful", false->JSON.Encode.bool),
@@ -764,7 +764,7 @@ let make = (
             ->then(json => json->handleRetrievePaymentResponse)
             ->catch(err => {
               if redirect.contents === "always" {
-                Window.replaceRootHref(
+                Utils.replaceRootHref(
                   redirectUrl->JSON.Decode.string->Option.getOr(""),
                   shouldUseTopRedirection,
                 )

--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -422,9 +422,9 @@ let make = (publishableKey, options: option<JSON.t>, analyticsInfo: option<JSON.
                 let submitSuccessfulValue = val->JSON.Decode.bool->Option.getOr(false)
 
                 if isSdkButton && submitSuccessfulValue {
-                  Window.replaceRootHref(returnUrl, shouldUseTopRedirection)
+                  Utils.replaceRootHref(returnUrl, shouldUseTopRedirection)
                 } else if submitSuccessfulValue && redirect === "always" {
-                  Window.replaceRootHref(returnUrl, shouldUseTopRedirection)
+                  Utils.replaceRootHref(returnUrl, shouldUseTopRedirection)
                 } else if !submitSuccessfulValue {
                   resolve1(json)
                 } else {
@@ -602,7 +602,7 @@ let make = (publishableKey, options: option<JSON.t>, analyticsInfo: option<JSON.
                 )
                 let url = decodedData->getString("return_url", "/")
                 if val->JSON.Decode.bool->Option.getOr(false) && url !== "/" {
-                  Window.replaceRootHref(url, shouldUseTopRedirection)
+                  Utils.replaceRootHref(url, shouldUseTopRedirection)
                 } else {
                   resolve(json)
                 }

--- a/src/hyper-loader/HyperLoader.res
+++ b/src/hyper-loader/HyperLoader.res
@@ -7,9 +7,27 @@ let loadStripe = (str, option) => {
   loadHyper(str, option)
 }
 
+let removeBeforeUnloadEventListener: ('ev => unit) => unit = handler => {
+  let iframeMessageHandler = (ev: Types.event) => {
+    let dict = ev.data->Identity.anyTypeToJson->Utils.getDictFromJson
+    dict
+    ->Dict.get("disableBeforeUnloadEventListener")
+    ->Option.map(shouldRemove => {
+      if shouldRemove->JSON.Decode.bool->Option.getOr(false) {
+        Window.removeEventListener("beforeunload", handler)
+      }
+    })
+    ->ignore
+  }
+
+  // Subscribe to postMessage event
+  Window.addEventListener("message", iframeMessageHandler)
+}
+
 @val external window: {..} = "window"
 window["Hyper"] = Hyper.make
 window["Hyper"]["init"] = Hyper.make
+window["removeBeforeUnloadEventListener"] = removeBeforeUnloadEventListener
 
 let isWordpress = window["wp"] !== JSON.Encode.null
 if !isWordpress {

--- a/src/hyper-loader/LoaderPaymentElement.res
+++ b/src/hyper-loader/LoaderPaymentElement.res
@@ -244,7 +244,7 @@ let make = (
         switch eventDataObject->getOptionalJsonFromJson("openurl") {
         | Some(val) => {
             let url = val->getStringFromJson("")
-            Window.replaceRootHref(url, shouldUseTopRedirection)
+            Utils.replaceRootHref(url, shouldUseTopRedirection)
           }
         | None => ()
         }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds a functionality to remove any `beforeunload` event before redirecting in top contexts.

## How did you test it?
Locally using payment links.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
