### PR TITLE
fix: drop down arrow for phone code

### DIFF
--- a/src/Components/DropdownField.res
+++ b/src/Components/DropdownField.res
@@ -109,7 +109,7 @@ let make = (
               background: disabled ? disbaledBG : themeObj.colorBackground,
               opacity: disabled ? "35%" : "",
               padding: themeObj.spacingUnit,
-              width: "95%",
+              width: "75%",
             }
             ariaHidden=true>
             {React.string(displayValue->Option.getOr(""))}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
fixed arrow drop down for phone country code field
Before:-
<img width="523" alt="Screenshot 2025-02-04 at 3 30 44 PM" src="https://github.com/user-attachments/assets/df8bef3e-6ea2-4a9e-a93e-94b29bd11b7b" />


After
<img width="499" alt="Screenshot 2025-02-04 at 3 30 18 PM" src="https://github.com/user-attachments/assets/d31638c9-e4b8-4d20-a28e-59435c1d8cfa" />
:-


## How did you test it?

Tested Locally 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
