### PR TITLE
fix: correction in locale detection

### DIFF
--- a/src/LocaleStrings/LocaleStringHelper.res
+++ b/src/LocaleStrings/LocaleStringHelper.res
@@ -1,25 +1,52 @@
 open LocaleStringTypes
 let mapLocalStringToTypeLocale = val => {
-  switch val {
-  | "he" => HE
-  | "fr" => FR
-  | "en-GB" => EN_GB
-  | "ar" => AR
-  | "ja" => JA
-  | "de" => DE
-  | "fr-BE" => FR_BE
-  | "es" => ES
-  | "ca" => CA
-  | "pt" => PT
-  | "it" => IT
-  | "pl" => PL
-  | "nl" => NL
-  | "sv" => SV
-  | "ru" => RU
-  | "zh" => ZH
-  | "zh-Hant" => ZH_HANT
-  | "en"
-  | _ =>
-    EN
+  // First try the exact match
+  let exactMatch = switch val->String.toLowerCase {
+  | "he" => Some(HE)
+  | "fr" => Some(FR)
+  | "ar" => Some(AR)
+  | "ja" => Some(JA)
+  | "de" => Some(DE)
+  | "es" => Some(ES)
+  | "ca" => Some(CA)
+  | "pt" => Some(PT)
+  | "it" => Some(IT)
+  | "pl" => Some(PL)
+  | "nl" => Some(NL)
+  | "sv" => Some(SV)
+  | "ru" => Some(RU)
+  | "zh" => Some(ZH)
+  | "en-gb" => Some(EN_GB)
+  | "fr-be" => Some(FR_BE)
+  | "zh-hant" => Some(ZH_HANT)
+  | "en" => Some(EN)
+  | _ => None
+  }
+
+  // If exact match found, return it
+  switch exactMatch {
+  | Some(locale) => locale
+  // If no exact match is found, try to match based on the first part of the language code (before the "-")
+  | None => {
+      let baseLanguage = val->String.toLowerCase->String.split("-")->Array.get(0)->Option.getOr("")
+      switch baseLanguage {
+      | "he" => HE
+      | "fr" => FR
+      | "ar" => AR
+      | "ja" => JA
+      | "de" => DE
+      | "es" => ES
+      | "ca" => CA
+      | "pt" => PT
+      | "it" => IT
+      | "pl" => PL
+      | "nl" => NL
+      | "sv" => SV
+      | "ru" => RU
+      | "zh" => ZH
+      | "en" => EN
+      | _ => EN // Default fallback
+      }
+    }
   }
 }

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -85,7 +85,7 @@ let make = (
       elem
     }
 
-    let locale = localOptions->getJsonStringFromDict("locale", "")
+    let locale = localOptions->getJsonStringFromDict("locale", "auto")
     let loader = localOptions->getJsonStringFromDict("loader", "")
     let clientSecret = localOptions->getRequiredString("clientSecret", "", ~logger)
     let clientSecretReMatch = Re.test(`.+_secret_[A-Za-z0-9]+`->Re.fromString, clientSecret)

--- a/src/hyper-loader/PaymentMethodsManagementElements.res
+++ b/src/hyper-loader/PaymentMethodsManagementElements.res
@@ -69,7 +69,7 @@ let make = (
       elem
     }
 
-    let locale = localOptions->getJsonStringFromDict("locale", "")
+    let locale = localOptions->getJsonStringFromDict("locale", "auto")
     let loader = localOptions->getJsonStringFromDict("loader", "")
 
     let preMountLoaderIframeDiv = mountPreMountLoaderIframe()


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Unable to get the default browser language for users running in different locations.

## How did you test it?
To test it, I changed the default language of my Mac, Firefox, and Chrome to German. After that, I restarted my laptop.


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
