### PR TITLE
refactor: remove unnecessary headers from API calls

### DIFF
--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -853,10 +853,6 @@ let getHeaders = (
     ("Content-Type", "application/json"),
     ("api-key", publishableKey->Option.map(key => key)->Option.getOr("invalid_key")),
     ("X-Client-Version", Window.version),
-    ("X-Payment-Confirm-Source", "sdk"),
-    ("X-Browser-Name", HyperLogger.arrayOfNameAndVersion->Array.get(0)->Option.getOr("Others")),
-    ("X-Browser-Version", HyperLogger.arrayOfNameAndVersion->Array.get(1)->Option.getOr("0")),
-    ("X-Client-Platform", "web"),
   ]
 
   let authHeader = switch (token, uri) {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring

## Description

fixes #1156 
Removed unnecessary headers from API calls (`getHeaders` in Utils.res): deleted X-Payment-Confirm-Source, X-Browser-Name, X-Browser-Version, X-Client-Platform. Only essential headers are now sent.

## How did you test it?

- Searched codebase for removed headers
- Verified no syntax errors

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible