### PR TITLE
revert: rollback CSP header changes

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -46,12 +46,12 @@ echo
 echo "${YELLOW}*****~~~~~ Commit message validation! ~~~~~*****${NC}"
 echo
 
-commit_regex="^(Merge branch|(feat|fix|chore|refactor|docs|test|style|enhancement|ci)(\([a-zA-Z0-9-]+\))?:).+"
+commit_regex="^(Merge branch|(feat|fix|chore|refactor|docs|test|style|enhancement|ci|revert)(\([a-zA-Z0-9-]+\))?:).+"
 
 if ! echo "$commit_msg" | grep -Ei "$commit_regex" ; then
     echo "${RED}Aborting commit. Your commit message does not follow the conventional format.${NC}"
     echo "${YELLOW}The commit message should begin with one of the following keywords followed by a colon and an optional scope in parentheses:${NC}"
-    echo "${YELLOW}'feat', 'fix', 'chore', 'refactor', 'docs', 'test', 'style', 'enhancement', or 'ci'${NC}"
+    echo "${YELLOW}'feat', 'fix', 'chore', 'refactor', 'docs', 'test', 'style', 'enhancement', 'revert', or 'ci'${NC}"
     echo "${YELLOW}Example: 'feat(api): add user authentication endpoint' or 'fix(ui): resolve button alignment issue'${NC}"
     exit 1
 fi

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -265,8 +265,8 @@ module.exports = (publicPath = "auto") => {
     new HtmlWebpackPlugin({
       inject: true,
       template: "./public/build.html",
-      //       chunks: ["app"],
-      //       scriptLoading: "blocking",
+      chunks: ["app"],
+      scriptLoading: "blocking",
       //       // Add CSP meta tag
       //       meta: {
       //         "Content-Security-Policy": {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -265,23 +265,23 @@ module.exports = (publicPath = "auto") => {
     new HtmlWebpackPlugin({
       inject: true,
       template: "./public/build.html",
-      chunks: ["app"],
-      scriptLoading: "blocking",
-      // Add CSP meta tag
-      meta: {
-        "Content-Security-Policy": {
-          "http-equiv": "Content-Security-Policy",
-          content: `default-src 'self' ; script-src ${authorizedScriptSources.join(
-            " "
-          )}; 
-          style-src ${authorizedStyleSources.join(" ")};
-          frame-src ${authorizedFrameSources.join(" ")};
-          img-src ${authorizedImageSources.join(" ")};
-          font-src ${authorizedFontSources.join(" ")}; 
-          connect-src ${authorizedConnectSources.join(" ")} ${logEndpoint} ;
-`,
-        },
-      },
+      //       chunks: ["app"],
+      //       scriptLoading: "blocking",
+      //       // Add CSP meta tag
+      //       meta: {
+      //         "Content-Security-Policy": {
+      //           "http-equiv": "Content-Security-Policy",
+      //           content: `default-src 'self' ; script-src ${authorizedScriptSources.join(
+      //             " "
+      //           )};
+      //           style-src ${authorizedStyleSources.join(" ")};
+      //           frame-src ${authorizedFrameSources.join(" ")};
+      //           img-src ${authorizedImageSources.join(" ")};
+      //           font-src ${authorizedFontSources.join(" ")};
+      //           connect-src ${authorizedConnectSources.join(" ")} ${logEndpoint} ;
+      // `,
+      //         },
+      //       },
     }),
     new HtmlWebpackPlugin({
       // Also generate a test.html
@@ -289,20 +289,20 @@ module.exports = (publicPath = "auto") => {
       filename: "fullscreenIndex.html",
       template: "./public/fullscreenIndexTemplate.html",
       // Add CSP meta tag
-      meta: {
-        "Content-Security-Policy": {
-          "http-equiv": "Content-Security-Policy",
-          content: `default-src 'self' ; script-src ${authorizedScriptSources.join(
-            " "
-          )};
-          style-src ${authorizedStyleSources.join(" ")};
-          frame-src ${authorizedFrameSources.join(" ")}; 
-          img-src ${authorizedImageSources.join(" ")};
-          font-src ${authorizedFontSources.join(" ")};
-          connect-src ${authorizedConnectSources.join(" ")} ${logEndpoint} ;
-          `,
-        },
-      },
+      // meta: {
+      //   "Content-Security-Policy": {
+      //     "http-equiv": "Content-Security-Policy",
+      //     content: `default-src 'self' ; script-src ${authorizedScriptSources.join(
+      //       " "
+      //     )};
+      //     style-src ${authorizedStyleSources.join(" ")};
+      //     frame-src ${authorizedFrameSources.join(" ")};
+      //     img-src ${authorizedImageSources.join(" ")};
+      //     font-src ${authorizedFontSources.join(" ")};
+      //     connect-src ${authorizedConnectSources.join(" ")} ${logEndpoint} ;
+      //     `,
+      //   },
+      // },
     }),
     new SubresourceIntegrityPlugin({
       hashFuncNames: ["sha384"],


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removed CSP headers due to issues with dynamic ACS (Access Control Server) URLs, which were causing payment failures. Since other dynamic or unknown URLs may also be blocked, we are reverting the CSP configuration for now.

CSP will be reintroduced after a thorough audit and verification of all required endpoints and domains to ensure safe and functional integration.


## How did you test it?

I have tested it in the local react demo app.
<img width="1481" alt="Screenshot 2025-05-09 at 2 10 47 pm" src="https://github.com/user-attachments/assets/dfac015d-d300-4ef5-9d9f-8af3a3735b87" />

https://github.com/user-attachments/assets/1ca8b46a-e9f1-4387-a888-47688839f7f2


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
