### PR TITLE
chore: add custom autocomplete attributes for card details

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -331,6 +331,7 @@ let make = (
               maxLength=maxCardLength
               inputRef=cardRef
               placeholder="1234 1234 1234 1234"
+              autocomplete="cc-number"
             />
           | CardExpiryMonth
           | CardExpiryYear
@@ -347,6 +348,7 @@ let make = (
               maxLength=7
               inputRef=expiryRef
               placeholder=localeString.expiryPlaceholder
+              autocomplete="cc-exp"
             />
           | CardCvc =>
             <PaymentInputField
@@ -368,6 +370,7 @@ let make = (
               maxLength=4
               inputRef=cvcRef
               placeholder="123"
+              autocomplete="cc-csc"
             />
           | CardExpiryAndCvc =>
             <div className="flex gap-10">
@@ -383,6 +386,7 @@ let make = (
                 maxLength=7
                 inputRef=expiryRef
                 placeholder=localeString.expiryPlaceholder
+                autocomplete="cc-exp"
               />
               <PaymentInputField
                 fieldName=localeString.cvcTextLabel
@@ -403,6 +407,7 @@ let make = (
                 maxLength=4
                 inputRef=cvcRef
                 placeholder="123"
+                autocomplete="cc-csc"
               />
             </div>
           | Currency(currencyArr) =>

--- a/src/Components/InputField.res
+++ b/src/Components/InputField.res
@@ -24,6 +24,7 @@ let make = (
   ~isFocus,
   ~labelClassName="",
   ~paymentType: option<CardThemeType.mode>=?,
+  ~autocomplete="on",
 ) => {
   open ElementType
   let (eleClassName, setEleClassName) = React.useState(_ => "input-base")
@@ -144,6 +145,7 @@ let make = (
         onChange
         onBlur=handleBlur
         onFocus=handleFocus
+        autoComplete={autocomplete}
         ariaLabel={`Type to fill ${fieldName} input`}
       />
       <div className={`flex -ml-10  items-center`}> {rightIcon} </div>

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -22,6 +22,7 @@ let make = (
   ~className="",
   ~inputRef,
   ~paymentType=?,
+  ~autocomplete="on",
 ) => {
   let {themeObj, config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {innerLayout} = config.appearance
@@ -117,7 +118,7 @@ let make = (
           className={`${inputClassStyles} ${inputClass} ${className} focus:outline-none transition-shadow ease-out duration-200`}
           placeholder={config.appearance.labels == Above ? placeholder : ""}
           value
-          autoComplete="on"
+          autoComplete={autocomplete}
           onChange
           onBlur=handleBlur
           onFocus=handleFocus

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -233,6 +233,7 @@ let make = (
                       placeholder="123"
                       height="1.8rem"
                       name={TestUtils.cardCVVInputTestId}
+                      autocomplete="cc-csc"
                     />
                   </div>
                 </div>

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -351,6 +351,7 @@ let make = (
                 ? "border-b-0"
                 : ""}
               name=TestUtils.cardNoInputTestId
+              autocomplete="cc-number"
             />
             <div
               className="flex flex-row w-full place-content-between"
@@ -371,6 +372,7 @@ let make = (
                   inputRef=expiryRef
                   placeholder=localeString.expiryPlaceholder
                   name=TestUtils.expiryInputTestId
+                  autocomplete="cc-exp"
                 />
               </div>
               <div className={innerLayout === Spaced ? "w-[47%]" : "w-[50%]"}>
@@ -394,6 +396,7 @@ let make = (
                   inputRef=cvcRef
                   placeholder="123"
                   name=TestUtils.cardCVVInputTestId
+                  autocomplete="cc-csc"
                 />
               </div>
             </div>

--- a/src/RenderPaymentMethods.res
+++ b/src/RenderPaymentMethods.res
@@ -94,6 +94,7 @@ let make = (
             placeholder="1234 1234 1234 1234"
             id="card-number"
             isFocus
+            autocomplete="cc-number"
           />
         | CardExpiryElement =>
           <InputField
@@ -109,6 +110,7 @@ let make = (
             placeholder=localeString.expiryPlaceholder
             id="card-expiry"
             isFocus
+            autocomplete="cc-exp"
           />
         | CardCVCElement =>
           <InputField
@@ -125,6 +127,7 @@ let make = (
             placeholder="123"
             id="card-cvc"
             isFocus
+            autocomplete="cc-csc"
           />
         | PaymentMethodsManagement =>
           <ReusableReactSuspense

--- a/src/SingleLineCardPayment.res
+++ b/src/SingleLineCardPayment.res
@@ -124,6 +124,7 @@ let make = (
             inputRef=cardRef
             placeholder="1234 1234 1234 1234"
             isFocus
+            autocomplete="cc-number"
           />
         </div>
       </div>}
@@ -143,6 +144,7 @@ let make = (
             inputRef=expiryRef
             placeholder=localeString.expiryPlaceholder
             isFocus
+            autocomplete="cc-exp"
           />
         </div>
         <div className="w-1/5">
@@ -161,6 +163,7 @@ let make = (
             inputRef=cvcRef
             placeholder="123"
             isFocus
+            autocomplete="cc-csc"
           />
         </div>
         <RenderIf condition={!options.hidePostalCode}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added custom autocomplete attributes for card details.
card number : `cc-number`
card exp : `cc-exp`
card CVC : `cc-csc`
<!-- Describe your changes in detail -->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
