### PR TITLE
fix: shimmer not stopping

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -335,9 +335,8 @@ let make = (
 
   let enableSavedPaymentShimmer = React.useMemo(() => {
     savedCardlength === 0 &&
-      (loadSavedCards === PaymentType.LoadingSavedCards ||
-      !showPaymentMethodsScreen ||
-      clickToPayConfig.isReady->Option.isNone)
+    !showPaymentMethodsScreen &&
+    (loadSavedCards === PaymentType.LoadingSavedCards || clickToPayConfig.isReady->Option.isNone)
   }, (savedCardlength, loadSavedCards, showPaymentMethodsScreen, clickToPayConfig.isReady))
 
   <div className="flex flex-col overflow-auto h-auto no-scrollbar animate-slowShow">


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

While using click to pay shimmer is not stopping.

## How did you test it?
issue is:

https://github.com/user-attachments/assets/b5a18d5c-51c2-42ce-91f0-157232d35eb0


Case 1: click to pay

https://github.com/user-attachments/assets/7f3d7e6f-3108-41ec-a562-1b0e51eb56a6

Case 2: Saved cards

https://github.com/user-attachments/assets/60f321b1-6f46-4574-a346-74f796abd86b


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
