### PR TITLE
fix: card number and card expiry validation payout

### DIFF
--- a/src/CollectWidget.res
+++ b/src/CollectWidget.res
@@ -91,12 +91,12 @@ let make = (
     | (_, _, "") => (true, "")
     | (PayoutMethodData(CardExpDate(_)), "number" | "tel", _) => {
         let formattedExpiry = CardValidations.formatCardExpiryNumber(value)
-        let checkCardExpiryIsValid = isExipryValid(formattedExpiry)
-        if checkCardExpiryIsValid {
+        let isCardExpiryValid = isExipryValid(formattedExpiry)
+        if isCardExpiryValid {
           handleInputFocus(~currentRef=cardExpRef, ~destinationRef=cardHolderRef)
         }
         if formattedExpiry->String.length == getPaymentMethodDataFieldMaxLength(key) {
-          setValidityDictVal("card.cardExp", Some(checkCardExpiryIsValid))
+          setValidityDictVal("card.cardExp", Some(isCardExpiryValid))
         } else {
           setValidityDictVal("card.cardExp", Some(true))
         }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Previously, validation errors were only shown on blur or form submission. Now, errors are displayed immediately after the user finishes typing a complete card number (based on card brand length) or a full expiry date, providing instant feedback for invalid inputs.

## How did you test it?

Before:

https://github.com/user-attachments/assets/c0a1f8be-81d8-491a-9fa7-af257815b43b


After: 


https://github.com/user-attachments/assets/84794c7a-37d2-42c2-8f01-d6eb700e42d6


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
