### PR TITLE
fix: apple pay height

### DIFF
--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -27,6 +27,12 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions, ~paymentType: CardTheme
   let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
   let isWallet = walletOptions->Array.includes("apple_pay")
 
+  let (heightType, _, _, _, _) = options.wallets.style.height
+  let height = switch heightType {
+  | ApplePay(val) => val
+  | _ => 48
+  }
+
   UtilityHooks.useHandlePostMessages(
     ~complete=areRequiredFieldsValid,
     ~empty=areRequiredFieldsEmpty,
@@ -98,7 +104,7 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions, ~paymentType: CardTheme
   let css = `@supports (-webkit-appearance: -apple-pay-button) {
     .apple-pay-loader-div {
       background-color: ${loaderDivBackgroundColor};
-      height: 3rem;
+      height: ${height->Int.toString}px;
       display: flex;
       justify-content: center;
       align-items: center;
@@ -135,7 +141,7 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions, ~paymentType: CardTheme
     .apple-pay-button-black-with-text {
         -apple-pay-button-style: ${buttonColor};
         width: 100%;
-        height: 3rem;
+        height: ${height->Int.toString}px;
         display: flex;
         cursor: pointer;
         border-radius: ${options.wallets.style.buttonRadius->Int.toString}px;


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Added height support for apple pay button

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
tested locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
