### PR TITLE
refactor: card, cvc, expiry & zip props

### DIFF
--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -14,55 +14,108 @@ type cardIssuer =
   | INTERAC
   | NOTFOUND
 
-type cardProps = (
-  option<bool>,
-  (option<bool> => option<bool>) => unit,
-  option<bool>,
-  string,
-  JsxEvent.Form.t => unit,
-  JsxEvent.Focus.t => unit,
-  React.ref<Nullable.t<Dom.element>>,
-  React.element,
-  string,
-  (string => string) => unit,
-  int,
-  string,
-)
+type cardProps = {
+  isCardValid: option<bool>,
+  setIsCardValid: (option<bool> => option<bool>) => unit,
+  isCardSupported: option<bool>,
+  cardNumber: string,
+  changeCardNumber: JsxEvent.Form.t => unit,
+  handleCardBlur: JsxEvent.Focus.t => unit,
+  cardRef: React.ref<Nullable.t<Dom.element>>,
+  icon: React.element,
+  cardError: string,
+  setCardError: (string => string) => unit,
+  maxCardLength: int,
+  cardBrand: string,
+}
 
-type expiryProps = (
-  option<bool>,
-  (option<bool> => option<bool>) => unit,
-  string,
-  JsxEvent.Form.t => unit,
-  JsxEvent.Focus.t => unit,
-  React.ref<Nullable.t<Dom.element>>,
-  ReactEvent.Keyboard.t => unit,
-  string,
-  (string => string) => unit,
-)
+let defaultCardProps: cardProps = {
+  isCardValid: None,
+  setIsCardValid: _ => (),
+  isCardSupported: None,
+  cardNumber: "",
+  changeCardNumber: _ => (),
+  handleCardBlur: _ => (),
+  cardRef: React.useRef(Nullable.null),
+  icon: React.null,
+  cardError: "",
+  setCardError: _ => (),
+  maxCardLength: 0,
+  cardBrand: "",
+}
 
-type cvcProps = (
-  option<bool>,
-  (option<bool> => option<bool>) => unit,
-  string,
-  (string => string) => unit,
-  JsxEvent.Form.t => unit,
-  JsxEvent.Focus.t => unit,
-  React.ref<Nullable.t<Dom.element>>,
-  ReactEvent.Keyboard.t => unit,
-  string,
-  (string => string) => unit,
-)
-type zipProps = (
-  option<bool>,
-  (option<bool> => option<bool>) => unit,
-  string,
-  ReactEvent.Form.t => unit,
-  ReactEvent.Focus.t => unit,
-  React.ref<Nullable.t<Dom.element>>,
-  ReactEvent.Keyboard.t => unit,
-  bool,
-)
+type expiryProps = {
+  isExpiryValid: option<bool>,
+  setIsExpiryValid: (option<bool> => option<bool>) => unit,
+  cardExpiry: string,
+  changeCardExpiry: JsxEvent.Form.t => unit,
+  handleExpiryBlur: JsxEvent.Focus.t => unit,
+  expiryRef: React.ref<Nullable.t<Dom.element>>,
+  onExpiryKeyDown: ReactEvent.Keyboard.t => unit,
+  expiryError: string,
+  setExpiryError: (string => string) => unit,
+}
+
+let defaultExpiryProps: expiryProps = {
+  isExpiryValid: None,
+  setIsExpiryValid: _ => (),
+  cardExpiry: "",
+  changeCardExpiry: _ => (),
+  handleExpiryBlur: _ => (),
+  expiryRef: React.useRef(Nullable.null),
+  onExpiryKeyDown: _ => (),
+  expiryError: "",
+  setExpiryError: _ => (),
+}
+
+type cvcProps = {
+  isCVCValid: option<bool>,
+  setIsCVCValid: (option<bool> => option<bool>) => unit,
+  cvcNumber: string,
+  setCvcNumber: (string => string) => unit,
+  changeCVCNumber: JsxEvent.Form.t => unit,
+  handleCVCBlur: JsxEvent.Focus.t => unit,
+  cvcRef: React.ref<Nullable.t<Dom.element>>,
+  onCvcKeyDown: ReactEvent.Keyboard.t => unit,
+  cvcError: string,
+  setCvcError: (string => string) => unit,
+}
+
+let defaultCvcProps: cvcProps = {
+  isCVCValid: None,
+  setIsCVCValid: _ => (),
+  cvcNumber: "",
+  setCvcNumber: _ => (),
+  changeCVCNumber: _ => (),
+  handleCVCBlur: _ => (),
+  cvcRef: React.useRef(Nullable.null),
+  onCvcKeyDown: _ => (),
+  cvcError: "",
+  setCvcError: _ => (),
+}
+
+type zipProps = {
+  isZipValid: option<bool>,
+  setIsZipValid: (option<bool> => option<bool>) => unit,
+  zipCode: string,
+  changeZipCode: ReactEvent.Form.t => unit,
+  handleZipBlur: ReactEvent.Focus.t => unit,
+  zipRef: React.ref<Nullable.t<Dom.element>>,
+  onZipCodeKeyDown: ReactEvent.Keyboard.t => unit,
+  displayPincode: bool,
+}
+
+let defaultZipProps: zipProps = {
+  isZipValid: None,
+  setIsZipValid: _ => (),
+  zipCode: "",
+  changeZipCode: _ => (),
+  handleZipBlur: _ => (),
+  zipRef: React.useRef(Nullable.null),
+  onZipCodeKeyDown: _ => (),
+  displayPincode: false,
+}
+
 @val external document: 'a = "document"
 
 @send external focus: Dom.element => unit = "focus"

--- a/src/Components/AccordionContainer.res
+++ b/src/Components/AccordionContainer.res
@@ -57,7 +57,11 @@ module Loader = {
   }
 }
 @react.component
-let make = (~paymentOptions: array<string>, ~checkoutEle: React.element, ~cardProps) => {
+let make = (
+  ~paymentOptions: array<string>,
+  ~checkoutEle: React.element,
+  ~cardProps: CardUtils.cardProps,
+) => {
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let paymentMethodList = Recoil.useRecoilValueFromAtom(paymentMethodList)
   let {layout} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -65,7 +69,7 @@ let make = (~paymentOptions: array<string>, ~checkoutEle: React.element, ~cardPr
   let (showMore, setShowMore) = React.useState(_ => false)
   let (selectedOption, setSelectedOption) = Recoil.useRecoilState(selectedOptionAtom)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
-  let (_, _, _, _, _, _, _, _, _, _, _, cardBrand) = cardProps
+  let {cardBrand} = cardProps
 
   PaymentUtils.useEmitPaymentMethodInfo(
     ~paymentMethodName=selectedOption,

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -127,46 +127,6 @@ let make = (
     logger,
   )
 
-  let defaultCardProps = (
-    None,
-    _ => (),
-    None,
-    "",
-    _ => (),
-    _ => (),
-    React.useRef(Nullable.null),
-    React.null,
-    "",
-    _ => (),
-    0,
-    "",
-  )
-
-  let defaultExpiryProps = (
-    None,
-    _ => (),
-    "",
-    _ => (),
-    _ => (),
-    React.useRef(Nullable.null),
-    _ => (),
-    "",
-    _ => (),
-  )
-
-  let defaultCvcProps = (
-    None,
-    _ => (),
-    "",
-    _ => (),
-    _ => (),
-    _ => (),
-    React.useRef(Nullable.null),
-    _ => (),
-    "",
-    _ => (),
-  )
-
   let (stateJson, setStatesJson) = React.useState(_ => None)
 
   let bankNames = Bank.getBanks(paymentMethodType)->getBankNames(paymentMethodTypes.bank_names)
@@ -182,53 +142,45 @@ let make = (
     setCountry(val)
   }
 
-  let (
+  let {
     isCardValid,
     setIsCardValid,
-    _,
     cardNumber,
     changeCardNumber,
     handleCardBlur,
     cardRef,
     icon,
     cardError,
-    _,
     maxCardLength,
-    _,
-  ) = switch cardProps {
+  } = switch cardProps {
   | Some(cardProps) => cardProps
-  | None => defaultCardProps
+  | None => CardUtils.defaultCardProps
   }
 
-  let (
+  let {
     isExpiryValid,
     setIsExpiryValid,
     cardExpiry,
     changeCardExpiry,
     handleExpiryBlur,
     expiryRef,
-    _,
     expiryError,
-    _,
-  ) = switch expiryProps {
+  } = switch expiryProps {
   | Some(expiryProps) => expiryProps
-  | None => defaultExpiryProps
+  | None => CardUtils.defaultExpiryProps
   }
 
-  let (
+  let {
     isCVCValid,
     setIsCVCValid,
     cvcNumber,
-    _,
     changeCVCNumber,
     handleCVCBlur,
     cvcRef,
-    _,
     cvcError,
-    _,
-  ) = switch cvcProps {
+  } = switch cvcProps {
   | Some(cvcProps) => cvcProps
-  | None => defaultCvcProps
+  | None => CardUtils.defaultCvcProps
   }
 
   let isCvcValidValue = CardUtils.getBoolOptionVal(isCVCValid)

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -54,7 +54,7 @@ let make = (
   ~brandIcon,
   ~index,
   ~savedCardlength,
-  ~cvcProps,
+  ~cvcProps: CardUtils.cvcProps,
   ~setRequiredFieldsBody,
 ) => {
   let {themeObj, config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
@@ -64,18 +64,7 @@ let make = (
     displayBillingDetails,
   } = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let (cardBrand, setCardBrand) = Recoil.useRecoilState(RecoilAtoms.cardBrand)
-  let (
-    isCVCValid,
-    setIsCVCValid,
-    cvcNumber,
-    _,
-    changeCVCNumber,
-    handleCVCBlur,
-    _,
-    _,
-    cvcError,
-    _,
-  ) = cvcProps
+  let {isCVCValid, setIsCVCValid, cvcNumber, changeCVCNumber, handleCVCBlur, cvcError} = cvcProps
   let cvcRef = React.useRef(Nullable.null)
   let pickerItemClass = isActive ? "PickerItem--selected" : ""
 

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -137,7 +137,7 @@ let make = (
     </div>
   }
 
-  let (isCVCValid, _, cvcNumber, _, _, _, _, _, _, setCvcError) = cvcProps
+  let {isCVCValid, cvcNumber, setCvcError} = cvcProps
   let complete = switch isCVCValid {
   | Some(val) => paymentTokenVal !== "" && val
   | _ => false

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -403,7 +403,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     <CardSchemeComponent cardNumber paymentType cardBrand setCardBrand />
   }, (cardType, paymentType, cardBrand, cardNumber))
 
-  let cardProps: CardUtils.cardProps = (
+  let cardProps: CardUtils.cardProps = {
     isCardValid,
     setIsCardValid,
     isCardSupported,
@@ -416,9 +416,9 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     setCardError,
     maxCardLength,
     cardBrand,
-  )
+  }
 
-  let expiryProps: CardUtils.expiryProps = (
+  let expiryProps: CardUtils.expiryProps = {
     isExpiryValid,
     setIsExpiryValid,
     cardExpiry,
@@ -428,9 +428,9 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     onExpiryKeyDown,
     expiryError,
     setExpiryError,
-  )
+  }
 
-  let cvcProps: CardUtils.cvcProps = (
+  let cvcProps: CardUtils.cvcProps = {
     isCVCValid,
     setIsCVCValid,
     cvcNumber,
@@ -441,9 +441,9 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     onCvcKeyDown,
     cvcError,
     setCvcError,
-  )
+  }
 
-  let zipProps: CardUtils.zipProps = (
+  let zipProps: CardUtils.zipProps = {
     isZipValid,
     setIsZipValid,
     zipCode,
@@ -452,7 +452,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     zipRef,
     onZipCodeKeyDown,
     displayPincode,
-  )
+  }
 
   if integrateError {
     <ErrorOccured />

--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -47,7 +47,7 @@ let make = (
   ~dropDownOptions: array<string>,
   ~checkoutEle: React.element,
   ~cardShimmerCount: int,
-  ~cardProps,
+  ~cardProps: CardUtils.cardProps,
 ) => {
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {readOnly, customMethodNames} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -82,7 +82,7 @@ let make = (
     ->Array.find(item => item.paymentMethodName == selectedOption)
     ->Option.getOr(PaymentMethodsRecord.defaultPaymentMethodFields)
 
-  let (_, _, _, _, _, _, _, _, _, _, _, cardBrand) = cardProps
+  let {cardBrand} = cardProps
   React.useEffect(() => {
     let intervalId = setInterval(() => {
       if dropDownOptionsDetails->Array.length > 1 {

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -2,7 +2,12 @@ type target = {checked: bool}
 type event = {target: target}
 
 @react.component
-let make = (~cardProps, ~expiryProps, ~cvcProps, ~isBancontact=false) => {
+let make = (
+  ~cardProps: CardUtils.cardProps,
+  ~expiryProps: CardUtils.expiryProps,
+  ~cvcProps: CardUtils.cvcProps,
+  ~isBancontact=false,
+) => {
   open PaymentType
   open PaymentModeType
   open Utils
@@ -24,7 +29,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~isBancontact=false) => {
 
   let nickname = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCardNickName)
 
-  let (
+  let {
     isCardValid,
     setIsCardValid,
     isCardSupported,
@@ -37,32 +42,29 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~isBancontact=false) => {
     setCardError,
     maxCardLength,
     cardBrand,
-  ) = cardProps
+  } = cardProps
 
-  let (
+  let {
     isExpiryValid,
     setIsExpiryValid,
     cardExpiry,
     changeCardExpiry,
     handleExpiryBlur,
     expiryRef,
-    _,
     expiryError,
     setExpiryError,
-  ) = expiryProps
+  } = expiryProps
 
-  let (
+  let {
     isCVCValid,
     setIsCVCValid,
     cvcNumber,
-    _,
     changeCVCNumber,
     handleCVCBlur,
     cvcRef,
-    _,
     cvcError,
     setCvcError,
-  ) = cvcProps
+  } = cvcProps
   let {displaySavedPaymentMethodsCheckbox} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Card)
   let showFields = Recoil.useRecoilValueFromAtom(RecoilAtoms.showCardFieldsAtom)

--- a/src/RenderPaymentMethods.res
+++ b/src/RenderPaymentMethods.res
@@ -2,55 +2,36 @@ open RecoilAtoms
 @react.component
 let make = (
   ~paymentType: CardThemeType.mode,
-  ~cardProps,
-  ~expiryProps,
-  ~cvcProps,
-  ~zipProps,
+  ~cardProps: CardUtils.cardProps,
+  ~expiryProps: CardUtils.expiryProps,
+  ~cvcProps: CardUtils.cvcProps,
+  ~zipProps: CardUtils.zipProps,
   ~handleElementFocus,
   ~blurState,
   ~isFocus,
 ) => {
   let {showLoader} = Recoil.useRecoilValueFromAtom(configAtom)
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-  let (
+  let {
     isCardValid,
     setIsCardValid,
-    _,
     cardNumber,
     changeCardNumber,
     handleCardBlur,
     cardRef,
-    _,
-    _,
-    _,
     maxCardLength,
-    _,
-  ) = cardProps
+  } = cardProps
 
-  let (
+  let {
     isExpiryValid,
     setIsExpiryValid,
     cardExpiry,
     changeCardExpiry,
     handleExpiryBlur,
     expiryRef,
-    _,
-    _,
-    _,
-  ) = expiryProps
+  } = expiryProps
 
-  let (
-    isCVCValid,
-    setIsCVCValid,
-    cvcNumber,
-    _,
-    changeCVCNumber,
-    handleCVCBlur,
-    cvcRef,
-    _,
-    _,
-    _,
-  ) = cvcProps
+  let {isCVCValid, setIsCVCValid, cvcNumber, changeCVCNumber, handleCVCBlur, cvcRef} = cvcProps
 
   let blur = blurState ? "blur(2px)" : ""
   let frameRef = React.useRef(Nullable.null)

--- a/src/SingleLineCardPayment.res
+++ b/src/SingleLineCardPayment.res
@@ -3,10 +3,10 @@ open CardUtils
 @react.component
 let make = (
   ~paymentType: CardThemeType.mode,
-  ~cardProps,
-  ~expiryProps,
-  ~cvcProps,
-  ~zipProps,
+  ~cardProps: CardUtils.cardProps,
+  ~expiryProps: CardUtils.expiryProps,
+  ~cvcProps: CardUtils.cvcProps,
+  ~zipProps: CardUtils.zipProps,
   ~handleElementFocus,
   ~isFocus,
 ) => {
@@ -14,22 +14,18 @@ let make = (
   let options = Recoil.useRecoilValueFromAtom(elementOptions)
   let {localeString} = Recoil.useRecoilValueFromAtom(configAtom)
 
-  let (
+  let {
     isCardValid,
     setIsCardValid,
-    _,
     cardNumber,
     changeCardNumber,
     handleCardBlur,
     cardRef,
     icon,
-    _,
-    _,
     maxCardLength,
-    _,
-  ) = cardProps
+  } = cardProps
 
-  let (
+  let {
     isExpiryValid,
     setIsExpiryValid,
     cardExpiry,
@@ -37,24 +33,19 @@ let make = (
     handleExpiryBlur,
     expiryRef,
     onExpiryKeyDown,
-    _,
-    _,
-  ) = expiryProps
+  } = expiryProps
 
-  let (
+  let {
     isCVCValid,
     setIsCVCValid,
     cvcNumber,
-    _,
     changeCVCNumber,
     handleCVCBlur,
     cvcRef,
     onCvcKeyDown,
-    _,
-    _,
-  ) = cvcProps
+  } = cvcProps
 
-  let (
+  let {
     isZipValid,
     setIsZipValid,
     zipCode,
@@ -63,7 +54,7 @@ let make = (
     zipRef,
     onZipCodeKeyDown,
     displayPincode,
-  ) = zipProps
+  } = zipProps
 
   let isCardValidValue = getBoolOptionVal(isCardValid)
   let isExpiryValidValue = getBoolOptionVal(isExpiryValid)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removed tuple and added typed records for refactoring of card, cvc, expiry and zip props.

## How did you test it?

Via compiling and basic sanity.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
