### PR TITLE
chore: add a classname to tab header element

### DIFF
--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -121,7 +121,7 @@ let make = (
   <div className="w-full">
     <div
       ref={payOptionsRef->ReactDOM.Ref.domRef}
-      className="flex flex-row overflow-auto no-scrollbar"
+      className="TabHeader flex flex-row overflow-auto no-scrollbar"
       dataTestId={TestUtils.paymentMethodListTestId}
       style={
         columnGap: themeObj.spacingTab,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds a class name to the Tab Header element in the payment widget.

## How did you test it?
-

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
