### PR TITLE
fix: saved cards screen consent checkbox in case of mandate cards

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -323,14 +323,12 @@ let make = (
     !isGuestCustomer &&
     paymentMethodListValue.payment_type === NEW_MANDATE &&
     displaySavedPaymentMethodsCheckbox &&
-    savedMethods->Array.some(ele => {
-      ele.paymentMethod === "card" && ele.requiresCvv
-    })
+    customerMethod.requiresCvv
   }, (
     isGuestCustomer,
     paymentMethodListValue.payment_type,
     displaySavedPaymentMethodsCheckbox,
-    savedMethods,
+    customerMethod,
   ))
 
   let enableSavedPaymentShimmer = React.useMemo(() => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
#1230 
<!-- Describe your changes in detail -->
Saved cards screen was showing Card terms checkbox in case when any one of the saved cards had `requires_cvv` as `true` as shown below
https://github.com/user-attachments/assets/ebed9d2f-2aa7-4457-9ab5-152b127eb73e

Fix:
Changed the condition for showing save details checkbox to only when if the current selected card has an option of `requires_cvv` as `true`.

Fix:
https://github.com/user-attachments/assets/492286cb-361b-4b40-9e48-190d4cf09a67

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested via Checking confirm call and SDK Flow (Attached Flow Recordings above)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
