### PR TITLE
feat: 3ds redirection inside popup

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -70,6 +70,7 @@ let make = () => {
     | "redsys3ds" => <Redsys3ds />
     | "3ds" => <ThreeDSMethod />
     | "voucherData" => <VoucherDisplay />
+    | "3dsRedirectionPopup" => <ThreeDSRedirectionModal />
     | "preMountLoader" => {
         let clientSecret = getQueryParamsDictforKey(url.search, "clientSecret")
         let sessionId = getQueryParamsDictforKey(url.search, "sessionId")

--- a/src/Payments/ThreeDSRedirectionModal.res
+++ b/src/Payments/ThreeDSRedirectionModal.res
@@ -1,0 +1,48 @@
+open Utils
+
+@react.component
+let make = () => {
+  let (popupUrl, setPopupUrl) = React.useState(_ => "")
+  let (openModal, setOpenModal) = React.useState(_ => false)
+  let (loader, setloader) = React.useState(_ => false)
+  let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
+
+  let eventsToSendToParent = ["openurl_if_required"]
+  eventsToSendToParent->UtilityHooks.useSendEventsToParent
+
+  let handleOnClose = () => {
+    Utils.messageParentWindow([("fullscreen", false->JSON.Encode.bool)])
+    postFailedSubmitResponse(~errortype="error", ~message="Something went wrong.")
+  }
+
+  React.useEffect0(() => {
+    messageParentWindow([("iframeMountedCallback", true->JSON.Encode.bool)])
+    setloader(_ => true)
+    let handle = (ev: Window.event) => {
+      try {
+        let json = ev.data->safeParse
+        let dict = json->getDictFromJson
+        if dict->Dict.get("fullScreenIframeMounted")->Option.isSome {
+          let metadata = dict->getJsonObjectFromDict("metadata")
+          let metaDataDict = metadata->JSON.Decode.object->Option.getOr(Dict.make())
+          let popupUrl = metaDataDict->getString("popupUrl", "")
+          setPopupUrl(_ => popupUrl)
+          setloader(_ => false)
+        }
+      } catch {
+      | err => {
+          let exceptionMessage = err->formatException->JSON.stringify
+          loggerState.setLogError(~value=exceptionMessage, ~eventName=THREE_DS_POPUP_REDIRECTION)
+          postFailedSubmitResponse(~errortype="error", ~message="Something went wrong.")
+        }
+      }
+    }
+    Window.addEventListener("message", handle)
+    Some(() => Window.removeEventListener("message", handle))
+  })
+  <Modal loader openModal setOpenModal closeCallback=handleOnClose>
+    <div className="w-full h-[500px] bg-white">
+      <iframe className="w-full h-full" src={popupUrl} />
+    </div>
+  </Modal>
+}

--- a/src/Types/HyperLoggerTypes.res
+++ b/src/Types/HyperLoggerTypes.res
@@ -93,6 +93,7 @@ type eventName =
   | CLICK_TO_PAY_SCRIPT
   | CLICK_TO_PAY_FLOW
   | PAYMENT_METHOD_TYPE_DETECTION_FAILED
+  | THREE_DS_POPUP_REDIRECTION
 
 type maskableDetails = Email | CardDetails
 type source = Loader | Elements(CardThemeType.mode) | Headless

--- a/src/Types/PaymentConfirmTypes.res
+++ b/src/Types/PaymentConfirmTypes.res
@@ -35,6 +35,7 @@ type voucherDetails = {
 
 type nextAction = {
   redirectToUrl: string,
+  popupUrl: string,
   type_: string,
   bank_transfer_steps_and_charges_details: option<JSON.t>,
   session_token: option<JSON.t>,
@@ -65,6 +66,7 @@ let defaultRedirectTourl = {
 }
 let defaultNextAction = {
   redirectToUrl: "",
+  popupUrl: "",
   type_: "",
   bank_transfer_steps_and_charges_details: None,
   session_token: None,
@@ -140,6 +142,7 @@ let getNextAction = (dict, str) => {
   ->Option.map(json => {
     {
       redirectToUrl: getString(json, "redirect_to_url", ""),
+      popupUrl: getString(json, "popup_url", ""),
       type_: getString(json, "type", ""),
       bank_transfer_steps_and_charges_details: Some(
         getJsonObjFromDict(

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -536,6 +536,22 @@ let rec intentCall = (
                   ~paymentMethod,
                 )
                 handleOpenUrl(intent.nextAction.redirectToUrl)
+              } else if intent.nextAction.type_ == "redirect_inside_popup" {
+                let popupUrl = intent.nextAction.popupUrl
+                handleLogging(
+                  ~optLogger,
+                  ~value="",
+                  ~internalMetadata=popupUrl,
+                  ~eventName=THREE_DS_POPUP_REDIRECTION,
+                  ~paymentMethod,
+                )
+                let metaData = [("popupUrl", popupUrl->JSON.Encode.string)]->Dict.fromArray
+                messageParentWindow([
+                  ("fullscreen", true->JSON.Encode.bool),
+                  ("param", `3dsRedirectionPopup`->JSON.Encode.string),
+                  ("iframeId", iframeId->JSON.Encode.string),
+                  ("metadata", metaData->JSON.Encode.object),
+                ])
               } else if intent.nextAction.type_ == "display_bank_transfer_information" {
                 let metadata = switch intent.nextAction.bank_transfer_steps_and_charges_details {
                 | Some(obj) => obj->getDictFromJson


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
New 3DS authentication flow inside a modal dialog in Hyperswitch, Merchants can choose between top level redirection (replacing the current window) and an in-page iframe-based modal, merchants gain better control over UI, faster flows, without leaving the checkout context.

To enable the redirection inside iframe, Merchants need to pass 
 `is_iframe_redirection_enabled: true`
with paymentData object for creating paymentIntent.

## How did you test it?
tested locally

https://github.com/user-attachments/assets/5356b11f-13a7-4a25-80e0-6e76e717cb6c


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
