### PR TITLE
fix: external vault proxy endpoint fixed in v2 and request payload st…

### DIFF
--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -1136,6 +1136,7 @@ let usePaymentIntent = (optLogger, paymentType) => {
     ~isThirdPartyFlow=false,
     ~intentCallback=_ => (),
     ~manualRetry=false,
+    ~isExternalVaultFlow=false,
   ) => {
     switch keys.clientSecret {
     | Some(clientSecret) =>
@@ -1174,7 +1175,9 @@ let usePaymentIntent = (optLogger, paymentType) => {
       )
       let path = switch GlobalVars.sdkVersion {
       | V1 => `payments/${paymentIntentID}/confirm`
-      | V2 => `v2/payments/${keys.paymentId}/confirm-intent`
+      | V2 =>
+        let baseUrl = `v2/payments/${keys.paymentId}/confirm-intent`
+        isExternalVaultFlow ? `${baseUrl}/external-vault-proxy` : baseUrl
       }
       let uri = `${endpoint}/${path}`
 
@@ -1880,6 +1883,7 @@ let usePostSessionTokens = (
     ~isThirdPartyFlow=false,
     ~intentCallback=_ => (),
     ~manualRetry as _=false,
+    ~isExternalVaultFlow as _=false,
   ) => {
     switch keys.clientSecret {
     | Some(clientSecret) =>

--- a/src/Utilities/PaymentHelpersTypes.res
+++ b/src/Utilities/PaymentHelpersTypes.res
@@ -18,6 +18,7 @@ type paymentIntent = (
   ~isThirdPartyFlow: bool=?,
   ~intentCallback: Core__JSON.t => unit=?,
   ~manualRetry: bool=?,
+  ~isExternalVaultFlow: bool=?,
 ) => unit
 
 type completeAuthorize = (

--- a/src/Utilities/PaymentManagementBody.res
+++ b/src/Utilities/PaymentManagementBody.res
@@ -49,15 +49,17 @@ let saveCardBody = (
   ]
 }
 
-let vgsCardBody = (~cardNumber, ~month, ~year, ~cvcNumber) => {
+let vgsCardBody = (~cardNumber, ~month, ~year, ~cvcNumber, ~binNumber, ~lastFour) => {
   let cardBody = [
     ("card_number", cardNumber->JSON.Encode.string),
     ("card_exp_month", month->JSON.Encode.string),
     ("card_exp_year", year->JSON.Encode.string),
     ("card_cvc", cvcNumber->JSON.Encode.string),
+    ("bin_number", binNumber->JSON.Encode.string),
+    ("last_four", lastFour->JSON.Encode.string),
   ]
 
-  let paymentMethodData = [("external_proxy_card_data", cardBody->Utils.getJsonFromArrayOfJson)]
+  let paymentMethodData = [("vault_data_card", cardBody->Utils.getJsonFromArrayOfJson)]
 
   [
     ("payment_method_type", "card"->JSON.Encode.string),

--- a/src/VGSVault/VGSHelpers.res
+++ b/src/VGSVault/VGSHelpers.res
@@ -26,7 +26,9 @@ let getTokenizedData = data => {
   let expiryDetails = getExpiryToken(dict)
   let cardNumber = dict->getString("card_number", "")
   let cardCvc = dict->getString("card_cvc", "")
-  (cardNumber, expiryDetails.month, expiryDetails.year, cardCvc)
+  let binNumber = cardNumber->String.slice(~start=0, ~end=5)
+  let lastFour = cardNumber->String.sliceToEnd(~start=-4)
+  (cardNumber, expiryDetails.month, expiryDetails.year, cardCvc, binNumber, lastFour)
 }
 
 let getErrorStr = (fieldname, ~empty=false, localeString: LocaleStringTypes.localeStrings) => {

--- a/src/VGSVault/VGSVault.res
+++ b/src/VGSVault/VGSVault.res
@@ -107,15 +107,22 @@ let make = (~isBancontact=false) => {
         let emptyPayload = JSON.Encode.object(Dict.make())
 
         let onSuccess = (_, data) => {
-          let (cardNumber, month, year, cvcNumber) = getTokenizedData(data)
+          let (cardNumber, month, year, cvcNumber, binNumber, lastFour) = getTokenizedData(data)
 
-          let cardBody = PaymentManagementBody.vgsCardBody(~cardNumber, ~month, ~year, ~cvcNumber)
-
+          let cardBody = PaymentManagementBody.vgsCardBody(
+            ~cardNumber,
+            ~month,
+            ~year,
+            ~cvcNumber,
+            ~binNumber,
+            ~lastFour,
+          )
           intent(
             ~bodyArr={cardBody},
             ~confirmParam=confirm.confirmParams,
             ~handleUserError=false,
             ~manualRetry=isManualRetryEnabled,
+            ~isExternalVaultFlow=true,
           )
         }
 


### PR DESCRIPTION
…ructure

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
#1204 
Changed V2 Endpoint for External vault to `/confirm-intent/external-vault-proxy`
New request payload 
```
{
  "payment_method_type": "card",
  "payment_method_subtype": "debit",
  "payment_method_data": {
    "vault_data_card": {
      "card_number": "4242429789164242",
      "card_exp_month": "04",
      "card_exp_year": "29",
      "card_cvc": "tok_sandbox_6EwSgJEYoqREZo8TkpP9Vr",
      "bin_number": "42424",
      "last_four": "4242"
    }
  },
}
```

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
