### PR TITLE
fix: fixed click to pay loader coming above saved cards

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -529,24 +529,25 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
         {paymentLabel->Option.getOr("")->React.string}
       </div>
     </RenderIf>
-    <RenderIf condition={clickToPayConfig.isReady->Option.isNone}>
+    {if clickToPayConfig.isReady->Option.isNone {
       <ClickToPayHelpers.SrcLoader />
-    </RenderIf>
-    <RenderIf
-      condition={!showFields &&
-      (displaySavedPaymentMethods || isShowPaymentMethodsDependingOnClickToPay)}>
-      <SavedMethods
-        paymentToken
-        setPaymentToken
-        savedMethods
-        loadSavedCards
-        cvcProps
-        paymentType
-        sessions
-        isClickToPayAuthenticateError
-        setIsClickToPayAuthenticateError
-      />
-    </RenderIf>
+    } else {
+      <RenderIf
+        condition={!showFields &&
+        (displaySavedPaymentMethods || isShowPaymentMethodsDependingOnClickToPay)}>
+        <SavedMethods
+          paymentToken
+          setPaymentToken
+          savedMethods
+          loadSavedCards
+          cvcProps
+          paymentType
+          sessions
+          isClickToPayAuthenticateError
+          setIsClickToPayAuthenticateError
+        />
+      </RenderIf>
+    }}
     <RenderIf
       condition={(paymentOptions->Array.length > 0 || walletOptions->Array.length > 0) &&
       showFields &&


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Click to Pay Loader coming above Saved Cards

## How did you test it?


https://github.com/user-attachments/assets/101c1c7f-7cca-4b6c-88ae-aa863cc99d40




https://github.com/user-attachments/assets/a82ef5a0-64f8-478a-b6a3-d8b1b4e7418e





## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
