### PR TITLE
fix: netcetera and cvc cypress test

### DIFF
--- a/cypress-tests/cypress/e2e/cvc-checks-e2e-test.cy.ts
+++ b/cypress-tests/cypress/e2e/cvc-checks-e2e-test.cy.ts
@@ -38,6 +38,7 @@ describe("Card CVC Checks", () => {
 
 
     it('user can enter 4 digit cvc in card form', () => {
+        cy.wait(2000)
         getIframeBody().find(`[data-testid=${testIds.addNewCardIcon}]`).click()
         getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).type(amexTestCard)
         getIframeBody().find(`[data-testid=${testIds.expiryInputTestId}]`).type("0444")
@@ -49,6 +50,7 @@ describe("Card CVC Checks", () => {
     })
 
     it('removing cvc and expiry on card brand change or after clearing card number', () => {
+        cy.wait(2000)
         getIframeBody().find(`[data-testid=${testIds.addNewCardIcon}]`).click()
         getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).type(amexTestCard)
         getIframeBody().find(`[data-testid=${testIds.expiryInputTestId}]`).type("0444")
@@ -67,6 +69,7 @@ describe("Card CVC Checks", () => {
     })
 
     it('user can enter 3 digit cvc in card form', () => {
+        cy.wait(2000)
         getIframeBody().find(`[data-testid=${testIds.addNewCardIcon}]`).click()
         getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).type(visaTestCard)
         getIframeBody().find(`[data-testid=${testIds.expiryInputTestId}]`).type("0444")

--- a/cypress-tests/cypress/e2e/external-3DS-netcetera-e2e-test.cy.ts
+++ b/cypress-tests/cypress/e2e/external-3DS-netcetera-e2e-test.cy.ts
@@ -37,6 +37,7 @@ describe("External 3DS using Netcetera Checks", () => {
 
 
     it('If the user completes the challenge, the payment should be successful.', () => {
+        cy.wait(1500)
         getIframeBody().find(`[data-testid=${testIds.addNewCardIcon}]`).click()
         getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).type(netceteraChallengeTestCard)
         getIframeBody().find(`[data-testid=${testIds.expiryInputTestId}]`).type("0444")
@@ -57,6 +58,7 @@ describe("External 3DS using Netcetera Checks", () => {
     })
 
     it('If the user closes the challenge, the payment should fail.', () => {
+        cy.wait(1000)
         getIframeBody().find(`[data-testid=${testIds.addNewCardIcon}]`).click()
         getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).type(netceteraChallengeTestCard)
         getIframeBody().find(`[data-testid=${testIds.expiryInputTestId}]`).type("0444")

--- a/cypress-tests/cypress/e2e/external-3DS-netcetera-e2e-test.cy.ts
+++ b/cypress-tests/cypress/e2e/external-3DS-netcetera-e2e-test.cy.ts
@@ -37,7 +37,7 @@ describe("External 3DS using Netcetera Checks", () => {
 
 
     it('If the user completes the challenge, the payment should be successful.', () => {
-        cy.wait(1500)
+        cy.wait(2000)
         getIframeBody().find(`[data-testid=${testIds.addNewCardIcon}]`).click()
         getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).type(netceteraChallengeTestCard)
         getIframeBody().find(`[data-testid=${testIds.expiryInputTestId}]`).type("0444")
@@ -58,7 +58,7 @@ describe("External 3DS using Netcetera Checks", () => {
     })
 
     it('If the user closes the challenge, the payment should fail.', () => {
-        cy.wait(1000)
+        cy.wait(2000)
         getIframeBody().find(`[data-testid=${testIds.addNewCardIcon}]`).click()
         getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).type(netceteraChallengeTestCard)
         getIframeBody().find(`[data-testid=${testIds.expiryInputTestId}]`).type("0444")


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The Netcetera Cypress test was failing because the SDK was taking longer to load, causing the test to execute before the SDK was fully loaded. Additionally, `browserInformation.acceptLanguage` was not set in the dashboard.

## How did you test it?
I ran cypress test in local React Demo App.

https://github.com/user-attachments/assets/462b4e3b-7e41-4009-a0e1-a83082fd26b5


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
