### PR TITLE
feat: add regex for UnionPay and allow card number checking if cardbrand not detected

### DIFF
--- a/src/CardPattern.res
+++ b/src/CardPattern.res
@@ -10,9 +10,9 @@ type card = {details: array<patterns>}
 let defaultCardPattern = {
   issuer: "",
   pattern: %re("/^[0-9]/"),
-  cvcLength: [3],
-  maxCVCLength: 3,
-  length: [16],
+  cvcLength: [3, 4],
+  maxCVCLength: 4,
+  length: [13, 14, 15, 16, 17, 18, 19],
   pincodeRequired: false,
 }
 let cardPatterns = [
@@ -24,6 +24,14 @@ let cardPatterns = [
     cvcLength: [3, 4],
     length: [12, 13, 14, 15, 16, 17, 18, 19],
     maxCVCLength: 4,
+    pincodeRequired: true,
+  },
+  {
+    issuer: "UnionPay",
+    pattern: %re("/^(6[27]|81)/"),
+    cvcLength: [3],
+    length: [16, 17, 18, 19],
+    maxCVCLength: 3,
     pincodeRequired: true,
   },
   {

--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -470,19 +470,13 @@ let isCardLengthValid = (cardBrand, cardNumberLength) => {
 
 let cardValid = (cardNumber, cardBrand) => {
   let clearValueLength = cardNumber->clearSpaces->String.length
-  if cardBrand == "" {
-    ((GlobalVars.isInteg || GlobalVars.isSandbox) && Utils.checkIsTestCardWildcard(cardNumber)) ||
-      (isCardLengthValid(cardBrand, clearValueLength) && calculateLuhn(cardNumber))
-  } else {
-    isCardLengthValid(cardBrand, clearValueLength) && calculateLuhn(cardNumber)
-  }
+  isCardLengthValid(cardBrand, clearValueLength) && calculateLuhn(cardNumber)
 }
 
 let focusCardValid = (cardNumber, cardBrand) => {
   let clearValueLength = cardNumber->clearSpaces->String.length
   if cardBrand == "" {
-    ((GlobalVars.isInteg || GlobalVars.isSandbox) && Utils.checkIsTestCardWildcard(cardNumber)) ||
-      (clearValueLength == maxCardLength(cardBrand) && calculateLuhn(cardNumber))
+    clearValueLength == maxCardLength(cardBrand) && calculateLuhn(cardNumber)
   } else {
     (clearValueLength == maxCardLength(cardBrand) ||
       (cardBrand === "Visa" && clearValueLength == 16)) && calculateLuhn(cardNumber)

--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -181,6 +181,7 @@ let formatCardNumber = (val, cardType) => {
   | DISCOVER
   | SODEXO
   | RUPAY
+  | UNIONPAY
   | VISA =>
     `${clearValue->slice(0, 4)} ${clearValue->slice(4, 8)} ${clearValue->slice(
         8,
@@ -348,7 +349,7 @@ let getCardBrandIcon = (cardType, paymentType) => {
   | RUPAY => <Icon size=brandIconSize name="rupay-card" />
   | JCB => <Icon size=brandIconSize name="jcb-card" />
   | CARTESBANCAIRES => <Icon size=brandIconSize name="cartesbancaires-card" />
-  | UNIONPAY => <Icon size=brandIconSize name="card" />
+  | UNIONPAY => <Icon size=brandIconSize name="union-pay" />
   | INTERAC => <Icon size=brandIconSize name="interac" />
   | NOTFOUND =>
     switch paymentType {
@@ -469,8 +470,9 @@ let isCardLengthValid = (cardBrand, cardNumberLength) => {
 
 let cardValid = (cardNumber, cardBrand) => {
   let clearValueLength = cardNumber->clearSpaces->String.length
-  if cardBrand == "" && (GlobalVars.isInteg || GlobalVars.isSandbox) {
-    Utils.checkIsTestCardWildcard(cardNumber)
+  if cardBrand == "" {
+    ((GlobalVars.isInteg || GlobalVars.isSandbox) && Utils.checkIsTestCardWildcard(cardNumber)) ||
+      (isCardLengthValid(cardBrand, clearValueLength) && calculateLuhn(cardNumber))
   } else {
     isCardLengthValid(cardBrand, clearValueLength) && calculateLuhn(cardNumber)
   }
@@ -478,8 +480,9 @@ let cardValid = (cardNumber, cardBrand) => {
 
 let focusCardValid = (cardNumber, cardBrand) => {
   let clearValueLength = cardNumber->clearSpaces->String.length
-  if cardBrand == "" && (GlobalVars.isInteg || GlobalVars.isSandbox) {
-    Utils.checkIsTestCardWildcard(cardNumber)
+  if cardBrand == "" {
+    ((GlobalVars.isInteg || GlobalVars.isSandbox) && Utils.checkIsTestCardWildcard(cardNumber)) ||
+      (clearValueLength == maxCardLength(cardBrand) && calculateLuhn(cardNumber))
   } else {
     (clearValueLength == maxCardLength(cardBrand) ||
       (cardBrand === "Visa" && clearValueLength == 16)) && calculateLuhn(cardNumber)

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -89,8 +89,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     setCardValid(clearValue, setIsCardValid)
     if (
       focusCardValid(clearValue, cardBrand) &&
-      (PaymentUtils.checkIsCardSupported(clearValue, supportedCardBrands)->Option.getOr(false) ||
-        Utils.checkIsTestCardWildcard(clearValue))
+      PaymentUtils.checkIsCardSupported(clearValue, supportedCardBrands)->Option.getOr(false)
     ) {
       handleInputFocus(~currentRef=cardRef, ~destinationRef=expiryRef)
     }

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -225,13 +225,9 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       checkCardExpiry(getCardElementValue(iframeId, "card-expiry"))
     | _ => true
     }
-    let cardNetwork = {
-      if cardBrand != "" {
-        [("card_network", cardBrand->JSON.Encode.string)]
-      } else {
-        [("card_network", JSON.Encode.null)]
-      }
-    }
+    let cardNetwork = [
+      ("card_network", cardBrand != "" ? cardBrand->JSON.Encode.string : JSON.Encode.null),
+    ]
     if validFormat {
       let body = switch paymentMode->getPaymentMode {
       | Card =>

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -229,7 +229,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       if cardBrand != "" {
         [("card_network", cardBrand->JSON.Encode.string)]
       } else {
-        []
+        [("card_network", JSON.Encode.null)]
       }
     }
     if validFormat {

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -150,13 +150,9 @@ let make = (
     let (month, year) = CardUtils.getExpiryDates(cardExpiry)
 
     let onSessionBody = [("customer_acceptance", PaymentBody.customerAcceptanceBody)]
-    let cardNetwork = {
-      if cardBrand != "" {
-        [("card_network", cardBrand->JSON.Encode.string)]
-      } else {
-        [("card_network", JSON.Encode.null)]
-      }
-    }
+    let cardNetwork = [
+      ("card_network", cardBrand != "" ? cardBrand->JSON.Encode.string : JSON.Encode.null),
+    ]
     let defaultCardBody = PaymentBody.cardPaymentBody(
       ~cardNumber,
       ~month,

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -154,7 +154,7 @@ let make = (
       if cardBrand != "" {
         [("card_network", cardBrand->JSON.Encode.string)]
       } else {
-        []
+        [("card_network", JSON.Encode.null)]
       }
     }
     let defaultCardBody = PaymentBody.cardPaymentBody(

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -559,7 +559,7 @@ let getSupportedCardBrands = (paymentMethodListValue: PaymentMethodsRecord.payme
 let checkIsCardSupported = (cardNumber, supportedCardBrands) => {
   let cardBrand = cardNumber->CardUtils.getCardBrand
   let clearValue = cardNumber->CardUtils.clearSpaces
-  if cardBrand == "" && (GlobalVars.isInteg || GlobalVars.isSandbox) {
+  if cardBrand == "" {
     Some(CardUtils.cardValid(clearValue, cardBrand))
   } else if CardUtils.cardValid(clearValue, cardBrand) {
     switch supportedCardBrands {

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1428,7 +1428,6 @@ let getFirstAndLastNameFromFullName = fullName => {
 }
 
 let isKeyPresentInDict = (dict, key) => dict->Dict.get(key)->Option.isSome
-let checkIsTestCardWildcard = val => ["1111222233334444"]->Array.includes(val)
 
 let minorUnitToString = val => (val->Int.toFloat /. 100.)->Float.toString
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This update enhances our card validation logic by adding regex support for UnionPay and allow card number checking if cardbrand not detected.

The UnionPay regex pattern and pin was derived from the following sources:
1. https://github.com/validatorjs/validator.js/blob/a1e84761802e050ed5d0e3d138e8f87cc1564860/src/lib/isCreditCard.js#L10
2. https://en.wikipedia.org/wiki/Payment_card_number
3. https://www.mystoredemo.io/#/checkout
4. https://m.unionpayintl.com/wap/en/serviceCenter/cardUsingInstructions/1439.shtml


## How did you test it?
I have checked it by running the local React demo app.
<img width="463" alt="Screenshot 2025-01-30 at 11 40 44 AM" src="https://github.com/user-attachments/assets/d9dbb324-f47b-4106-ba05-66172539b53b" />

If the card brand is not detected but the card number is valid (passes the Luhn test and falls within the valid card number length range), we allow the user to make a payment. We send `card_network` as `null`.
<img width="408" alt="Screenshot 2025-01-30 at 2 18 25 PM" src="https://github.com/user-attachments/assets/f6ec63d5-541f-4bac-b883-12875cbfb574" />

I have also changed the default pattern, as many card brands have different CVC and card number lengths.
<img width="372" alt="Screenshot 2025-01-30 at 2 19 51 PM" src="https://github.com/user-attachments/assets/6e38e69d-4708-41ca-b46b-c2a1dcb3893a" />

I have removed `checkIsTestCardWildcard`, as it is passing luhn test.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
