### PR TITLE
chore: custom surcharge message prop exposed

### DIFF
--- a/src/Components/SurchargeUtils.res
+++ b/src/Components/SurchargeUtils.res
@@ -56,6 +56,7 @@ let useSurchargeDetailsForOneClickWallets = (~paymentMethodListValue) => {
 
 let useMessageGetter = () => {
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {customSurchargeMessage} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
 
   let getMessage = (
     ~surchargeDetails: PaymentMethodsRecord.surchargeDetails,
@@ -64,7 +65,20 @@ let useMessageGetter = () => {
   ) => {
     let surchargeValue = surchargeDetails.displayTotalSurchargeAmount->Float.toString
 
-    let localeStrForSurcharge = if paymentMethod === "card" {
+    let localeStrForSurcharge = if (
+      customSurchargeMessage->Option.isSome &&
+        customSurchargeMessage->Option.getOr("")->String.includes("{{amountAndCurrency}}")
+    ) {
+      let customSurchargeMessageFilteredValue =
+        customSurchargeMessage
+        ->Option.getOr("")
+        ->String.replace(
+          "{{amountAndCurrency}}",
+          `${paymentMethodListValue.currency} ${surchargeValue}`,
+        )
+
+      {React.string(customSurchargeMessageFilteredValue)}
+    } else if paymentMethod === "card" {
       localeString.surchargeMsgAmountForCard(paymentMethodListValue.currency, surchargeValue)
     } else {
       localeString.surchargeMsgAmount(paymentMethodListValue.currency, surchargeValue)

--- a/src/Components/SurchargeUtils.res
+++ b/src/Components/SurchargeUtils.res
@@ -63,30 +63,25 @@ let useMessageGetter = () => {
     ~paymentMethod,
     ~paymentMethodListValue: PaymentMethodsRecord.paymentMethodList,
   ) => {
+    let currency = paymentMethodListValue.currency
     let surchargeValue = surchargeDetails.displayTotalSurchargeAmount->Float.toString
+    let messageTemplate = customSurchargeMessage->Option.getOr("")
 
-    let localeStrForSurcharge = if (
-      customSurchargeMessage->Option.isSome &&
-        customSurchargeMessage->Option.getOr("")->String.includes("{{amountAndCurrency}}")
-    ) {
+    if messageTemplate->String.includes("{{amountAndCurrency}}") {
       let customSurchargeMessageFilteredValue =
-        customSurchargeMessage
-        ->Option.getOr("")
-        ->String.replace(
-          "{{amountAndCurrency}}",
-          `${paymentMethodListValue.currency} ${surchargeValue}`,
-        )
+        messageTemplate->String.replace("{{amountAndCurrency}}", `${currency} ${surchargeValue}`)
 
-      {React.string(customSurchargeMessageFilteredValue)}
-    } else if paymentMethod === "card" {
-      localeString.surchargeMsgAmountForCard(paymentMethodListValue.currency, surchargeValue)
+      Some(React.string(customSurchargeMessageFilteredValue))
     } else {
-      localeString.surchargeMsgAmount(paymentMethodListValue.currency, surchargeValue)
+      let message = if paymentMethod === "card" {
+        localeString.surchargeMsgAmountForCard(currency, surchargeValue)
+      } else {
+        localeString.surchargeMsgAmount(currency, surchargeValue)
+      }
+
+      Some(message)
     }
-
-    Some(localeStrForSurcharge)
   }
-
   getMessage
 }
 

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -195,6 +195,7 @@ type options = {
   hideCardNicknameField: bool,
   displayBillingDetails: bool,
   customMessageForCardTerms: string,
+  customSurchargeMessage: option<string>,
 }
 
 type payerDetails = {
@@ -360,6 +361,7 @@ let defaultOptions = {
   hideCardNicknameField: false,
   displayBillingDetails: false,
   customMessageForCardTerms: "",
+  customSurchargeMessage: None,
 }
 
 let getLayout = (str, logger) => {
@@ -1088,6 +1090,7 @@ let itemToObjMapper = (dict, logger) => {
       "hideCardNicknameField",
       "displayBillingDetails",
       "customMessageForCardTerms",
+      "customSurchargeMessage",
     ],
     dict,
     "options",
@@ -1134,6 +1137,7 @@ let itemToObjMapper = (dict, logger) => {
     hideCardNicknameField: getBool(dict, "hideCardNicknameField", false),
     displayBillingDetails: getBool(dict, "displayBillingDetails", false),
     customMessageForCardTerms: getString(dict, "customMessageForCardTerms", ""),
+    customSurchargeMessage: getOptionString(dict, "customSurchargeMessage"),
   }
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Added a prop `customSurchargeMessage` , Merchant can pass a custom string message for showing surcharge details along with a placeholder in the message for populating the currency and amount values from SDK, Placeholder will be `{{amountAndCurrency}}`.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested locally :-

- When the message is not passed we fall back to default way of showing surcharge message.

- When the message is passed but the placeholder is not correct then also we fall back to default way.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
