### PR TITLE
fix: fixed shimmer stuck for click to pay

### DIFF
--- a/src/Components/ClickToPayLearnMore.res
+++ b/src/Components/ClickToPayLearnMore.res
@@ -13,7 +13,7 @@ let make = () => {
   }
 
   React.useEffect0(() => {
-    ClickToPayHelpers.loadClickToPayScripts(logger)
+    ClickToPayHelpers.loadClickToPayScripts(logger)->ignore
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->getDictFromJson

--- a/src/Components/PaymentElementShimmer.res
+++ b/src/Components/PaymentElementShimmer.res
@@ -30,6 +30,23 @@ module SavedPaymentShimmer = {
   }
 }
 
+module SavedPaymentCardShimmer = {
+  @react.component
+  let make = () => {
+    let {themeObj} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+    <div
+      className="Label flex flex-row gap-3 items-end cursor-pointer"
+      style={
+        fontSize: "14px",
+        color: themeObj.colorPrimary,
+        fontWeight: "400",
+        marginTop: "25px",
+      }>
+      <SavedPaymentShimmer />
+    </div>
+  }
+}
+
 @react.component
 let make = () => {
   <div className="flex flex-col gap-4">

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -327,19 +327,10 @@ let make = (
   <div className="flex flex-col overflow-auto h-auto no-scrollbar animate-slowShow">
     {if (
       savedCardlength === 0 &&
-        ((clickToPayConfig.isReady->Option.isNone &&
-          loadSavedCards === PaymentType.LoadingSavedCards) || !showFields)
+      clickToPayConfig.isReady->Option.isNone &&
+      (loadSavedCards === PaymentType.LoadingSavedCards || !showFields)
     ) {
-      <div
-        className="Label flex flex-row gap-3 items-end cursor-pointer"
-        style={
-          fontSize: "14px",
-          color: themeObj.colorPrimary,
-          fontWeight: "400",
-          marginTop: "25px",
-        }>
-        <PaymentElementShimmer.SavedPaymentShimmer />
-      </div>
+      <PaymentElementShimmer.SavedPaymentCardShimmer />
     } else {
       <RenderIf condition={!showFields}> {bottomElement} </RenderIf>
     }}

--- a/src/Types/ClickToPayHelpers.res
+++ b/src/Types/ClickToPayHelpers.res
@@ -624,6 +624,7 @@ external appendChild: Dom.element => unit = "appendChild"
 @set external setSrc: (Dom.element, string) => unit = "src"
 @set external setRel: (Dom.element, string) => unit = "rel"
 @set external setHref: (Dom.element, string) => unit = "href"
+@set external setOnload: (Dom.element, unit => unit) => unit = "onload"
 @val @scope(("top", "location"))
 external topLocationHref: string = "href"
 
@@ -633,32 +634,65 @@ external topLocationHref: string = "href"
 
 // Add the function at the end of the file
 let loadClickToPayScripts = (logger: HyperLogger.loggerMake) => {
-  let scriptSelector = `script[src="${srcUiKitScriptSrc}"]`
-  let linkSelector = `link[href="${srcUiKitCssHref}"]`
+  Promise.make((clickToPayScriptsPromiseResolve, _) => {
+    let scriptSelector = `script[src="${srcUiKitScriptSrc}"]`
+    let linkSelector = `link[href="${srcUiKitCssHref}"]`
 
-  // Add script if not exists
-  switch querySelector(scriptSelector)->Nullable.toOption {
-  | None => {
-      let script = createElement("script")
-      script->setType("module")
-      script->setSrc(srcUiKitScriptSrc)
-      appendChild(script)
-      logger.setLogInfo(~value="ClickToPay UI Kit Script Loaded", ~eventName=CLICK_TO_PAY_SCRIPT)
-    }
-  | Some(_) => ()
-  }
+    // Add script if not exists
+    let srcUiKitScriptPromise = Promise.make((scriptPromiseResolve, _) => {
+      switch querySelector(scriptSelector)->Nullable.toOption {
+      | None => {
+          let script = createElement("script")
+          script->setType("module")
+          script->setSrc(srcUiKitScriptSrc)
+          script->setOnLoad(
+            () => {
+              logger.setLogInfo(
+                ~value="ClickToPay UI Kit Script Loaded",
+                ~eventName=CLICK_TO_PAY_SCRIPT,
+              )
+              scriptPromiseResolve()
+            },
+          )
+          appendChild(script)
+        }
+      | Some(_) => scriptPromiseResolve()
+      }
+    })
 
-  // Add link if not exists
-  switch querySelector(linkSelector)->Nullable.toOption {
-  | None => {
-      let link = createElement("link")
-      link->setRel("stylesheet")
-      link->setHref(srcUiKitCssHref)
-      appendChild(link)
-      logger.setLogInfo(~value="ClickToPay UI Kit CSS Loaded", ~eventName=CLICK_TO_PAY_SCRIPT)
-    }
-  | Some(_) => ()
-  }
+    // Add link if not exists
+    let srcUiKitCssPromise = Promise.make((cssPromiseResolve, _) => {
+      switch querySelector(linkSelector)->Nullable.toOption {
+      | None => {
+          let link = createElement("link")
+          link->setRel("stylesheet")
+          link->setHref(srcUiKitCssHref)
+          link->setOnLoad(
+            () => {
+              logger.setLogInfo(
+                ~value="ClickToPay UI Kit CSS Loaded",
+                ~eventName=CLICK_TO_PAY_SCRIPT,
+              )
+              cssPromiseResolve()
+            },
+          )
+          appendChild(link)
+        }
+      | Some(_) => cssPromiseResolve()
+      }
+    })
+
+    Promise.all([srcUiKitScriptPromise, srcUiKitCssPromise])
+    ->then(_ => {
+      clickToPayScriptsPromiseResolve()
+      resolve()
+    })
+    ->catch(_ => {
+      logger.setLogError(~value="ClickToPay UI Kit CSS Load Error", ~eventName=CLICK_TO_PAY_SCRIPT)
+      resolve()
+    })
+    ->ignore
+  })
 }
 
 // Add this function at the end of the file


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Click to Pay Shimmer getting stuck because of the following condition being always true when Click to Pay is enabled

```
savedCardlength === 0 &&
((clickToPayConfig.isReady->Option.isNone &&
loadSavedCards === PaymentType.LoadingSavedCards) || !showFields)
```

## How did you test it?

1. Click To Pay Disabled
  A. Card is saved for both Demo Store and Payment Link
  B. Card is not saved for both Demo Store and Payment Link
2. Click To Pay Enabled
  A. Card is saved for both Demo Store and Payment Link
  B. Card is not saved for both Demo Store and Payment Link

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
