### PR TITLE
fix: hs saas cleanup event listener and error messages

### DIFF
--- a/src/Payments/CardVault.res
+++ b/src/Payments/CardVault.res
@@ -171,10 +171,14 @@ let make = () => {
 
         ev.source->Window.sendPostMessage(msg)
       } else {
+        let msg = [("errorMsg", "Payment token not found"->JSON.Encode.string)]->Dict.fromArray
+        ev.source->Window.sendPostMessage(msg)
         Console.error("Payment token not found ")
       }
     } catch {
     | err =>
+      let msg = [("errorMsg", "Something went wrong."->JSON.Encode.string)]->Dict.fromArray
+      ev.source->Window.sendPostMessage(msg)
       let exceptionMessage = err->formatException->JSON.stringify
       Console.error2("Unable to Save Card ", exceptionMessage)
     }

--- a/src/Payments/CardVault.res
+++ b/src/Payments/CardVault.res
@@ -176,10 +176,11 @@ let make = () => {
         Console.error("Payment token not found ")
       }
     } catch {
-    | err =>
-      let msg = [("errorMsg", "Something went wrong."->JSON.Encode.string)]->Dict.fromArray
+    | Exn.Error(err) =>
+      let errorMsg = err->Exn.message->Option.getOr("Something went wrong")->JSON.Encode.string
+      let msg = [("errorMsg", errorMsg)]->Dict.fromArray
       ev.source->Window.sendPostMessage(msg)
-      let exceptionMessage = err->formatException->JSON.stringify
+      let exceptionMessage = err->Exn.anyToExnInternal->formatException->JSON.stringify
       Console.error2("Unable to Save Card ", exceptionMessage)
     }
   }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
The confirm-intent event listener was not being properly cleaned up, causing it to be attached multiple times. This resulted in multiple confirm-intent calls on subsequent attempts.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
