### PR TITLE
feat: integration for redsys 3ds

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -67,6 +67,7 @@ let make = () => {
       </div>
     | "qrData" => <QRCodeDisplay />
     | "3dsAuth" => <ThreeDSAuth />
+    | "redsys3ds" => <Redsys3ds />
     | "3ds" => <ThreeDSMethod />
     | "voucherData" => <VoucherDisplay />
     | "preMountLoader" => {

--- a/src/Redsys3ds.res
+++ b/src/Redsys3ds.res
@@ -1,0 +1,127 @@
+open Utils
+
+@react.component
+let make = () => {
+  let logger = HyperLogger.make(~source=Elements(Payment))
+  let isCompleteAuthorizeCalledRef = React.useRef(false)
+  let timeoutRef = React.useRef(None)
+  let eventsToSendToParent = ["confirmParams", "poll_status", "openurl_if_required"]
+  let completeAuthorize = PaymentHelpers.useRedsysCompleteAuthorize(Some(logger))
+
+  let handleCompleteAuthorizeCall = (
+    threeDsMethodComp,
+    paymentIntentId,
+    publishableKey,
+    headers,
+    returnUrl,
+  ) => {
+    let body = [
+      ("client_secret", paymentIntentId->JSON.Encode.string),
+      ("threeds_method_comp_ind", threeDsMethodComp->JSON.Encode.string),
+    ]
+    completeAuthorize(
+      ~bodyArr=body,
+      ~confirmParam={
+        return_url: returnUrl,
+        publishableKey,
+      },
+      ~headers,
+      ~iframeId="redsys3ds",
+      ~clientSecret=Some(paymentIntentId),
+    )
+  }
+
+  eventsToSendToParent->UtilityHooks.useSendEventsToParent
+
+  React.useEffect0(() => {
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
+    let handle = (ev: Window.event) => {
+      try {
+        let json = ev.data->safeParse
+        let dict = json->getDictFromJson
+        if dict->Dict.get("fullScreenIframeMounted")->Option.isSome {
+          let metadata = dict->getJsonObjectFromDict("metadata")
+          let metaDataDict = metadata->JSON.Decode.object->Option.getOr(Dict.make())
+          let paymentIntentId = metaDataDict->getString("paymentIntentId", "")
+          let publishableKey = metaDataDict->getString("publishableKey", "")
+
+          logger.setClientSecret(paymentIntentId)
+          logger.setMerchantId(publishableKey)
+
+          let headersDict = metaDataDict->getDictFromDict("headers")
+
+          let headers = headersDict->convertDictToArrayOfKeyStringTuples
+
+          let confirmParam = metaDataDict->getDictFromObj("confirmParams")
+          let returnUrl = confirmParam->getString("return_url", "")
+          let iframeDataDict = metaDataDict->getDictFromObj("iframeData")
+          let methodKey = iframeDataDict->getString("method_key", "threeDSMethodData")
+          let threeDsMethodUrl = iframeDataDict->getString("three_ds_method_url", "")
+          let threeDsMethodData = iframeDataDict->getString("three_ds_method_data", "")
+          let threeDsIframe = CommonHooks.querySelector("#threeDsAuthFrame")
+
+          switch Window.querySelector("#threeDsDiv")->Nullable.toOption {
+          | Some(elem) =>
+            if threeDsMethodUrl !== "" {
+              let form = elem->makeForm(threeDsMethodUrl, "threeDsHiddenPostMethod")
+              let input = Types.createElement("input")
+              input.name = encodeURIComponent(methodKey)
+              input.value = encodeURIComponent(threeDsMethodData)
+              form.target = "threeDsAuthFrame"
+              form.appendChild(input)
+              form.submit()
+            }
+          | None => ()
+          }
+
+          timeoutRef.current->Option.forEach(clearTimeout)
+
+          timeoutRef.current = Some(setTimeout(() => {
+              isCompleteAuthorizeCalledRef.current = true
+              handleCompleteAuthorizeCall(
+                "N",
+                paymentIntentId,
+                publishableKey,
+                headers,
+                returnUrl,
+              )->ignore
+            }, 10000))
+
+          switch threeDsIframe->Nullable.toOption {
+          | Some(elem) =>
+            elem->CommonHooks.addEventListener("load", _ => {
+              timeoutRef.current->Option.forEach(clearTimeout)
+              if !isCompleteAuthorizeCalledRef.current {
+                handleCompleteAuthorizeCall(
+                  "Y",
+                  paymentIntentId,
+                  publishableKey,
+                  headers,
+                  returnUrl,
+                )->ignore
+              }
+            })
+          | None => ()
+          }
+        }
+      } catch {
+      | _ =>
+        postFailedSubmitResponse(
+          ~errortype="complete_authorize_failed",
+          ~message="Something went wrong.",
+        )
+      }
+    }
+    Window.addEventListener("message", handle)
+    Some(
+      () => {
+        Window.removeEventListener("message", handle)
+        timeoutRef.current->Option.forEach(clearTimeout)
+      },
+    )
+  })
+
+  <div id="threeDsDiv" className="max-w-1 max-h-1 opacity-0 fixed left-[-9999px]">
+    <iframe id="threeDsAuthFrame" name="threeDsAuthFrame" title="3D Secure Authentication Frame" />
+  </div>
+}

--- a/src/ThreeDSAuth.res
+++ b/src/ThreeDSAuth.res
@@ -48,13 +48,7 @@ let make = () => {
           ->JSON.Decode.object
           ->Option.getOr(Dict.make())
           ->getString("three_ds_authorize_url", "")
-        let headers =
-          headersDict
-          ->Dict.toArray
-          ->Array.map(entries => {
-            let (x, val) = entries
-            (x, val->JSON.Decode.string->Option.getOr(""))
-          })
+        let headers = headersDict->convertDictToArrayOfKeyStringTuples
 
         let threeDsMethodComp = metaDataDict->getString("3dsMethodComp", "U")
         open Promise

--- a/src/Types/PaymentConfirmTypes.res
+++ b/src/Types/PaymentConfirmTypes.res
@@ -45,6 +45,7 @@ type nextAction = {
   next_action_data: option<JSON.t>,
   display_text: option<string>,
   border_color: option<string>,
+  iframe_data: option<JSON.t>,
 }
 type intent = {
   nextAction: nextAction,
@@ -74,6 +75,7 @@ let defaultNextAction = {
   next_action_data: None,
   display_text: None,
   border_color: None,
+  iframe_data: None,
 }
 let defaultIntent = {
   nextAction: defaultNextAction,
@@ -170,6 +172,7 @@ let getNextAction = (dict, str) => {
       next_action_data: Some(json->getDictFromDict("next_action_data")->JSON.Encode.object),
       display_text: json->getOptionString("display_text"),
       border_color: json->getOptionString("border_color"),
+      iframe_data: Some(json->Utils.getJsonObjectFromDict("iframe_data")),
     }
   })
   ->Option.getOr(defaultNextAction)

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -566,12 +566,7 @@ let rec intentCall = (
                 let borderColor = intent.nextAction.border_color->Option.getOr("")
                 let expiryTime = intent.nextAction.display_to_timestamp->Option.getOr(0.0)
                 let headerObj = Dict.make()
-                headers->Array.forEach(
-                  entries => {
-                    let (x, val) = entries
-                    Dict.set(headerObj, x, val->JSON.Encode.string)
-                  },
-                )
+                mergeHeadersIntoDict(~dict=headerObj, ~headers)
                 let metaData =
                   [
                     ("qrData", qrData->JSON.Encode.string),
@@ -615,12 +610,8 @@ let rec intentCall = (
                   ->getBoolValue
 
                 let headerObj = Dict.make()
-                headers->Array.forEach(
-                  entries => {
-                    let (x, val) = entries
-                    Dict.set(headerObj, x, val->JSON.Encode.string)
-                  },
-                )
+                mergeHeadersIntoDict(~dict=headerObj, ~headers)
+
                 let metaData =
                   [
                     ("threeDSData", threeDsData->JSON.Encode.object),
@@ -654,18 +645,38 @@ let rec intentCall = (
                     ("metadata", metaData->JSON.Encode.object),
                   ])
                 }
+              } else if intent.nextAction.type_ === "invoke_hidden_iframe" {
+                let iframeData =
+                  intent.nextAction.iframe_data
+                  ->Option.flatMap(JSON.Decode.object)
+                  ->Option.getOr(Dict.make())
+
+                let headerObj = Dict.make()
+                mergeHeadersIntoDict(~dict=headerObj, ~headers)
+                let metaData =
+                  [
+                    ("iframeData", iframeData->JSON.Encode.object),
+                    ("paymentIntentId", clientSecret->JSON.Encode.string),
+                    ("publishableKey", confirmParam.publishableKey->JSON.Encode.string),
+                    ("headers", headerObj->JSON.Encode.object),
+                    ("url", url.href->JSON.Encode.string),
+                    ("iframeId", iframeId->JSON.Encode.string),
+                    ("confirmParams", confirmParam->anyTypeToJson),
+                  ]->Dict.fromArray
+
+                messageParentWindow([
+                  ("fullscreen", true->JSON.Encode.bool),
+                  ("param", `redsys3ds`->JSON.Encode.string),
+                  ("iframeId", iframeId->JSON.Encode.string),
+                  ("metadata", metaData->JSON.Encode.object),
+                ])
               } else if intent.nextAction.type_ === "display_voucher_information" {
                 let voucherData = intent.nextAction.voucher_details->Option.getOr({
                   download_url: "",
                   reference: "",
                 })
                 let headerObj = Dict.make()
-                headers->Array.forEach(
-                  entries => {
-                    let (x, val) = entries
-                    Dict.set(headerObj, x, val->JSON.Encode.string)
-                  },
-                )
+                mergeHeadersIntoDict(~dict=headerObj, ~headers)
                 let metaData =
                   [
                     ("voucherUrl", voucherData.download_url->JSON.Encode.string),
@@ -987,6 +998,123 @@ let rec maskPayload = payloadJson => {
   }
 }
 
+let useCompleteAuthorizeHandler = () => {
+  open RecoilAtoms
+
+  let customPodUri = Recoil.useRecoilValueFromAtom(customPodUri)
+  let setIsManualRetryEnabled = Recoil.useSetRecoilState(isManualRetryEnabled)
+  let isCallbackUsedVal = Recoil.useRecoilValueFromAtom(isCompleteCallbackUsed)
+  let redirectionFlags = Recoil.useRecoilValueFromAtom(redirectionFlagsAtom)
+
+  (
+    ~clientSecret: option<string>,
+    ~bodyArr,
+    ~confirmParam: ConfirmType.confirmParams,
+    ~iframeId,
+    ~optLogger,
+    ~handleUserError,
+    ~paymentType,
+    ~sdkHandleOneClickConfirmPayment,
+    ~headers: option<array<(string, string)>>=?,
+    ~paymentMode: option<string>=?,
+  ) =>
+    switch clientSecret {
+    | Some(cs) =>
+      let endpoint = ApiEndpoint.getApiEndPoint(~publishableKey=confirmParam.publishableKey)
+      let uri = `${endpoint}/payments/${cs->getPaymentId}/complete_authorize`
+
+      let finalHeaders = switch headers {
+      | Some(h) => h
+      | None => [
+          ("Content-Type", "application/json"),
+          ("api-key", confirmParam.publishableKey),
+          ("X-Client-Source", paymentMode->Option.getOr("")),
+        ]
+      }
+      let bodyStr =
+        [("client_secret", cs->JSON.Encode.string)]
+        ->Array.concatMany([bodyArr, BrowserSpec.broswerInfo()])
+        ->getJsonFromArrayOfJson
+        ->JSON.stringify
+
+      intentCall(
+        ~fetchApi,
+        ~uri,
+        ~headers=finalHeaders,
+        ~bodyStr,
+        ~confirmParam,
+        ~clientSecret=cs,
+        ~optLogger,
+        ~handleUserError,
+        ~paymentType,
+        ~iframeId,
+        ~fetchMethod=#POST,
+        ~setIsManualRetryEnabled,
+        ~customPodUri,
+        ~sdkHandleOneClickConfirmPayment,
+        ~counter=0,
+        ~isCallbackUsedVal,
+        ~redirectionFlags,
+      )->ignore
+    | None =>
+      postFailedSubmitResponse(
+        ~errortype="complete_authorize_failed",
+        ~message="Complete Authorize Failed. Try Again!",
+      )
+    }
+}
+
+let useCompleteAuthorize = (optLogger, paymentType) => {
+  let completeAuthorizeHandler = useCompleteAuthorizeHandler()
+  let keys = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let paymentMethodList = Recoil.useRecoilValueFromAtom(RecoilAtoms.paymentMethodList)
+  let url = RescriptReactRouter.useUrl()
+  let mode =
+    CardUtils.getQueryParamsDictforKey(url.search, "componentName")
+    ->CardThemeType.getPaymentMode
+    ->CardThemeType.getPaymentModeToStrMapper
+
+  (~handleUserError=false, ~bodyArr, ~confirmParam, ~iframeId=keys.iframeId) =>
+    switch paymentMethodList {
+    | Loaded(_) =>
+      completeAuthorizeHandler(
+        ~clientSecret=keys.clientSecret,
+        ~bodyArr,
+        ~confirmParam,
+        ~iframeId,
+        ~optLogger,
+        ~handleUserError,
+        ~paymentType,
+        ~sdkHandleOneClickConfirmPayment=keys.sdkHandleOneClickConfirmPayment,
+        ~paymentMode=mode,
+      )
+    | _ => ()
+    }
+}
+
+let useRedsysCompleteAuthorize = optLogger => {
+  let completeAuthorizeHandler = useCompleteAuthorizeHandler()
+  (
+    ~handleUserError=false,
+    ~bodyArr,
+    ~confirmParam,
+    ~iframeId="redsys3ds",
+    ~clientSecret,
+    ~headers,
+  ) =>
+    completeAuthorizeHandler(
+      ~clientSecret,
+      ~bodyArr,
+      ~confirmParam,
+      ~iframeId,
+      ~optLogger,
+      ~handleUserError,
+      ~paymentType=Card,
+      ~sdkHandleOneClickConfirmPayment=false,
+      ~headers,
+    )
+}
+
 let usePaymentIntent = (optLogger, paymentType) => {
   open RecoilAtoms
   open Promise
@@ -1172,75 +1300,6 @@ let usePaymentIntent = (optLogger, paymentType) => {
       postFailedSubmitResponse(
         ~errortype="confirm_payment_failed",
         ~message="Payment failed. Try again!",
-      )
-    }
-  }
-}
-
-let useCompleteAuthorize = (optLogger: option<HyperLogger.loggerMake>, paymentType: payment) => {
-  open RecoilAtoms
-  let paymentMethodList = Recoil.useRecoilValueFromAtom(paymentMethodList)
-  let keys = Recoil.useRecoilValueFromAtom(keys)
-  let customPodUri = Recoil.useRecoilValueFromAtom(customPodUri)
-  let setIsManualRetryEnabled = Recoil.useSetRecoilState(isManualRetryEnabled)
-  let url = RescriptReactRouter.useUrl()
-  let isCallbackUsedVal = Recoil.useRecoilValueFromAtom(RecoilAtoms.isCompleteCallbackUsed)
-  let redirectionFlags = Recoil.useRecoilValueFromAtom(redirectionFlagsAtom)
-  let paymentTypeFromUrl =
-    CardUtils.getQueryParamsDictforKey(url.search, "componentName")->CardThemeType.getPaymentMode
-  (
-    ~handleUserError=false,
-    ~bodyArr: array<(string, JSON.t)>,
-    ~confirmParam: ConfirmType.confirmParams,
-    ~iframeId=keys.iframeId,
-  ) => {
-    switch keys.clientSecret {
-    | Some(clientSecret) =>
-      let paymentIntentID = clientSecret->getPaymentId
-      let headers = [
-        ("Content-Type", "application/json"),
-        ("api-key", confirmParam.publishableKey),
-        ("X-Client-Source", paymentTypeFromUrl->CardThemeType.getPaymentModeToStrMapper),
-      ]
-      let endpoint = ApiEndpoint.getApiEndPoint(~publishableKey=confirmParam.publishableKey)
-      let uri = `${endpoint}/payments/${paymentIntentID}/complete_authorize`
-
-      let browserInfo = BrowserSpec.broswerInfo
-      let bodyStr =
-        [("client_secret", clientSecret->JSON.Encode.string)]
-        ->Array.concatMany([bodyArr, browserInfo()])
-        ->getJsonFromArrayOfJson
-        ->JSON.stringify
-
-      let completeAuthorize = () => {
-        intentCall(
-          ~fetchApi,
-          ~uri,
-          ~headers,
-          ~bodyStr,
-          ~confirmParam: ConfirmType.confirmParams,
-          ~clientSecret,
-          ~optLogger,
-          ~handleUserError,
-          ~paymentType,
-          ~iframeId,
-          ~fetchMethod=#POST,
-          ~setIsManualRetryEnabled,
-          ~customPodUri,
-          ~sdkHandleOneClickConfirmPayment=keys.sdkHandleOneClickConfirmPayment,
-          ~counter=0,
-          ~isCallbackUsedVal,
-          ~redirectionFlags,
-        )->ignore
-      }
-      switch paymentMethodList {
-      | Loaded(_) => completeAuthorize()
-      | _ => ()
-      }
-    | None =>
-      postFailedSubmitResponse(
-        ~errortype="complete_authorize_failed",
-        ~message="Complete Authorize Failed. Try Again!",
       )
     }
   }

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -77,6 +77,22 @@ let getStringFromJson = (json, default) => {
   json->JSON.Decode.string->Option.getOr(default)
 }
 
+let convertDictToArrayOfKeyStringTuples = dict => {
+  dict
+  ->Dict.toArray
+  ->Array.map(entries => {
+    let (x, val) = entries
+    (x, val->JSON.Decode.string->Option.getOr(""))
+  })
+}
+
+let mergeHeadersIntoDict = (~dict, ~headers) => {
+  headers->Array.forEach(entries => {
+    let (x, val) = entries
+    Dict.set(dict, x, val->JSON.Encode.string)
+  })
+}
+
 let getInt = (dict, key, default: int) => {
   dict
   ->Dict.get(key)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Redsys 3DS auth implementation.

- handled new next action `invoke_hidden_iframe`

- Task Details:
new next action behavior (`invoke_hidden_iframe`) 
Construct a hidden Iframe as given bellow
endpoint: three_ds_method_url
input field name: method_key
input field value: three_ds_method_data
On submitting, wait for the 10sec time out. If submission of the form takes more than 10secs, call complete_authorize with client_secret and  `threeds_method_comp_ind` flag marked as "N" . Else send `threeds_method_comp_ind` marked as "Y".

`curl --location 'http://localhost:8080/payments/pay_2n5oBH26fEGkdLjsw152/complete_authorize' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_a4914922937e42f7a55065450b26aa1d' \
--data '{
    "threeds_method_comp_ind": "Y",
    "client_secret": "pay_2n5oBH26fEGkdLjsw152_secret_p8t3s9TtYkhjbV63hgax"
}'
`

This complete authorize call can either return the payment status with no next action or  return a redirect_to_url next action.

## How did you test it?
Tested Locally

https://github.com/user-attachments/assets/adc31198-496b-429e-819f-99930cdab444

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible


