### PR TITLE
fix: app.js twice render fix

### DIFF
--- a/public/fullscreenIndexTemplate.html
+++ b/public/fullscreenIndexTemplate.html
@@ -39,7 +39,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="app"></div>
-    <script src="<%= publicPath%>/app.js"></script>
 
     <!--
       This HTML file is a template.


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fix for App.js rendering twice due to manual adding of 
`<script src="<%= publicPath%>/app.js"></script>` inside fullscreenIndexTemplate.html and injecting the same via webpack config
`inject: true`

that caused the loading of app.js twice

## How did you test it?

tested locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
