### PR TITLE
chore: added logic for trimming nick name for larger length

### DIFF
--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -7,7 +7,13 @@ module RenderSavedPaymentMethodItem = {
         className="flex flex-col items-start"
         role="group"
         ariaLabel={`Card ${paymentItem.card.nickname}, ending in ${paymentItem.card.last4Digits}`}>
-        <div className="text-base tracking-wide"> {React.string(paymentItem.card.nickname)} </div>
+        <div className="text-base tracking-wide">
+          {React.string(
+            paymentItem.card.nickname->String.length > 15
+              ? paymentItem.card.nickname->String.slice(~start=0, ~end=13)->String.concat("..")
+              : paymentItem.card.nickname,
+          )}
+        </div>
         <div className={`PickerItemLabel flex flex-row gap-3 items-center text-sm`}>
           <div className="tracking-widest" ariaHidden=true> {React.string(`****`)} </div>
           <div className="tracking-wide" ariaHidden=true>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Added the logic for trimming nickname if the length is greater than 15 characters and append ".." at the end.

Before :-
<img width="479" alt="Screenshot 2025-03-28 at 1 06 28 PM" src="https://github.com/user-attachments/assets/d4c51d87-b5f6-4b34-b884-bd4739aa8853" />

After :-
<img width="477" alt="Screenshot 2025-03-28 at 1 07 07 PM" src="https://github.com/user-attachments/assets/7a7a2a83-70b3-478e-bcbd-d5872356e6ca" />

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested it locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
