### PR TITLE
refactor: remove appearance prop from various payment components

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -368,7 +368,6 @@ let make = (
               errorString=cardError
               paymentType
               type_="tel"
-              appearance=config.appearance
               maxLength=maxCardLength
               inputRef=cardRef
               placeholder="1234 1234 1234 1234"
@@ -386,7 +385,6 @@ let make = (
               errorString=expiryError
               paymentType
               type_="tel"
-              appearance=config.appearance
               maxLength=7
               inputRef=expiryRef
               placeholder=localeString.expiryPlaceholder
@@ -407,7 +405,6 @@ let make = (
                 ~color=themeObj.colorIconCardCvcError,
                 ~cardComplete,
               )}
-              appearance=config.appearance
               type_="tel"
               className="tracking-widest w-full"
               maxLength=4
@@ -426,7 +423,6 @@ let make = (
                 errorString=expiryError
                 paymentType
                 type_="tel"
-                appearance=config.appearance
                 maxLength=7
                 inputRef=expiryRef
                 placeholder=localeString.expiryPlaceholder
@@ -446,7 +442,6 @@ let make = (
                   ~color=themeObj.colorIconCardCvcError,
                   ~cardComplete,
                 )}
-                appearance=config.appearance
                 type_="tel"
                 className="tracking-widest w-full"
                 maxLength=4

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -18,7 +18,6 @@ let make = (
   ~maxLength=?,
   ~pattern=?,
   ~placeholder="",
-  ~appearance: CardThemeType.appearance,
   ~className="",
   ~inputRef,
 ) => {
@@ -81,7 +80,7 @@ let make = (
   <div className="flex flex-col w-full" style={color: themeObj.colorText}>
     <RenderIf
       condition={fieldName->String.length > 0 &&
-      appearance.labels == Above &&
+      config.appearance.labels == Above &&
       innerLayout === Spaced}>
       <div
         className={`Label ${labelClass}`}
@@ -112,7 +111,7 @@ let make = (
           ?maxLength
           ?pattern
           className={`${inputClassStyles} ${inputClass} ${className} focus:outline-none transition-shadow ease-out duration-200`}
-          placeholder={appearance.labels == Above ? placeholder : ""}
+          placeholder={config.appearance.labels == Above ? placeholder : ""}
           value
           autoComplete="on"
           onChange
@@ -120,7 +119,7 @@ let make = (
           onFocus=handleFocus
           ariaLabel={`Type to fill ${fieldName->String.length > 0 ? fieldName : name} input`}
         />
-        <RenderIf condition={appearance.labels == Floating}>
+        <RenderIf condition={config.appearance.labels == Floating}>
           <div
             className={`Label ${floatinglabelClass} ${labelClass} absolute bottom-0 ml-3 ${focusClass} text-opacity-20 pointer-events-none`}
             style={

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -239,7 +239,6 @@ let make = (
                       errorString=""
                       inputFieldClassName="flex justify-start"
                       paymentType
-                      appearance=config.appearance
                       type_="tel"
                       className={`tracking-widest justify-start w-full`}
                       maxLength=4

--- a/src/Payments/BacsBankDebit.res
+++ b/src/Payments/BacsBankDebit.res
@@ -24,7 +24,7 @@ let cleanSortCode = str => str->String.replaceRegExp(%re("/-/g"), "")
 let make = (~paymentType: CardThemeType.mode) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
-  let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
+  let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {displaySavedPaymentMethods} = Recoil.useRecoilValueFromAtom(optionAtom)
 
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankDebits)
@@ -145,7 +145,6 @@ let make = (~paymentType: CardThemeType.mode) => {
             errorString=sortCodeError
             isValid={sortCodeError == "" ? None : Some(false)}
             type_="tel"
-            appearance=config.appearance
             maxLength=8
             onBlur=sortcodeBlur
             inputRef=sortCodeRef
@@ -157,7 +156,6 @@ let make = (~paymentType: CardThemeType.mode) => {
             onChange=changeAccNum
             paymentType
             type_="text"
-            appearance=config.appearance
             inputRef=accNumRef
             placeholder="00012345"
           />

--- a/src/Payments/Boleto.res
+++ b/src/Payments/Boleto.res
@@ -25,7 +25,7 @@ let formatSocialSecurityNumber = socialSecurityNumber => {
 @react.component
 let make = (~paymentType: CardThemeType.mode) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
-  let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
+  let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Other)
@@ -94,7 +94,6 @@ let make = (~paymentType: CardThemeType.mode) => {
       errorString=socialSecurityNumberError
       isValid={socialSecurityNumberError == "" ? None : Some(false)}
       type_="tel"
-      appearance=config.appearance
       maxLength=14
       onBlur=socialSecurityNumberBlur
       inputRef=socialSecurityNumberRef

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -349,7 +349,6 @@ let make = (
               errorString=cardError
               paymentType
               type_="tel"
-              appearance=config.appearance
               maxLength=maxCardLength
               inputRef=cardRef
               placeholder="1234 1234 1234 1234"
@@ -374,7 +373,6 @@ let make = (
                   errorString=expiryError
                   paymentType
                   type_="tel"
-                  appearance=config.appearance
                   maxLength=7
                   inputRef=expiryRef
                   placeholder=localeString.expiryPlaceholder
@@ -397,7 +395,6 @@ let make = (
                     ~cardInvalid,
                     ~color=themeObj.colorIconCardCvcError,
                   )}
-                  appearance=config.appearance
                   type_="tel"
                   className={`tracking-widest w-full ${compressedLayoutStyleForCvcError}`}
                   maxLength=4


### PR DESCRIPTION
## Type of Change

- [x] Refactoring

## Description

prop unnecessary. component can use config.appearance directly


