### PR TITLE
fix: added validation for empty clientSecret in completeUpdateIntent

### DIFF
--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -729,6 +729,9 @@ let make = (keys, options: option<JSON.t>, analyticsInfo: option<JSON.t>) => {
       }
 
       let completeUpdateIntent = clientSecret => {
+        if clientSecret->String.length == 0 {
+          ()
+        }
         sessionUpdate(clientSecret)
       }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Fixes [#9355](https://github.com/juspay/hyperswitch/issues/9355)
Added validation to check whether clientSecret is empty if its length is empty if it is then returning else continue with the existing flow

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
