### PR TITLE
fix: ui for dropdown document type

### DIFF
--- a/src/Components/DocumentNumberInput.res
+++ b/src/Components/DocumentNumberInput.res
@@ -17,14 +17,14 @@ let make = (~options) => {
     None
   }, (documentType, pixCNPJ, pixCPF))
 
-  <div className="flex flex-row gap-2">
+  <div className="flex w-full">
     <DropdownField
       appearance=config.appearance
       value=documentType
       setValue=setSelectedDocumentType
       fieldName=localeString.documentTypeLabel
       options
-      width="w-1/4"
+      width="w-40 mr-2"
     />
     {switch documentType {
     | "cpf" => <PixPaymentInput fieldType="pixCPF" />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Changed the width of drop down options for document type dropdown
#1386 
https://github.com/user-attachments/assets/50a6a3c2-7f2b-47c5-b704-a679a474dd43


https://github.com/user-attachments/assets/d79b9767-98ef-48ce-9fe8-138fc745b874



## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested via locally checing SDK and checking on demo, Putting screenshots and video below

https://github.com/user-attachments/assets/cbc5c74b-41f1-44ac-994d-9d2fa26bd85d


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
