### PR TITLE
fix: visa CTP passkey auth fix

### DIFF
--- a/src/Types/ClickToPayHelpers.res
+++ b/src/Types/ClickToPayHelpers.res
@@ -1149,6 +1149,8 @@ let loadClickToPayUIScripts = (
   }
 }
 
+let formatOrderId = orderId => orderId->String.replace("pay_", "")->String.slice(~start=0, ~end=48)
+
 let getVisaInitConfig = (token: clickToPayToken, clientSecret) => {
   {
     dpaTransactionOptions: {
@@ -1170,7 +1172,7 @@ let getVisaInitConfig = (token: clickToPayToken, clientSecret) => {
       acquirerMerchantId: token.acquirerMerchantId,
       merchantCategoryCode: token.merchantCategoryCode,
       merchantCountryCode: token.merchantCountryCode,
-      merchantOrderId: clientSecret->Option.getOr(""),
+      merchantOrderId: clientSecret->Option.getOr("")->formatOrderId,
     },
   }
 }
@@ -1209,7 +1211,7 @@ let checkoutVisaUnified = async (
       acquirerBIN: clickToPayToken.acquirerBIN,
       acquirerMerchantId: clickToPayToken.acquirerMerchantId,
       merchantName: clickToPayToken.dpaName,
-      merchantOrderId: orderId,
+      merchantOrderId: orderId->formatOrderId,
     },
   }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

merchantOrderId length should be less than 50 for passkey authentication

## How did you test it?

tested locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
