### PR TITLE
refactor: remove displaySavedPaymentMethodsCheckbox condition for card terms

### DIFF
--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -451,7 +451,7 @@ let make = (
     <RenderIf condition={showFields || isBancontact}>
       <Surcharge paymentMethod paymentMethodType cardBrand={cardBrand->CardUtils.getCardType} />
     </RenderIf>
-    <RenderIf condition={displaySavedPaymentMethodsCheckbox && !isBancontact}>
+    <RenderIf condition={!isBancontact}>
       {switch (
         paymentMethodListValue.mandate_payment,
         options.terms.card,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Removed `displaySavedPaymentMethodsCheckbox` check for rendering card Terms 
For rendering terms for cards we are already checking if the payment type is mandate or not, displaySavedPaymentMethodsCheckbox is just an extra frontend check which is unnecessary in this case. 

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested locally
## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
