### PR TITLE
fix: correct headers for confirm call v2

### DIFF
--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -1187,12 +1187,12 @@ let usePaymentIntent = (optLogger, paymentType) => {
         ]
       | V2 => {
           let authorizationHeader = (
-            "authorization",
+            "Authorization",
             `publishable-key=${keys.publishableKey},client-secret=${clientSecret}`,
           )
           [
             authorizationHeader,
-            ("X-profile-id", keys.profileId),
+            ("x-profile-id", keys.profileId),
             ...customPodUri != "" ? [("x-feature", customPodUri)] : [],
           ]
         }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Wrong headers were getting set in confirm call v2.

## How did you test it?

before:
<img width="632" height="166" alt="image" src="https://github.com/user-attachments/assets/555a9830-226b-4f01-a13a-c400c5a36332" />
<img width="634" height="113" alt="image" src="https://github.com/user-attachments/assets/aaadd40e-372a-4b96-a47d-95b3a02ffa08" />
<img width="583" height="123" alt="image" src="https://github.com/user-attachments/assets/3715d323-72b6-474b-b1f1-c2a50e4e50e9" />


after:

<img width="636" height="244" alt="image" src="https://github.com/user-attachments/assets/69aaa6b5-e950-4724-b419-65dbe24674bf" />
<img width="544" height="182" alt="image" src="https://github.com/user-attachments/assets/14c2d3bd-32f0-4170-8ef8-4cc9e50f0db2" />

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
