### PR TITLE
refactor: centralize V2 update payment method endpoint   

### DIFF
--- a/src/Utilities/APIHelpers/APIUtils.res
+++ b/src/Utilities/APIHelpers/APIUtils.res
@@ -13,7 +13,9 @@ type apiCallV1 =
   | RetrieveStatus
   | ConfirmPayout
 
-type apiCallV2 = FetchSessionsV2
+type apiCallV2 = 
+  | FetchSessionsV2
+  | UpdatePaymentMethodV2
 
 type apiCall =
   | V1(apiCallV1)
@@ -27,6 +29,7 @@ type apiParams = {
   forceSync: option<string>,
   pollId: option<string>,
   payoutId: option<string>,
+  pmSessionId : option<string>,
 }
 
 let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
@@ -38,6 +41,7 @@ let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
     forceSync,
     pollId,
     payoutId,
+    pmSessionId,
   } = params
 
   let clientSecretVal = clientSecret->Option.getOr("")
@@ -46,6 +50,7 @@ let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
   let paymentMethodIdVal = paymentMethodId->Option.getOr("")
   let pollIdVal = pollId->Option.getOr("")
   let payoutIdVal = payoutId->Option.getOr("")
+  let pmSessionIdVal = pmSessionId->Option.getOr("")
 
   let baseUrl =
     customBackendBaseUrl->Option.getOr(
@@ -118,6 +123,7 @@ let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
   | V2(inner) =>
     switch inner {
     | FetchSessionsV2 => `v2/payments/${paymentIntentID}/create-external-sdk-tokens`
+    | UpdatePaymentMethodV2 => `v2/payment-method-sessions/${pmSessionIdVal}/update-saved-payment-method`
     }
   }
 

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -37,6 +37,7 @@ let retrievePaymentIntent = async (
       forceSync: isForceSync ? Some("true") : None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -73,6 +74,7 @@ let threeDsAuth = async (~clientSecret, ~logger, ~threeDsMethodComp, ~headers) =
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
   let broswerInfo = BrowserSpec.broswerInfo
@@ -175,6 +177,7 @@ let retrieveStatus = async (~publishableKey, ~customPodUri, pollID, logger) => {
       forceSync: None,
       pollId: Some(pollID),
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1372,6 +1375,7 @@ let fetchSessions = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1413,6 +1417,7 @@ let confirmPayout = async (
       forceSync: None,
       pollId: None,
       payoutId: Some(payoutId),
+      pmSessionId: None,
     },
   )
 
@@ -1456,6 +1461,7 @@ let createPaymentMethod = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1498,6 +1504,7 @@ let fetchPaymentMethodList = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1535,6 +1542,7 @@ let fetchCustomerPaymentMethodList = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1642,6 +1650,7 @@ let callAuthLink = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1706,6 +1715,7 @@ let callAuthExchange = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1779,6 +1789,7 @@ let fetchSavedPaymentMethodList = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1810,6 +1821,7 @@ let deletePaymentMethod = async (~ephemeralKey, ~paymentMethodId, ~logger, ~cust
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
 
@@ -1848,6 +1860,7 @@ let calculateTax = async (
       forceSync: None,
       pollId: None,
       payoutId: None,
+      pmSessionId: None,
     },
   )
   let onSuccess = data => data

--- a/src/Utilities/PaymentHelpersV2.res
+++ b/src/Utilities/PaymentHelpersV2.res
@@ -351,14 +351,27 @@ let updatePaymentMethod = (
   ~customPodUri,
 ) => {
   open Promise
-  let endpoint = ApiEndpoint.getApiEndPoint()
+  
   let headers = [
     ("x-profile-id", `${profileId}`),
     ("Authorization", `publishable-key=${publishableKey},client-secret=${pmClientSecret}`),
     ("Content-Type", "application/json"),
   ]
-  let uri = `${endpoint}/v2/payment-method-sessions/${pmSessionId}/update-saved-payment-method`
 
+  let uri = APIUtils.generateApiUrl(
+    V2(UpdatePaymentMethodV2),
+    ~params={
+      customBackendBaseUrl: None,
+      clientSecret: None,
+      publishableKey: Some(publishableKey),
+      paymentMethodId: None,
+      forceSync: None,
+      pollId: None,
+      payoutId: None,
+      pmSessionId: Some(pmSessionId),  
+    },
+  )
+  
   fetchApi(
     uri,
     ~method=#PUT,

--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -341,6 +341,7 @@ let make = (keys, options: option<JSON.t>, analyticsInfo: option<JSON.t>) => {
             forceSync: None,
             pollId: None,
             payoutId: None,
+            pmSessionId: None,
           },
         )
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

Centralizes the Update Payment Method V2 endpoint by moving it from `PaymentHelpersV2.res` into `APIUtils.res`, improving maintainability and consistency with V1 endpoints.

Fixes juspay/hyperswitch#9319

## 📋 Changes Made

### `APIUtils.res`
- ✅ Added `UpdatePaymentMethodV2` variant to `apiCallV2` type
- ✅ Added `pmSessionId: option<string>` to `apiParams` type
- ✅ Extended `generateApiUrl` function to handle V2 update payment method path
- ✅ Organized V2 endpoints under clear case pattern matching

### `PaymentHelpersV2.res`
- ✅ Replaced hardcoded URL 
- ✅ Removed direct endpoint construction


## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Only build test

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
