### PR TITLE
fix: card number focus for payouts

### DIFF
--- a/src/CollectWidget.res
+++ b/src/CollectWidget.res
@@ -104,7 +104,7 @@ let make = (
         )
         let formattedCardNumber = formatCardNumber(value, cardType)
         if (
-          cardValid(
+          focusCardValid(
             CardValidations.clearSpaces(formattedCardNumber),
             getCardStringFromType(cardType),
           )


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

card number  input was changing focus before entering full card number.

## How did you test it?


https://github.com/user-attachments/assets/515ff77b-ce1c-4c8d-85d4-4d6565f99f4d


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
