### PR TITLE
refactor: Centralize V2 Fetch Payment Method List endpoint

### DIFF
--- a/src/Payments/PreMountLoader.res
+++ b/src/Payments/PreMountLoader.res
@@ -112,11 +112,9 @@ let getMessageHandlerV2Elements = (
 ) => {
   let paymentMethodsListPromise = PaymentHelpersV2.fetchPaymentMethodList(
     ~clientSecret,
-    ~paymentId,
     ~publishableKey,
     ~logger,
     ~customPodUri,
-    ~endpoint,
     ~profileId,
   )
 

--- a/src/Utilities/APIHelpers/APIUtils.res
+++ b/src/Utilities/APIHelpers/APIUtils.res
@@ -14,7 +14,9 @@ type apiCallV1 =
   | ConfirmPayout
   | FetchBlockedBins
 
-type apiCallV2 = FetchSessionsV2
+type apiCallV2 =
+  | FetchSessionsV2
+  | FetchPaymentMethodListV2
 
 type apiCall =
   | V1(apiCallV1)
@@ -121,6 +123,7 @@ let generateApiUrl = (apiCallType: apiCall, ~params: apiParams) => {
   | V2(inner) =>
     switch inner {
     | FetchSessionsV2 => `v2/payments/${paymentIntentID}/create-external-sdk-tokens`
+    | FetchPaymentMethodListV2 => `/v2/payments/${paymentIntentID}/payment-methods`
     }
   }
 

--- a/src/Utilities/PaymentHelpersV2.res
+++ b/src/Utilities/PaymentHelpersV2.res
@@ -492,11 +492,9 @@ let useSaveCard = (optLogger: option<HyperLoggerTypes.loggerMake>, paymentType: 
 
 let fetchPaymentMethodList = (
   ~clientSecret,
-  ~paymentId,
   ~publishableKey,
   ~logger as _,
   ~customPodUri,
-  ~endpoint,
   ~profileId,
 ) => {
   open Promise
@@ -510,7 +508,18 @@ let fetchPaymentMethodList = (
   | value if value != "" => [...baseHeaders, ("x-feature", value)]
   | _ => baseHeaders
   }
-  let uri = `${endpoint}/v2/payments/${paymentId}/payment-methods`
+  let uri = APIUtils.generateApiUrl(
+    V2(FetchPaymentMethodListV2),
+    ~params={
+      clientSecret: Some(clientSecret),
+      publishableKey: Some(publishableKey),
+      customBackendBaseUrl: Some(customPodUri),
+      paymentMethodId: None,
+      forceSync: None,
+      pollId: None,
+      payoutId: None,
+    },
+  )
 
   fetchApi(uri, ~method=#GET, ~headers=headers->ApiEndpoint.addCustomPodHeader(~customPodUri))
   ->then(resp => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes [#9315](https://github.com/juspay/hyperswitch/issues/9315)

Centralized the Fetch Payment Method List V2 endpoint by moving it from PaymentHelpersV2 into APIUtils.res under the V2 section.

removed unused variables

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
