### PR TITLE
fix: clear card expiry and CVC when switching to saved method and back

### DIFF
--- a/src/Payment.res
+++ b/src/Payment.res
@@ -83,6 +83,14 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   }, (cvcNumber, cardNumber))
 
   React.useEffect(() => {
+    setCvcNumber(_ => "")
+    setCardExpiry(_ => "")
+    setIsExpiryValid(_ => None)
+    setIsCVCValid(_ => None)
+    None
+  }, [showFields])
+
+  React.useEffect(() => {
     if prevCardBrandRef.current !== "" {
       setCvcNumber(_ => "")
       setCardExpiry(_ => "")


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR ensures that the card expiry and CVC fields are cleared when switching from the payment section to the saved method section and back.

## How did you test it?
I have tested in React demo app.
Before:

https://github.com/user-attachments/assets/d6dcbbe7-5d9c-4901-8d86-a20f190da142



After:

https://github.com/user-attachments/assets/c017c7b4-cf86-4d67-b373-ec30c5eb5ded



<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

https://github.com/user-attachments/assets/45d8a0d4-603e-423e-9289-649a2e8f4d96

