### PR TITLE
chore: c2p logs enhancement

### DIFF
--- a/src/hyper-loader/AuthenticationSessionMethods.res
+++ b/src/hyper-loader/AuthenticationSessionMethods.res
@@ -253,7 +253,7 @@ let initClickToPaySession = async (
               ->Array.length
 
             logger.setLogInfo(
-              ~value=`GET_USER_TYPE | SUCCESS | Visa: ${visaCount->Int.toString} | Mastercard: ${mastercardCount->Int.toString}`,
+              ~value=`GET_USER_TYPE | SUCCESS | visa: ${visaCount->Int.toString} | mastercard: ${mastercardCount->Int.toString}`,
               ~eventName=CLICK_TO_PAY_FLOW,
             )
             "RECOGNIZED_CARDS_PRESENT"
@@ -345,7 +345,7 @@ let initClickToPaySession = async (
           ->Array.length
 
         logger.setLogInfo(
-          ~value=`AUTH_VALIDATION | SUCCESS | Visa : ${visaCount->Int.toString} | Mastercard : ${mastercardCount->Int.toString}`,
+          ~value=`AUTH_VALIDATION | SUCCESS | visa : ${visaCount->Int.toString} | mastercard : ${mastercardCount->Int.toString}`,
           ~eventName=CLICK_TO_PAY_FLOW,
         )
 
@@ -448,7 +448,6 @@ let initClickToPaySession = async (
               )
 
               let dict = checkoutWithCardResponse->Utils.getDictFromJson
-
               let visaClickToPayBodyArr = PaymentBody.visaClickToPayAuthenticationBody(
                 ~encryptedPayload=dict->Utils.getString("checkoutResponse", ""),
               )
@@ -469,9 +468,17 @@ let initClickToPaySession = async (
               authenticationSyncResponse->transformKeysWithoutModifyingValue(CamelCase)
             }
           | _ => {
+              let errorReason = if actionCode == "ERROR" {
+                checkoutWithCardResponse
+                ->Utils.getDictFromJson
+                ->Utils.getDictFromDict("error")
+                ->Utils.getString("reason", "UNKNOWN_ERROR")
+              } else {
+                ""
+              }
               logger.setLogError(
                 ~value={
-                  "message": `CHECKOUT | Visa checkout failed with card, Action Code -> ${actionCode}`,
+                  "message": `CHECKOUT | FAILED | code: ${actionCode} ${errorReason !== "" ? "| reason: " ++ errorReason : ""}`,
                   "scheme": clickToPayProvider,
                 }
                 ->JSON.stringifyAny


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [X] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Click to Pay – Grafana Logging
We added structured logs in the Click to Pay flow to help build Grafana dashboards.
All logs follow this format for easy filtering:
```
FUNCTION | STATUS | DETAILS
```

All logs are under the event:
```
CLICK_TO_PAY_FLOW
```
What is being logged (No Sensitive data)
1. Visa & Mastercard card count 

Logged when cards are fetched or after authentication.

Example:
```
GET_USER_TYPE | SUCCESS | Visa: 2 | Mastercard: 1
AUTH_VALIDATION | SUCCESS | Visa: 1 | Mastercard: 0
```
2. Click to Pay session creation count

Logged during session init and reuse.

Example:
```
C2P | INIT
C2P | SESSION | FOUND
C2P | SESSION | NOT_FOUND
```
3. Customer recognition status

Logged for both Visa and Mastercard and final result.
```
CUSTOMER_CHECK | STARTED
CUSTOMER_CHECK | VISA | Customer: present
CUSTOMER_CHECK | MASTERCARD | Customer: not present
CUSTOMER_CHECK | COMPLETED | Customer present
```
4. Mastercard & VISA Direct SDK load count

Logged during SDK initialization.

Example:
```
C2P | INIT_MASTER_DIRECT | Loaded
C2P | INIT_VISA_DIRECT | Loaded
```
5. RememberMe true vs false count 

Logged during checkout init.

Example:
```
CHECKOUT | INIT | RememberMe: true
CHECKOUT | INIT | RememberMe: false
```


## How did you test it?

I tested using the local machine and the logs are in grafanna.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
