### PR TITLE
chore: dynamic fields enabled for some payment methods

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -193,6 +193,11 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     switch paymentMethodList {
     | Loaded(paymentlist) =>
       let plist = paymentlist->getDictFromJson->PaymentMethodsRecord.itemToObjMapper
+      // Merge duplicate payment methods
+      let mergedPaymentMethods = PaymentMethodsRecord.mergeDuplicatePaymentMethods(
+        plist.payment_methods,
+      )
+      let mergedPlist = {...plist, payment_methods: mergedPaymentMethods}
 
       setPaymentOptions(_ =>
         [
@@ -201,7 +206,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
         ]->removeDuplicate
       )
       setWalletOptions(_ => walletList)
-      setPaymentMethodListValue(_ => plist)
+      setPaymentMethodListValue(_ => mergedPlist)
 
       if !(actualList->Array.includes(selectedOption)) && selectedOption !== "" {
         ErrorUtils.manageErrorWarning(

--- a/src/Payments/BankTransfersPopup.res
+++ b/src/Payments/BankTransfersPopup.res
@@ -17,7 +17,7 @@ let make = (~transferType) => {
   | "achBankTransfer" => ("ach_credit_transfer", "ACH")
   | "bacsBankTransfer" => ("bacs_bank_instructions", "BACS")
   | "sepaBankTransfer" => ("sepa_bank_instructions", "SEPA")
-  | _ => ("", "")
+  | _ => ("doku_bank_transfer_instructions", "")
   }
 
   let (isCopied, setIsCopied) = React.useState(_ => false)

--- a/src/Payments/VoucherDisplay.res
+++ b/src/Payments/VoucherDisplay.res
@@ -54,17 +54,24 @@ let make = () => {
               `${paymentMethod->snakeToTitleCase} voucher was successfully generated! If the document hasn't started downloading automatically, click `,
             )}
             <a
-              className="text font-medium text-sm text-[#006DF9] underline"
-              href=downloadUrl
+              className={`text font-medium text-sm underline ${downloadUrl == ""
+                  ? "text-gray-400 cursor-not-allowed"
+                  : "text-[#006DF9]"}`}
+              href={downloadUrl}
+              target="_blank"
               ref={linkRef->ReactDOM.Ref.domRef}
-              onClick={_ => {
-                setDownloadCounter(c => c + 1)
-                LoggerUtils.handleLogging(
-                  ~optLogger=Some(logger),
-                  ~value=downloadCounter->Int.toString,
-                  ~eventName=DISPLAY_VOUCHER,
-                  ~paymentMethod,
-                )
+              onClick={ev => {
+                if downloadUrl == "" {
+                  ReactEvent.Mouse.preventDefault(ev)
+                } else {
+                  setDownloadCounter(c => c + 1)
+                  LoggerUtils.handleLogging(
+                    ~optLogger=Some(logger),
+                    ~value=downloadCounter->Int.toString,
+                    ~eventName=DISPLAY_VOUCHER,
+                    ~paymentMethod,
+                  )
+                }
               }}>
               {React.string("here")}
             </a>

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -30,6 +30,16 @@ let dynamicFieldsEnabledPaymentMethods = [
   "paypal",
   "instant_bank_transfer_finland",
   "instant_bank_transfer_poland",
+  "seven_eleven",
+  "mini_stop",
+  "family_mart",
+  "seicomart",
+  "pay_easy",
+  "lawson",
+  "alfamart",
+  "indomaret",
+  "oxxo",
+  "pay_safe_card",
 ]
 
 let getName = (item: PaymentMethodsRecord.required_fields, field: RecoilAtomTypes.field) => {

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -1016,6 +1016,16 @@ let appendPaymentExperience = (paymentBodyArr, paymentMethodType) =>
     paymentBodyArr
   }
 
+let oxxoBody = () => {
+  open Utils
+  let paymentMethodData = [("voucher", "oxxo"->JSON.Encode.string)]->getJsonFromArrayOfJson
+  [
+    ("payment_method", "voucher"->JSON.Encode.string),
+    ("payment_method_type", "oxxo"->JSON.Encode.string),
+    ("payment_method_data", paymentMethodData),
+  ]
+}
+
 let dynamicPaymentBody = (paymentMethod, paymentMethodType, ~isQrPaymentMethod=false) => {
   let paymentMethodType = paymentMethod->getPaymentMethodType(paymentMethodType)
   [
@@ -1093,5 +1103,6 @@ let getPaymentBody = (
   | "evoucher" =>
     rewardBody(~paymentMethodType)
   | "eft" => eftBody()
+  | "oxxo" => oxxoBody()
   | _ => dynamicPaymentBody(paymentMethod, paymentMethodType)
   }

--- a/src/WalletElement.res
+++ b/src/WalletElement.res
@@ -18,8 +18,13 @@ let make = (~paymentType) => {
     switch methodslist {
     | Loaded(paymentlist) =>
       let plist = paymentlist->Utils.getDictFromJson->PaymentMethodsRecord.itemToObjMapper
+      // Merge duplicate payment methods
+      let mergedPaymentMethods = PaymentMethodsRecord.mergeDuplicatePaymentMethods(
+        plist.payment_methods,
+      )
+      let mergedPlist = {...plist, payment_methods: mergedPaymentMethods}
       setWalletOptions(_ => walletList)
-      setPaymentMethodListValue(_ => plist)
+      setPaymentMethodListValue(_ => mergedPlist)
     | _ => ()
     }
     None


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added dynamic fields for:

1. seven_eleven
2. mini_stop
3. family_mart
4. seicomart
5. pay_easy
6. lawson
7. alfamart
8. indomaret
9. oxxo
10. pay_safe_card


## How did you test it?
I have tested it locally
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
