### PR TITLE
fix: samsungpay script mount condition correction

### DIFF
--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -287,26 +287,6 @@ let make = (publishableKey, options: option<JSON.t>, analyticsInfo: option<JSON.
         logger.setLogInfo(~value="GooglePay Script Loaded", ~eventName=GOOGLE_PAY_SCRIPT)
       }
 
-      if (
-        Window.querySelectorAll(`script[src="https://img.mpay.samsung.com/gsmpi/sdk/samsungpay_web_sdk.js"]`)->Array.length === 0
-      ) {
-        let samsungPayScriptUrl = "https://img.mpay.samsung.com/gsmpi/sdk/samsungpay_web_sdk.js"
-        let samsungPayScript = Window.createElement("script")
-        samsungPayScript->Window.elementSrc(samsungPayScriptUrl)
-        samsungPayScript->Window.elementOnerror(err => {
-          logger.setLogError(
-            ~value="ERROR DURING LOADING SAMSUNG PAY SCRIPT",
-            ~eventName=SAMSUNG_PAY_SCRIPT,
-            ~internalMetadata=err->formatException->JSON.stringify,
-            ~paymentMethod="SAMSUNG_PAY",
-          )
-        })
-        Window.body->Window.appendChild(samsungPayScript)
-        samsungPayScript->Window.elementOnload(_ =>
-          logger.setLogInfo(~value="SamsungPay Script Loaded", ~eventName=SAMSUNG_PAY_SCRIPT)
-        )
-      }
-
       let iframeRef = ref([])
       let clientSecret = ref("")
       let ephemeralKey = ref("")


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The Samsung Pay script should be mounted only when Samsung Pay is present and the script is not already mounted. Previously, we only checked whether it was mounted.

## How did you test it?
I tested by running it in demo store.
<img width="705" alt="Screenshot 2025-02-12 at 4 49 13 PM" src="https://github.com/user-attachments/assets/7c79eb02-223e-4739-87a6-9a9345133386" />

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
