### PR TITLE
fix: detect country correction

### DIFF
--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -116,7 +116,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
       let optionsDict = dict->getDictFromObj("options")
       let (default, defaultRules) = (themeValues.default, themeValues.defaultRules)
       let config = CardTheme.itemToObjMapper(paymentOptions, default, defaultRules, logger)
-      let optionsLocaleString = getWarningString(optionsDict, "locale", "", ~logger)
+      let optionsLocaleString = getWarningString(optionsDict, "locale", "auto", ~logger)
       let optionsAppearance = CardTheme.getAppearance(
         "appearance",
         optionsDict,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Unable to get the default browser language for users running in different locations.

## How did you test it?

To test it, I changed the default language of my Mac, Firefox, and Chrome to German. After that, I restarted my laptop.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
