### PR TITLE
fix: inconsistent country code dropdown border

### DIFF
--- a/src/Components/DropdownField.res
+++ b/src/Components/DropdownField.res
@@ -103,7 +103,7 @@ let make = (
       <div className="relative">
         <RenderIf condition={isDisplayValueVisible && displayValue->Option.isSome}>
           <div
-            className="absolute top-1 left-1 right-0 bottom-0  pointer-events-none rounded-sm z-20 whitespace-nowrap"
+            className="absolute top-[2px] left-[2px] right-0 bottom-[2px]  pointer-events-none rounded-sm z-20 whitespace-nowrap"
             style={
               background: disabled ? disbaledBG : themeObj.colorBackground,
               opacity: disabled ? "35%" : "",


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Inconsistent country code dropdown border

## How did you test it?
I have checked it by running the local React demo app.

Before:
<img width="415" alt="Screenshot 2025-01-29 at 6 58 16 PM" src="https://github.com/user-attachments/assets/6e980cd4-d3d9-4d52-973c-a183f29bd774" />
After:
<img width="422" alt="Screenshot 2025-01-29 at 6 58 46 PM" src="https://github.com/user-attachments/assets/502f6366-b012-4184-8cf0-bf2aca3af4c7" />

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
