### PR TITLE
fix: savedMethods shimmer not visible

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -465,14 +465,17 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
   }, (paymentMethodList, customerPaymentMethods))
 
   let shouldShowSavedMethods =
-    (displaySavedPaymentMethods && savedMethods->Array.length > 0) ||
-      isShowPaymentMethodsDependingOnClickToPay
+    displaySavedPaymentMethods || isShowPaymentMethodsDependingOnClickToPay
 
   let shouldShowSavedMethodsScreen =
     !groupSavedMethodsWithPaymentMethods && !showPaymentMethodsScreen && shouldShowSavedMethods
 
+  let hasSavedPaymentMethods = displaySavedPaymentMethods && savedMethods->Array.length > 0
+
   let shouldShowUseExistingMethodsButton =
-    !groupSavedMethodsWithPaymentMethods && shouldShowSavedMethods && showPaymentMethodsScreen
+    !groupSavedMethodsWithPaymentMethods &&
+    (hasSavedPaymentMethods || isShowPaymentMethodsDependingOnClickToPay) &&
+    showPaymentMethodsScreen
 
   let isLoadingGroupedSavedMethods =
     customerPaymentMethods == LoadingSavedCards && groupSavedMethodsWithPaymentMethods


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
fixes: #1318 
saved payment methods shimmer not visible when customerMethods is in loading state
this issue came due to adding extra check of `savedMethods->Array.length > 0` when rendering savedMethodsScreen
<!-- Describe your changes in detail -->

## How did you test it?

Tested Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
