### PR TITLE
fix: openssl vulnerability in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-# Use Node 20 with Alpine
-FROM node:20-alpine
-
-# --- 🔐 Security Patch: Upgrade OpenSSL to fixed version ---
-RUN apk update && apk upgrade openssl libssl3 libcrypto3
+# Use Node 24 with Alpine
+FROM node:24-alpine
 
 # Install build essentials + git + bash
 RUN apk add --no-cache make gcc g++ python3 bash git


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
One of our merchants was using a 4-month-old image, and they encountered a critical issue due to outdated OpenSSL libraries. This led to a request from Peach Payments to upgrade the OS image of the Hyperswitch SDK and remediate the OpenSSL vulnerability urgently for security and PCI compliance reasons.

Details of the reported issue:
_Service: hyperswitch-web
OS: Alpine 3.22
Installed / Fixed Versions: 3.5.1-r0 → 3.5.5-r0
Image ID: sha256:58945ed092a6051710be69c3917dd0e6c2e1ad4638afc58e76ae074f8be29728 (ECR image)_
<img width="1272" height="742" alt="image" src="https://github.com/user-attachments/assets/326b6899-28ea-4d97-a175-964db35eaa21" />
ref: https://juspay.slack.com/archives/C03V08QDR24/p1771328807169659

So, to resolve this, we are upgrading the Node.js version from 20 to 24. Also, in the next release, the Alpine OS version will be updated automatically when we build a new Docker image.

Additionally, Alpine OS includes its own OpenSSL-related packages, and Node.js also bundles OpenSSL libraries. In the upgraded Alpine version, the OpenSSL packages (libssl3, libcrypto3) are already updated to stable, patched versions. This ensures that both the OS-level OpenSSL components are aligned with the latest security fixes. For Node js, we need to upgrade version.


## How did you test it?

**Before: checking from dockerhub:** 
1. pull image from from [dockerhub](https://hub.docker.com/r/juspaydotin/hyperswitch-web)
```
docker pull juspaydotin/hyperswitch-web (latest)
```
2. Run a container from the image and open a shell inside it
```
docker run -it -p 9050:80 --name hs-web-test juspaydotin/hyperswitch-web sh
```
3. check packages
```
apk list
```
or
```
apk info <packagename>
```

<img width="1027" height="405" alt="image" src="https://github.com/user-attachments/assets/732bcb28-2472-44d7-84b9-ff2da62f8ca4" />

versions of the openssl related packages were 3.5.4, which are vulnerable.

4. Execute command
```
docker run --rm node:20-alpine node -p "process.versions"
```
<img width="456" height="374" alt="image" src="https://github.com/user-attachments/assets/dc8e43f9-0d27-4f60-8c23-2b0c2f12233f" />

openssl version used 3.0.17 (which is vulnerable)

<img width="552" height="119" alt="image" src="https://github.com/user-attachments/assets/876733d1-2a54-4eb6-ad7d-7b41bc943249" />

alpine version is 3.23.2

**After: Building local image.**
1. build image
```
docker build -t hs-web-test-24 .
```
2. Run a container from the image and open a shell inside it
```
docker run -it -p 9050:9050 --name hs-web-test-24-container hs-web-test-24 sh
```
3. check packages
```
apk list
```
or
```
apk info <packagename>
```
<img width="350" height="420" alt="image" src="https://github.com/user-attachments/assets/ef294c8c-1d60-42dc-828d-ddf6d56dc348" />

<img width="643" height="472" alt="image" src="https://github.com/user-attachments/assets/dd7b0bf7-e506-4a36-be8e-f2aa8d9cf1a7" />

openssl version 3.5.5 which is stable and not vulnerable.

<img width="561" height="134" alt="image" src="https://github.com/user-attachments/assets/17c01a35-f4a0-48ed-9d15-2038f8e57071" />

alpine version is 3.23.3

4. Running React demo app with docker image

https://github.com/user-attachments/assets/a568068a-fc3a-4366-96f8-0992c7aacb8c

https://github.com/user-attachments/assets/87c41999-2551-49ed-8398-54f90534f30f

5. Running react demo app locally

https://github.com/user-attachments/assets/6f148e81-1b00-477f-bb18-d6c7df01df7f

https://github.com/user-attachments/assets/8c88b9d0-ab65-439a-a397-356757e7201b





### Note: 

In Alpine 3.23.3, the updated OpenSSL packages are already included by default. Node js 24 contains upgraded and stable version of openssl packages.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
