### PR TITLE
fix: correct useMemo dependency array syntax in CommonCardProps

### DIFF
--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -43,7 +43,7 @@ let useCardForm = (~logger, ~paymentType) => {
   let cardBrand = CardUtils.getCardBrandFromStates(cardBrand, cardScheme, showPaymentMethodsScreen)
   let supportedCardBrands = React.useMemo(() => {
     paymentMethodListValue->PaymentUtils.getSupportedCardBrands
-  }, paymentMethodListValue)
+  }, [paymentMethodListValue])
 
   let maxCardLength = React.useMemo(() => {
     getMaxLength(cardBrand)


### PR DESCRIPTION
## Type of Change
#1417 
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
corrected useMemo dependency array syntax in CommonCardProps
<!-- Describe your changes in detail -->

## How did you test it?
Tested locally
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
