### PR TITLE
 feat: Add lightweight Dockerfile for Helm and CDK-based deployments

### DIFF
--- a/Dockerfile.helm
+++ b/Dockerfile.helm
@@ -1,0 +1,45 @@
+# Stage 1: Build the assets
+FROM node:lts AS builder
+
+# Set the build environment as an argument
+ARG sdkEnv=sandbox
+ARG sdkVersion=main
+RUN if [ "$sdkVersion" != "main" ]; then gitBranch="v$sdkVersion"; else gitBranch="$sdkVersion"; fi && \
+    git clone --branch ${gitBranch} https://github.com/juspay/hyperswitch-web --depth 1 /app
+
+# Set the working directory to the cloned repository
+WORKDIR /app
+
+ENV ENV_BACKEND_URL=https://beta.hyperswitch.io/api
+# Install dependencies and build the project
+RUN npm_config_ignore_scripts=true npm install
+RUN npm run re:build
+RUN npm run build:sandbox
+# Stage 2: Serve the built assets
+FROM nginx:alpine
+
+# Set working directory and copy the built assets from the builder stage
+WORKDIR /usr/share/nginx/html
+ARG sdkVersion
+ARG port=80
+ARG nginxPath=/usr/share/nginx/html/web/$sdkVersion
+COPY --from=builder /app/dist/sandbox $nginxPath
+WORKDIR $nginxPath/v1
+
+# Add the embedded entrypoint script
+RUN printf '\
+echo "Starting build modifications..."\n\
+if [ -n "$envSdkUrl" ]; then\n\
+  sed -i'' -e "s|https://beta.hyperswitch.io/web%7C${envSdkUrl}/web%7Cg" app.js HyperLoader.js\n\
+fi\n\
+if [ -n "$envBackendUrl" ]; then\n\
+  sed -i'' -e "s|https://beta.hyperswitch.io/api%7C${envBackendUrl}%7Cg" app.js HyperLoader.js\n\
+fi\n\
+if [ -n "$envLogsUrl" ]; then\n\
+  sed -i'' -e "s|https://sandbox.hyperswitch.io/logs/sdk%7C${envLogsUrl}%7Cg" app.js HyperLoader.js\n\
+fi\n\
+echo "Build modifications completed."\n\
+exec "$@"' > /docker-entrypoint.d/change_urls.sh && chmod +x /docker-entrypoint.d/change_urls.sh
+
+# Use the embedded entrypoint script and run Nginx
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR introduces `Dockerfile.helm`, a lightweight Docker image tailored for Helm and CDK-based deployments.
This image builds the Hyperswitch Web SDK using `Node.js` and serves it via a minimal `Nginx` image.

Key Highlights:

Adds a two-stage build process:

- Clones the repo and builds the SDK using Node.js
- Serves the built assets using a minimal Nginx container

Supports dynamic environment variable substitution for:

- `envSdkUrl`
- `envBackendUrl`
- `envLogsUrl`

Image is intended for use in production-like deployments via Helm charts and AWS CDK stacks.
This addition does not affect the existing primary Dockerfile and keeps the deployment concerns separate and modular.

## How did you test it?

`docker run -p 9050:80 juspaydotin/hyperswitch-web:v0.109.2`

https://github.com/user-attachments/assets/4c6e5723-2f58-4ad6-b7a8-f7321b9123fe

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible



