### PR TITLE
fix: fullname input error correction

### DIFF
--- a/src/Components/FullNamePaymentInput.res
+++ b/src/Components/FullNamePaymentInput.res
@@ -31,6 +31,11 @@ let make = (~customFieldName=None, ~optionalRequiredFields=None) => {
     }
   }
 
+  React.useEffect(() => {
+    setFullName(prev => validateName(prev.value, prev, localeString))
+    None
+  }, [])
+
   let changeName = ev => {
     let val: string = ReactEvent.Form.target(ev)["value"]
     setFullName(prev => validateName(val, prev, localeString))


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The wrong error message is initially shown in the full name input field.
<!-- Describe your changes in detail -->

## How did you test it?
I have tested it in local react demo.

Before:
![Screenshot 2025-04-08 at 1 50 52 pm](https://github.com/user-attachments/assets/1f910b66-bdde-44b5-b4a6-24ec3d5621c3)


After:
![Screenshot 2025-04-08 at 1 51 19 pm](https://github.com/user-attachments/assets/b18671a5-3d82-4fd9-9f91-d7c2ecde7477)


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
