### PR TITLE
fix: use window.top.location.hostname for merchant's domain in sessions call

### DIFF
--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -1348,7 +1348,7 @@ let fetchSessions = (
   ~customPodUri,
   ~endpoint,
   ~isPaymentSession=false,
-  ~merchantHostname=Window.Location.hostname,
+  ~merchantHostname=Window.getRootHostName(),
 ) => {
   open Promise
   let headers = [


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Described in https://github.com/juspay/hyperswitch-web/issues/1041

## How did you test it?
NA

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
