### PR TITLE
fix: retrieve payment intent endpoint correction

### DIFF
--- a/src/Utilities/APIHelpers/APIUtils.res
+++ b/src/Utilities/APIHelpers/APIUtils.res
@@ -58,7 +58,7 @@ let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
     | None => None
     },
     switch forceSync {
-    | Some(fs) if apiCallType === RetrievePaymentIntent => Some(("false_sync", fs))
+    | Some(fs) if apiCallType === RetrievePaymentIntent => Some(("force_sync", fs))
     | _ => None
     },
   }->List.filterMap(x => x)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Wrong query parameter was set for the retrieve payment intent endpoint — false_sync was used instead of force_sync.

<!-- Describe your changes in detail -->

## How did you test it?
I have tested it locally.
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
