### PR TITLE
fix: added validation errors for payouts

### DIFF
--- a/src/FormViewTabs.res
+++ b/src/FormViewTabs.res
@@ -17,7 +17,7 @@ let make = (
   let payoutDynamicFields = Recoil.useRecoilValueFromAtom(payoutDynamicFieldsAtom)
   let formData = Recoil.useRecoilValueFromAtom(formDataAtom)
   let (activePmt, setActivePmt) = Recoil.useRecoilState(paymentMethodTypeAtom)
-  let validityDict = Recoil.useRecoilValueFromAtom(validityDictAtom)
+  let (validityDict, setValidityDict) = Recoil.useRecoilState(validityDictAtom)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
   let supportedCardBrands = React.useMemo(() => {
     paymentMethodListValue->PaymentUtils.getSupportedCardBrands
@@ -227,6 +227,7 @@ let make = (
             },
           )
 
+          setValidityDict(_ => fieldValidity)
           if isPmdValid {
             formPaymentMethodData(formData, fieldValidity, payoutDynamicFields)
             ->Option.map(pmd => View.setView(FinalizeView(activePmt, pmd)))

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -15,6 +15,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cvcTextLabel: `رمز الحماية`,
   emailLabel: `البريد الإلكتروني`,
   ibanEmptyText: `لا يمكن أن يكون رقم IBAN فارغًا`,
+  ibanInvalidText: `الرجاء إدخال رقم حساب مصرفي دولي (IBAN) صحيح`,
   emailEmptyText: `لا يمكن أن يكون البريد الإلكتروني فارغًا`,
   emailInvalidText: `عنوان البريد الإلكتروني غير صالح`,
   fullNameLabel: `الاسم الكامل`,

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Sobrenom de la targeta`,
   billingNamePlaceholder: `Nom i cognom`,
   ibanEmptyText: `L'IBAN no pot estar buit`,
+  ibanInvalidText: `Si us plau, introduïu un IBAN vàlid`,
   emailEmptyText: `El correu electrònic no pot estar buit`,
   emailInvalidText: `adressa de correu invàlida`,
   line1EmptyText: `La línia d'adreça 1 no pot estar buida`,

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -28,6 +28,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   accountNumberText: `账户号码`,
   emailLabel: `电子邮箱`,
   ibanEmptyText: `IBAN 不能为空`,
+  ibanInvalidText: `请输入有效的 IBAN`,
   emailEmptyText: `电子邮箱不能为空`,
   emailInvalidText: `无效的电子邮箱地址`,
   fullNameLabel: `全名`,

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -28,6 +28,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   accountNumberText: `Accountnummer`,
   emailLabel: `Email`,
   ibanEmptyText: `IBAN darf nicht leer sein`,
+  ibanInvalidText: `Bitte geben Sie eine gültige IBAN ein`,
   emailEmptyText: `E-Mail darf nicht leer sein`,
   emailInvalidText: `Ungültige E-Mail-Adresse`,
   fullNameLabel: `Vollständiger Name`,

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Kaartbijnaam`,
   billingNamePlaceholder: `Voornaam en achternaam`,
   ibanEmptyText: `IBAN mag niet leeg zijn`,
+  ibanInvalidText: `Voer een geldig IBAN in`,
   emailEmptyText: `E-mail mag niet leeg zijn`,
   emailInvalidText: `Ongeldig e-mailadres`,
   line1EmptyText: `Adresregel 1 mag niet leeg zijn`,

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -14,6 +14,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cvcTextLabel: "CVC",
   emailLabel: "Email",
   ibanEmptyText: "IBAN cannot be empty",
+  ibanInvalidText: "Please enter valid IBAN",
   emailEmptyText: "Email cannot be empty",
   emailInvalidText: "Invalid email address",
   line1Label: "Address line 1",

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -28,6 +28,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   accountNumberText: "Account Number",
   emailLabel: "Email",
   ibanEmptyText: "IBAN cannot be empty",
+  ibanInvalidText: "Please enter valid IBAN",
   emailEmptyText: "Email cannot be empty",
   emailInvalidText: "Invalid email address",
   fullNameLabel: "Full name",

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Pseudonyme de la carte`,
   billingNamePlaceholder: `Nom et prénom`,
   ibanEmptyText: `L'IBAN ne peut pas être vide`,
+  ibanInvalidText: `Veuillez saisir un IBAN valide`,
   emailEmptyText: `L'e-mail ne peut pas être vide`,
   emailInvalidText: `Adresse e-mail invalide`,
   line1EmptyText: `La ligne d'adresse 1 ne peut pas être vide`,

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -28,6 +28,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   accountNumberText: `Numéro de compte`,
   emailLabel: `E-mail`,
   ibanEmptyText: `L'IBAN ne peut pas être vide`,
+  ibanInvalidText: `Veuillez saisir un IBAN valide`,
   emailEmptyText: `L'e-mail ne peut pas être vide`,
   emailInvalidText: "Adresse e-mail invalide",
   fullNameLabel: `Nom complet`,

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -28,6 +28,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   accountNumberText: `מספר חשבון`,
   emailLabel: `אימייל`,
   ibanEmptyText: `ה-IBAN אינו יכול להיות ריק`,
+  ibanInvalidText: `אנא הכנס IBAN תקף`,
   emailEmptyText: `אימייל לא יכול להיות ריק`,
   emailInvalidText: `כתובת אימייל לא חוקית`,
   fullNameLabel: `שם מלא`,

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Soprannome della carta`,
   billingNamePlaceholder: `Nome e cognome`,
   ibanEmptyText: `L'IBAN non può essere vuoto`,
+  ibanInvalidText: `Inserisci un IBAN valido`,
   emailEmptyText: `L'e-mail non può essere vuota`,
   emailInvalidText: `indirizzo email non valido`,
   line1EmptyText: `La riga dell'indirizzo 1 non può essere vuota`,

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -15,6 +15,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   accountNumberText: `口座番号`,
   emailLabel: `Eメール`,
   ibanEmptyText: `IBANは空にできません`,
+  ibanInvalidText: `有効なIBANを入力してください`,
   emailEmptyText: `電子メールを空にすることはできません`,
   emailInvalidText: `無効なメールアドレス`,
   fullNameLabel: `フルネーム`,

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -17,6 +17,7 @@ type localeStrings = {
   cvcTextLabel: string,
   emailLabel: string,
   ibanEmptyText: string,
+  ibanInvalidText: string,
   emailEmptyText: string,
   emailInvalidText: string,
   accountNumberText: string,

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Przezwisko karty`,
   billingNamePlaceholder: `Imię i nazwisko`,
   ibanEmptyText: `IBAN nie może być pusty`,
+  ibanInvalidText: `Proszę podać prawidłowy IBAN`,
   emailEmptyText: `Adres e-mail nie może być pusty`,
   emailInvalidText: `Niepoprawny adres email`,
   line1EmptyText: `Linia adresu 1 nie może być pusta`,

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Apelido do cartão`,
   billingNamePlaceholder: `Nome e sobrenome`,
   ibanEmptyText: `O IBAN não pode estar vazio`,
+  ibanInvalidText: `Por favor, insira um IBAN válido`,
   emailEmptyText: `O e-mail não pode ficar vazio`,
   emailInvalidText: `Endereço de email invalido`,
   line1EmptyText: `A linha de endereço 1 não pode ficar vazia`,

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Прозвище карты`,
   billingNamePlaceholder: `Имя и фамилия`,
   ibanEmptyText: `IBAN не может быть пустым`,
+  ibanInvalidText: `Пожалуйста, введите действительный IBAN`,
   emailEmptyText: `Электронная почта не может быть пустой`,
   emailInvalidText: `Неверный адрес электронной почты`,
   line1EmptyText: `Адресная строка 1 не может быть пустой.`,

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Apodo de la tarjeta`,
   billingNamePlaceholder: `Nombre y apellido`,
   ibanEmptyText: `El IBAN no puede estar vacío`,
+  ibanInvalidText: `Por favor, introduzca un IBAN válido`,
   emailEmptyText: `El correo electrónico no puede estar vacío.`,
   emailInvalidText: `Dirección de correo electrónico no válida`,
   line1EmptyText: `La línea de dirección 1 no puede estar vacía`,

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -52,6 +52,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   cardNickname: `Kortets smeknamn`,
   billingNamePlaceholder: `Förnamn och efternamn`,
   ibanEmptyText: `IBAN får inte vara tomt`,
+  ibanInvalidText: `Vänligen ange ett giltigt IBAN`,
   emailEmptyText: `E-post får inte vara tom`,
   emailInvalidText: `Ogiltig e-postadress`,
   line1EmptyText: `Adressrad 1 får inte vara tom`,

--- a/src/LocaleStrings/TraditionalChineseLocale.res
+++ b/src/LocaleStrings/TraditionalChineseLocale.res
@@ -28,6 +28,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   accountNumberText: "帳戶號碼",
   emailLabel: "電子郵件",
   ibanEmptyText: "IBAN不能為空",
+  ibanInvalidText: `請輸入有效的 IBAN`,
   emailEmptyText: "電子郵件不能為空",
   emailInvalidText: "無效的電子郵件地址",
   fullNameLabel: "全名",

--- a/src/Utilities/PaymentMethodCollectUtils.res
+++ b/src/Utilities/PaymentMethodCollectUtils.res
@@ -400,7 +400,21 @@ let getPaymentMethodDataErrorString = (
   | (PayoutMethodData(CardExpDate(_)), false) => localeString.inCompleteExpiryErrorText
   | (PayoutMethodData(CardExpDate(_)), true) => localeString.pastExpiryErrorText
   | (PayoutMethodData(ACHRoutingNumber), false) => localeString.formFieldInvalidRoutingNumber
+  | (PayoutMethodData(CardHolderName), _) =>
+    if value->String.trim->String.length === 0 {
+      localeString.cardHolderName->localeString.nameEmptyText
+    } else {
+      localeString.cardHolderName->localeString.completeNameEmptyText
+    }
+  | (PayoutMethodData(SepaIban), _) =>
+    if value->String.trim->String.length === 0 {
+      localeString.ibanEmptyText
+    } else {
+      localeString.ibanInvalidText
+    }
   | (BillingAddress(AddressState), _) => "Invalid state"
+  | (PayoutMethodData(PaypalMobNumber), _) | (PayoutMethodData(VenmoMobNumber), _) =>
+    localeString.formFieldPhoneNumberLabel->localeString.nameEmptyText
   | _ => ""
   }
 }
@@ -653,6 +667,14 @@ let calculateValidity = (key, value, cardBrand, ~default=None) => {
     }
   | PayoutMethodData(CardExpDate(_)) =>
     if value->String.length > 0 && getExpiryValidity(value) {
+      Some(true)
+    } else if value->String.length == 0 {
+      default
+    } else {
+      Some(false)
+    }
+  | PayoutMethodData(CardHolderName) =>
+    if value->String.trim->String.includes(" ") {
       Some(true)
     } else if value->String.length == 0 {
       default


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Linked Issue - #1233

Fixed Validation Errors not appearing for few input fields when Save button was clicked for payouts.

Added validation errors for the following fields - 

- CardHolderName
- SepaIban
- PaypalPhoneNumber

## How did you test it?

https://github.com/user-attachments/assets/4682cec4-9358-41f2-9716-2803638cb33d

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
