### PR TITLE
fix(payout): pass payoutId explicitly as function param

### DIFF
--- a/src/PaymentMethodCollectElement.res
+++ b/src/PaymentMethodCollectElement.res
@@ -122,6 +122,7 @@ let make = (~integrateError, ~logger) => {
         ~customPodUri="",
         ~endpoint,
         ~body=pmdBody,
+        ~payoutId=options.payoutId,
       )
       ->then(res => {
         let data = res->decodePayoutConfirmResponse

--- a/src/Utilities/APIHelpers/APIUtils.res
+++ b/src/Utilities/APIHelpers/APIUtils.res
@@ -26,6 +26,7 @@ type apiParams = {
   paymentMethodId: option<string>,
   forceSync: option<string>,
   pollId: option<string>,
+  payoutId: option<string>,
 }
 
 let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
@@ -36,6 +37,7 @@ let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
     paymentMethodId,
     forceSync,
     pollId,
+    payoutId,
   } = params
 
   let clientSecretVal = clientSecret->Option.getOr("")
@@ -110,7 +112,7 @@ let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
     | CallAuthLink => "payment_methods/auth/link"
     | CallAuthExchange => "payment_methods/auth/exchange"
     | RetrieveStatus => `poll/status/${pollIdVal}`
-    | ConfirmPayout => `payouts/${paymentIntentID}/confirm`
+    | ConfirmPayout => `payouts/${payoutId->Option.getOr("")}/confirm`
     }
   | V2(inner) =>
     switch inner {

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -36,6 +36,7 @@ let retrievePaymentIntent = async (
       paymentMethodId: None,
       forceSync: isForceSync ? Some("true") : None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -71,6 +72,7 @@ let threeDsAuth = async (~clientSecret, ~logger, ~threeDsMethodComp, ~headers) =
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
   let broswerInfo = BrowserSpec.broswerInfo
@@ -172,6 +174,7 @@ let retrieveStatus = async (~publishableKey, ~customPodUri, pollID, logger) => {
       paymentMethodId: None,
       forceSync: None,
       pollId: Some(pollID),
+      payoutId: None,
     },
   )
 
@@ -1368,6 +1371,7 @@ let fetchSessions = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1397,6 +1401,7 @@ let confirmPayout = async (
   ~customPodUri,
   ~endpoint,
   ~body,
+  ~payoutId,
 ) => {
   let uri = APIUtils.generateApiUrl(
     V1(ConfirmPayout),
@@ -1407,6 +1412,7 @@ let confirmPayout = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: Some(payoutId),
     },
   )
 
@@ -1449,6 +1455,7 @@ let createPaymentMethod = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1490,6 +1497,7 @@ let fetchPaymentMethodList = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1526,6 +1534,7 @@ let fetchCustomerPaymentMethodList = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1632,6 +1641,7 @@ let callAuthLink = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1695,6 +1705,7 @@ let callAuthExchange = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1767,6 +1778,7 @@ let fetchSavedPaymentMethodList = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1797,6 +1809,7 @@ let deletePaymentMethod = async (~ephemeralKey, ~paymentMethodId, ~logger, ~cust
       paymentMethodId: Some(paymentMethodId),
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
 
@@ -1834,6 +1847,7 @@ let calculateTax = async (
       paymentMethodId: None,
       forceSync: None,
       pollId: None,
+      payoutId: None,
     },
   )
   let onSuccess = data => data

--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -340,6 +340,7 @@ let make = (keys, options: option<JSON.t>, analyticsInfo: option<JSON.t>) => {
             paymentMethodId: None,
             forceSync: None,
             pollId: None,
+            payoutId: None,
           },
         )
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR updates the creation of API endpoint for payouts confirmation. Instead of relying on client secret for fetching the `payout_id`, the changes are made to pass it directly in the function parameter.

## How did you test it?
Tested locally

Before change (confirmation endpoint has `/payout_link/` as payout ID)
<img width="556" height="909" alt="Screenshot 2025-09-17 at 3 05 15 PM" src="https://github.com/user-attachments/assets/4ae5b71e-5317-49ca-b661-8bc172a7503d" />

After change (confirmation endpoint has correct payout ID)
<img width="560" height="854" alt="Screenshot 2025-09-17 at 3 04 38 PM" src="https://github.com/user-attachments/assets/76e36d41-d614-4b48-a471-905f122eeede" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
