### PR TITLE
fix: replace hardcoded 'Invalid input' with localized strings

### DIFF
--- a/src/Components/ErrorComponent.res
+++ b/src/Components/ErrorComponent.res
@@ -2,7 +2,7 @@ open RecoilAtoms
 
 @react.component
 let make = (~errorStr=None, ~cardError="", ~expiryError="", ~cvcError="") => {
-  let {themeObj, config} = Recoil.useRecoilValueFromAtom(configAtom)
+  let {themeObj, config, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {innerLayout} = config.appearance
 
   let errorTextStyle: JsxDOM.style = {
@@ -29,7 +29,9 @@ let make = (~errorStr=None, ~cardError="", ~expiryError="", ~cvcError="") => {
     </RenderIf>
   | Compressed =>
     <RenderIf condition=isCompressedErrorShown>
-      <div className="Error pt-1" style=errorTextStyle> {React.string("Invalid input")} </div>
+      <div className="Error pt-1" style=errorTextStyle>
+        {React.string(localeString.enterValidDetailsText)}
+      </div>
     </RenderIf>
   }
 }

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -566,7 +566,7 @@ let make = (
                   alignSelf: "start",
                   textAlign: "left",
                 }>
-                {React.string("Invalid input")}
+                {React.string(localeString.enterValidDetailsText)}
               </div>
             </RenderIf>
           </RenderIf>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed hardcoded "Invalid input" validation error messages in card payment forms that were breaking localization for non-English users.

**Problem:**
Two components used hardcoded English strings instead of locale-aware text:
- `CardPayment.res` (line 569): Displayed "Invalid input" when expiry validation fails in compressed layout
- `ErrorComponent.res` (lines 5, 32): Displayed "Invalid input" for card field errors in compressed layout

**Solution:**
Replaced hardcoded strings with `localeString.enterValidDetailsText`:
- `CardPayment.res`: Now uses localized "Please enter valid details" message
- `ErrorComponent.res`: Added locale string access via Recoil and updated error display

## How did you test it?

- Ran `npm run re:build` - passes with 0 errors
- Verified no hardcoded "Invalid input" strings remain in the modified files
- Tested with German locale - now displays "Bitte geben Sie gültige Daten ein" instead of "Invalid input"

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible