### PR TITLE
fix: saved screen shimmer fix

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -333,12 +333,15 @@ let make = (
     savedMethods,
   ))
 
+  let enableSavedPaymentShimmer = React.useMemo(() => {
+    savedCardlength === 0 &&
+      (loadSavedCards === PaymentType.LoadingSavedCards ||
+      !showPaymentMethodsScreen ||
+      clickToPayConfig.isReady->Option.isNone)
+  }, (savedCardlength, loadSavedCards, showPaymentMethodsScreen, clickToPayConfig.isReady))
+
   <div className="flex flex-col overflow-auto h-auto no-scrollbar animate-slowShow">
-    {if (
-      savedCardlength === 0 &&
-      clickToPayConfig.isReady->Option.isNone &&
-      (loadSavedCards === PaymentType.LoadingSavedCards || !showPaymentMethodsScreen)
-    ) {
+    {if enableSavedPaymentShimmer {
       <PaymentElementShimmer.SavedPaymentCardShimmer />
     } else {
       <RenderIf condition={!showPaymentMethodsScreen}> {bottomElement} </RenderIf>
@@ -358,7 +361,7 @@ let make = (
         }
       />
     </RenderIf>
-    <RenderIf condition={!showPaymentMethodsScreen}>
+    <RenderIf condition={!enableSavedPaymentShimmer}>
       <div
         className="Label flex flex-row gap-3 items-end cursor-pointer mt-4"
         style={


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
The Saved screen shimmer was getting disabled even before we have the saved cards list
Example :- 

https://github.com/user-attachments/assets/39bca6df-0bf1-46fb-8d18-6f0213a483ab

Fixed :-

https://github.com/user-attachments/assets/2594def4-5ab6-452a-a0d6-dcc766fb30fd



## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Locally

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
