### PR TITLE
chore: short surcharge message prop added

### DIFF
--- a/src/Components/SurchargeUtils.res
+++ b/src/Components/SurchargeUtils.res
@@ -56,7 +56,7 @@ let useSurchargeDetailsForOneClickWallets = (~paymentMethodListValue) => {
 
 let useMessageGetter = () => {
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {customSurchargeMessage} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let {showShortSurchargeMessage} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
 
   let getMessage = (
     ~surchargeDetails: PaymentMethodsRecord.surchargeDetails,
@@ -65,13 +65,9 @@ let useMessageGetter = () => {
   ) => {
     let currency = paymentMethodListValue.currency
     let surchargeValue = surchargeDetails.displayTotalSurchargeAmount->Float.toString
-    let messageTemplate = customSurchargeMessage->Option.getOr("")
 
-    if messageTemplate->String.includes("{{amountAndCurrency}}") {
-      let customSurchargeMessageFilteredValue =
-        messageTemplate->String.replace("{{amountAndCurrency}}", `${currency} ${surchargeValue}`)
-
-      Some(React.string(customSurchargeMessageFilteredValue))
+    if showShortSurchargeMessage {
+      Some(localeString.shortSurchargeMessage(currency, surchargeValue))
     } else {
       let message = if paymentMethod === "card" {
         localeString.surchargeMsgAmountForCard(currency, surchargeValue)

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string(`${Utils.nbsp}على هذه المعاملة`)}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`الرسوم :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`سيتم تطبيق مبلغ إضافي يصل إلى${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}s'aplicarà per a aquesta transacció`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Tarifa :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Un recàrrec de fins a${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}的附加费用`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`费用 :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`此交易将收取最高${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string(`${Utils.nbsp}erhoben`)}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Gebühr :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Für diese Transaktion wird ein Zuschlagsbetrag von bis zu${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}zal voor deze transactie worden toegepast`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Kosten :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Een toeslagbedrag van maximaal${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string(`${Utils.nbsp}will be applied for this transaction`)}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Fee :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`A surcharge amount of upto${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}will be applied for this transaction`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Fee :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`A surcharge amount of upto${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}sera appliqué pour cette transaction`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Frais :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Un montant supplémentaire pouvant aller jusqu'à${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string(`${Utils.nbsp}sera appliqué pour cette transaction`)}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Frais :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Un montant supplémentaire allant jusqu'à${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string(`${Utils.nbsp}יוחל עבור עסקה זו`)}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`עמלה :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`סכום היטל של עד${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}verrà applicato per questa transazione`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Commissione :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Un importo di supplemento fino a${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string(`${Utils.nbsp}の追加料金が適用されます`)}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`手数料 :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`この取引には${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -57,6 +57,7 @@ type localeStrings = {
   selectPaymentMethodText: string,
   card: string,
   surchargeMsgAmount: (string, string) => React.element,
+  shortSurchargeMessage: (string, string) => React.element,
   surchargeMsgAmountForCard: (string, string) => React.element,
   surchargeMsgAmountForOneClickWallets: string,
   billingNameLabel: string,

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}zostaną zastosowane do tej transakcji`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Opłata :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Dopłata w wysokości do${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}será aplicado para esta transação`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Taxa :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Um valor adicional de até${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -66,6 +66,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
       `${Utils.nbsp}будет применено к этой транзакции`
     })}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Комиссия :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Сумма доплаты до${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}se aplicará para esta transacción`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Tarifa :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Un monto de recargo de hasta${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -64,6 +64,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string({`${Utils.nbsp}kommer att tillämpas för denna transaktion`})}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`Avgift :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`Ett tilläggsbelopp på upp till${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/LocaleStrings/TraditionalChineseLocale.res
+++ b/src/LocaleStrings/TraditionalChineseLocale.res
@@ -61,6 +61,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
     <strong> {React.string(`${currency} ${str}`)} </strong>
     {React.string(`${Utils.nbsp}的金額`)}
   </>,
+  shortSurchargeMessage: (currency, amount) => <>
+    {React.string(`費用 :${Utils.nbsp}`)}
+    <strong> {React.string(`${currency} ${amount}`)} </strong>
+  </>,
   surchargeMsgAmountForCard: (currency, str) => <>
     {React.string(`此交易將收取最高附加費${Utils.nbsp}`)}
     <strong> {React.string(`${currency} ${str}`)} </strong>

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -195,7 +195,7 @@ type options = {
   hideCardNicknameField: bool,
   displayBillingDetails: bool,
   customMessageForCardTerms: string,
-  customSurchargeMessage: option<string>,
+  showShortSurchargeMessage: bool,
 }
 
 type payerDetails = {
@@ -361,7 +361,7 @@ let defaultOptions = {
   hideCardNicknameField: false,
   displayBillingDetails: false,
   customMessageForCardTerms: "",
-  customSurchargeMessage: None,
+  showShortSurchargeMessage: false,
 }
 
 let getLayout = (str, logger) => {
@@ -1090,7 +1090,7 @@ let itemToObjMapper = (dict, logger) => {
       "hideCardNicknameField",
       "displayBillingDetails",
       "customMessageForCardTerms",
-      "customSurchargeMessage",
+      "showShortSurchargeMessage",
     ],
     dict,
     "options",
@@ -1137,7 +1137,7 @@ let itemToObjMapper = (dict, logger) => {
     hideCardNicknameField: getBool(dict, "hideCardNicknameField", false),
     displayBillingDetails: getBool(dict, "displayBillingDetails", false),
     customMessageForCardTerms: getString(dict, "customMessageForCardTerms", ""),
-    customSurchargeMessage: getOptionString(dict, "customSurchargeMessage"),
+    showShortSurchargeMessage: getBool(dict, "showShortSurchargeMessage", false),
   }
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Exposed a prop `showShortSurchargeMessage`, By default it is false, if it is passed as true then instead of long surcharge message we will show short message.
Format of short surcharge message :-
Fee : Currency amount

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested locally via passing the prop and with locale support

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
