### PR TITLE
fix: remove CVC number on card brand change & cobadeged cards CVV fixed

### DIFF
--- a/src/CardSchemeComponent.res
+++ b/src/CardSchemeComponent.res
@@ -22,7 +22,13 @@ module CoBadgeCardSchemeDropDown = {
 }
 
 @react.component
-let make = (~cardNumber, ~paymentType, ~cardBrand, ~setCardBrand) => {
+let make = (
+  ~cardNumber,
+  ~paymentType,
+  ~cardBrand,
+  ~setCardBrand,
+  ~isCoBadgedCardDetectedOnce: React.ref<bool>,
+) => {
   let cardType = React.useMemo1(_ => cardBrand->CardUtils.getCardType, [cardBrand])
   let animate = cardType == NOTFOUND ? "animate-slideLeft" : "animate-slideRight"
   let cardBrandIcon = React.useMemo1(
@@ -46,7 +52,6 @@ let make = (~cardNumber, ~paymentType, ~cardBrand, ~setCardBrand) => {
   let marginLeft = isCardCoBadged ? "-ml-2" : ""
 
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
-  let isCoBadgedCardDetectedOnce = React.useRef(false)
   let shouldShowCoBadgeCardSchemeDropDown =
     isCardCoBadged && cardNumber->CardUtils.clearSpaces->String.length >= 16
 

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -27,7 +27,6 @@ let useCardForm = (~logger, ~paymentType) => {
   let expiryRef = React.useRef(Nullable.null)
   let cvcRef = React.useRef(Nullable.null)
   let zipRef = React.useRef(Nullable.null)
-  let prevCardBrandRef = React.useRef("")
 
   let (isCardValid, setIsCardValid) = React.useState(_ => None)
   let (isExpiryValid, setIsExpiryValid) = React.useState(_ => None)
@@ -85,13 +84,10 @@ let useCardForm = (~logger, ~paymentType) => {
   }, [showPaymentMethodsScreen])
 
   React.useEffect(() => {
-    if prevCardBrandRef.current !== "" {
-      setCvcNumber(_ => "")
-      setCardExpiry(_ => "")
-      setIsExpiryValid(_ => None)
-      setIsCVCValid(_ => None)
-    }
-    prevCardBrandRef.current = cardBrand
+    setCvcNumber(_ => "")
+    setCardExpiry(_ => "")
+    setIsExpiryValid(_ => None)
+    setIsCVCValid(_ => None)
     None
   }, [cardBrand])
 
@@ -124,7 +120,7 @@ let useCardForm = (~logger, ~paymentType) => {
       setDisplayPincode(_ => false)
     }
     setCardNumber(_ => card)
-    if card->String.length == 0 && prevCardBrandRef.current !== "" {
+    if card->String.length == 0 {
       setCvcNumber(_ => "")
       setCardExpiry(_ => "")
       setIsExpiryValid(_ => None)

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -27,6 +27,8 @@ let useCardForm = (~logger, ~paymentType) => {
   let expiryRef = React.useRef(Nullable.null)
   let cvcRef = React.useRef(Nullable.null)
   let zipRef = React.useRef(Nullable.null)
+  let isCoBadgedCardDetectedOnce = React.useRef(false)
+  let prevCardBrandRef = React.useRef("")
 
   let (isCardValid, setIsCardValid) = React.useState(_ => None)
   let (isExpiryValid, setIsExpiryValid) = React.useState(_ => None)
@@ -84,10 +86,13 @@ let useCardForm = (~logger, ~paymentType) => {
   }, [showPaymentMethodsScreen])
 
   React.useEffect(() => {
-    setCvcNumber(_ => "")
-    setCardExpiry(_ => "")
-    setIsExpiryValid(_ => None)
-    setIsCVCValid(_ => None)
+    if !isCoBadgedCardDetectedOnce.current {
+      setCvcNumber(_ => "")
+      setCardExpiry(_ => "")
+      setIsExpiryValid(_ => None)
+      setIsCVCValid(_ => None)
+    }
+    prevCardBrandRef.current = cardBrand
     None
   }, [cardBrand])
 
@@ -120,7 +125,7 @@ let useCardForm = (~logger, ~paymentType) => {
       setDisplayPincode(_ => false)
     }
     setCardNumber(_ => card)
-    if card->String.length == 0 {
+    if card->String.length == 0 && prevCardBrandRef.current !== "" {
       setCvcNumber(_ => "")
       setCardExpiry(_ => "")
       setIsExpiryValid(_ => None)
@@ -293,7 +298,7 @@ let useCardForm = (~logger, ~paymentType) => {
   }, [cardNumber])
 
   let icon = React.useMemo(() => {
-    <CardSchemeComponent cardNumber paymentType cardBrand setCardBrand />
+    <CardSchemeComponent cardNumber paymentType cardBrand setCardBrand isCoBadgedCardDetectedOnce />
   }, (cardType, paymentType, cardBrand, cardNumber))
 
   let cardProps: CardUtils.cardProps = {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Previously, the card CVC was cleared only if the previously detected card brand was non-empty. Now, it will be cleared whenever the card brand changes.

## How did you test it?

https://github.com/user-attachments/assets/030999cb-07cc-49cf-8fce-7ee7cf893b37




<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
