### PR TITLE
feat: logs proxy using sw

### DIFF
--- a/src/Index.res
+++ b/src/Index.res
@@ -2,6 +2,7 @@
 %%raw("import './index.css'")
 
 Sentry.initiateSentry(~dsn=GlobalVars.sentryDSN)
+ServiceWorkerHelpers.registerSW()->ignore
 
 let app = switch ReactDOM.querySelector("#app") {
 | Some(container) =>

--- a/src/Utilities/LoggerUtils.res
+++ b/src/Utilities/LoggerUtils.res
@@ -87,6 +87,51 @@ let toSnakeCaseWithSeparator = (str, separator) => {
   )
 }
 
+let logFileToObj = (logFile: HyperLoggerTypes.logFile) => {
+  let getStringFromBool = val => val ? "true" : "false"
+  [
+    ("timestamp", logFile.timestamp->JSON.Encode.string),
+    (
+      "log_type",
+      switch logFile.logType {
+      | DEBUG => "DEBUG"
+      | INFO => "INFO"
+      | ERROR => "ERROR"
+      | WARNING => "WARNING"
+      | SILENT => "SILENT"
+      }->JSON.Encode.string,
+    ),
+    ("component", "WEB"->JSON.Encode.string),
+    (
+      "category",
+      switch logFile.category {
+      | API => "API"
+      | USER_ERROR => "USER_ERROR"
+      | USER_EVENT => "USER_EVENT"
+      | MERCHANT_EVENT => "MERCHANT_EVENT"
+      }->JSON.Encode.string,
+    ),
+    ("source", logFile.source->convertToScreamingSnakeCase->JSON.Encode.string),
+    ("version", logFile.version->JSON.Encode.string),
+    ("value", logFile.value->JSON.Encode.string),
+    // ("internal_metadata", logFile.internalMetadata->JSON.Encode.string),
+    ("session_id", logFile.sessionId->JSON.Encode.string),
+    ("merchant_id", logFile.merchantId->JSON.Encode.string),
+    ("payment_id", logFile.paymentId->JSON.Encode.string),
+    ("app_id", logFile.appId->JSON.Encode.string),
+    ("platform", logFile.platform->convertToScreamingSnakeCase->JSON.Encode.string),
+    ("user_agent", logFile.userAgent->JSON.Encode.string),
+    ("event_name", logFile.eventName->eventNameToStrMapper->JSON.Encode.string),
+    ("browser_name", logFile.browserName->convertToScreamingSnakeCase->JSON.Encode.string),
+    ("browser_version", logFile.browserVersion->JSON.Encode.string),
+    ("latency", logFile.latency->JSON.Encode.string),
+    ("first_event", logFile.firstEvent->getStringFromBool->JSON.Encode.string),
+    ("payment_method", logFile.paymentMethod->convertToScreamingSnakeCase->JSON.Encode.string),
+  ]
+  ->Dict.fromArray
+  ->JSON.Encode.object
+}
+
 let defaultLoggerConfig: HyperLoggerTypes.loggerMake = {
   sendLogs: () => (),
   setClientSecret: _x => (),
@@ -131,106 +176,201 @@ let defaultLoggerConfig: HyperLoggerTypes.loggerMake = {
 
 let saveLogsToIndexedDB = (logs: array<HyperLoggerTypes.logFile>) => {
   Promise.make((resolve, reject) => {
-    let request = openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs")
+    switch openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs") {
+    | Some(request) =>
+      request->OpenDBRequest.onsuccess(_ => {
+        let db = OpenDBRequest.result(request)
 
-    request->OpenDBRequest.onsuccess(_ => {
-      let db = OpenDBRequest.result(request)
+        if logs->Array.length > 0 {
+          let transaction = db->DB.transaction(["logs"], "readwrite")
+          let store = transaction->Transaction.objectStore("logs")
 
-      if logs->Array.length > 0 {
+          transaction->Transaction.oncomplete(
+            _ => {
+              db->DB.close
+              resolve()
+            },
+          )
+
+          transaction->Transaction.onerror(
+            _ => {
+              db->DB.close
+              reject()
+            },
+          )
+
+          logs->Array.forEach(
+            log => {
+              let _ = store->ObjectStore.put(log)
+            },
+          )
+        } else {
+          db->DB.close
+          reject()
+        }
+      })
+
+      request->OpenDBRequest.onerror(_ => {
+        reject()
+      })
+    | None => reject()
+    }
+  })
+}
+
+let retrieveLogsFromIndexedDB = () => {
+  Promise.make((resolve, reject) => {
+    switch openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs") {
+    | Some(request) =>
+      request->OpenDBRequest.onsuccess(_ => {
+        let db = OpenDBRequest.result(request)
+        let transaction = db->DB.transaction(["logs"], "readonly")
+        let store = transaction->Transaction.objectStore("logs")
+        let getAllRequest = store->ObjectStore.getAll
+
+        getAllRequest->Request.onsuccess(
+          _ => {
+            let result = Request.result(getAllRequest)
+            db->DB.close
+            resolve(result)
+          },
+        )
+
+        getAllRequest->Request.onerror(
+          _ => {
+            db->DB.close
+            reject([])
+          },
+        )
+      })
+
+      request->OpenDBRequest.onerror(_ => {
+        reject([])
+      })
+    | None => reject([])
+    }
+  })
+}
+
+let clearLogsFromIndexedDB = () => {
+  Promise.make((resolve, reject) => {
+    switch openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs") {
+    | Some(request) =>
+      request->OpenDBRequest.onsuccess(_ => {
+        let db = OpenDBRequest.result(request)
         let transaction = db->DB.transaction(["logs"], "readwrite")
         let store = transaction->Transaction.objectStore("logs")
+        let clearRequest = store->ObjectStore.clear
 
-        transaction->Transaction.oncomplete(
+        clearRequest->Request.onsuccess(
           _ => {
             db->DB.close
             resolve()
           },
         )
 
-        transaction->Transaction.onerror(
+        clearRequest->Request.onerror(
           _ => {
             db->DB.close
             reject()
           },
         )
+      })
 
-        logs->Array.forEach(
-          log => {
-            let _ = store->ObjectStore.put(log)
+      request->OpenDBRequest.onerror(_ => {
+        reject()
+      })
+    | None => reject()
+    }
+  })
+}
+
+let retrieveAndClearLogsFromIndexedDB = () => {
+  Promise.make((resolve, reject) => {
+    switch openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs") {
+    | Some(request) =>
+      request->OpenDBRequest.onsuccess(_ => {
+        let db = OpenDBRequest.result(request)
+        let transaction = db->DB.transaction(["logs"], "readwrite")
+        let store = transaction->Transaction.objectStore("logs")
+        let getAllRequest = store->ObjectStore.getAll
+
+        getAllRequest->Request.onsuccess(
+          _ => {
+            let result = Request.result(getAllRequest)
+            let _ = store->ObjectStore.clear
+
+            transaction->Transaction.oncomplete(
+              _ => {
+                db->DB.close
+                resolve(result)
+              },
+            )
+
+            transaction->Transaction.onerror(
+              _ => {
+                db->DB.close
+                reject([])
+              },
+            )
           },
         )
-      } else {
-        db->DB.close
-        reject()
-      }
-    })
 
-    request->OpenDBRequest.onerror(_ => {
-      reject()
-    })
+        getAllRequest->Request.onerror(
+          _ => {
+            db->DB.close
+            reject([])
+          },
+        )
+      })
+
+      request->OpenDBRequest.onerror(_ => {
+        reject([])
+      })
+    | None => reject([])
+    }
   })
 }
 
-let retrieveLogsFromIndexedDB = () => {
+let saveRawLogsToIndexedDB = (logs: array<JSON.t>) => {
   Promise.make((resolve, reject) => {
-    let request = openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs")
+    if logs->Array.length === 0 {
+      resolve()
+    } else {
+      switch openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs") {
+      | Some(request) =>
+        request->OpenDBRequest.onsuccess(_ => {
+          let db = OpenDBRequest.result(request)
+          let transaction = db->DB.transaction(["logs"], "readwrite")
+          let store = transaction->Transaction.objectStore("logs")
 
-    request->OpenDBRequest.onsuccess(_ => {
-      let db = OpenDBRequest.result(request)
-      let transaction = db->DB.transaction(["logs"], "readonly")
-      let store = transaction->Transaction.objectStore("logs")
-      let getAllRequest = store->ObjectStore.getAll
+          transaction->Transaction.oncomplete(
+            _ => {
+              db->DB.close
+              resolve()
+            },
+          )
 
-      getAllRequest->Request.onsuccess(
-        _ => {
-          let result = Request.result(getAllRequest)
-          db->DB.close
-          resolve(result)
-        },
-      )
+          transaction->Transaction.onerror(
+            _ => {
+              db->DB.close
+              reject()
+            },
+          )
 
-      getAllRequest->Request.onerror(
-        _ => {
-          db->DB.close
-          reject([])
-        },
-      )
-    })
+          logs->Array.forEach(
+            log => {
+              let _ = store->ObjectStore.put(log)
+            },
+          )
+        })
 
-    request->OpenDBRequest.onerror(_ => {
-      reject([])
-    })
-  })
-}
-
-let clearLogsFromIndexedDB = () => {
-  Promise.make((resolve, reject) => {
-    let request = openDBAndGetRequest(~dbName="HyperLogger", ~objectStoreName="logs")
-
-    request->OpenDBRequest.onsuccess(_ => {
-      let db = OpenDBRequest.result(request)
-      let transaction = db->DB.transaction(["logs"], "readwrite")
-      let store = transaction->Transaction.objectStore("logs")
-      let clearRequest = store->ObjectStore.clear
-
-      clearRequest->Request.onsuccess(
-        _ => {
-          db->DB.close
-          resolve()
-        },
-      )
-
-      clearRequest->Request.onerror(
-        _ => {
-          db->DB.close
+        request->OpenDBRequest.onerror(_ => {
           reject()
-        },
-      )
-    })
-
-    request->OpenDBRequest.onerror(_ => {
-      reject()
-    })
+        })
+      | None => reject()
+      }
+    }
   })
 }
 

--- a/src/Window.res
+++ b/src/Window.res
@@ -99,6 +99,26 @@ external removeEventListener: (string, 'ev => unit) => unit = "removeEventListen
 @val external windowOpen: (string, string, string) => Nullable.t<window> = "open"
 @val external isSecureContext: bool = "isSecureContext"
 
+type serviceWorkerRegistration
+
+module ServiceWorker = {
+  type t
+  @send
+  external postMessage: (t, {..}) => unit = "postMessage"
+  @get
+  external scriptURL: t => string = "scriptURL"
+}
+
+module ServiceWorkerContainer = {
+  type t
+
+  @get
+  external controller: t => Nullable.t<ServiceWorker.t> = "controller"
+
+  @send
+  external register: (t, string) => promise<serviceWorkerRegistration> = "register"
+}
+
 /* Module Definitions */
 module Navigator = {
   @val @scope("navigator")
@@ -118,6 +138,9 @@ module Navigator = {
 
   @val @scope("navigator")
   external sendBeacon: (string, string) => unit = "sendBeacon"
+
+  @val @scope(("window", "navigator"))
+  external serviceWorker: option<ServiceWorkerContainer.t> = "serviceWorker"
 }
 
 module Location = {

--- a/src/hyper-log-catcher/ErrorBoundary.res
+++ b/src/hyper-log-catcher/ErrorBoundary.res
@@ -131,7 +131,7 @@ module ErrorCard = {
   ) => {
     let beaconApiCall = data => {
       if data->Array.length > 0 {
-        let logData = data->Array.map(HyperLogger.logFileToObj)->JSON.Encode.array->JSON.stringify
+        let logData = data->Array.map(LoggerUtils.logFileToObj)->JSON.Encode.array->JSON.stringify
         Window.Navigator.sendBeacon(GlobalVars.logEndpoint, logData)
       }
     }

--- a/src/hyper-log-catcher/HyperLogger.res
+++ b/src/hyper-log-catcher/HyperLogger.res
@@ -1,50 +1,6 @@
 open HyperLoggerTypes
 open LoggerUtils
 
-let logFileToObj = logFile => {
-  [
-    ("timestamp", logFile.timestamp->JSON.Encode.string),
-    (
-      "log_type",
-      switch logFile.logType {
-      | DEBUG => "DEBUG"
-      | INFO => "INFO"
-      | ERROR => "ERROR"
-      | WARNING => "WARNING"
-      | SILENT => "SILENT"
-      }->JSON.Encode.string,
-    ),
-    ("component", "WEB"->JSON.Encode.string),
-    (
-      "category",
-      switch logFile.category {
-      | API => "API"
-      | USER_ERROR => "USER_ERROR"
-      | USER_EVENT => "USER_EVENT"
-      | MERCHANT_EVENT => "MERCHANT_EVENT"
-      }->JSON.Encode.string,
-    ),
-    ("source", logFile.source->convertToScreamingSnakeCase->JSON.Encode.string),
-    ("version", logFile.version->JSON.Encode.string),
-    ("value", logFile.value->JSON.Encode.string),
-    // ("internal_metadata", logFile.internalMetadata->JSON.Encode.string),
-    ("session_id", logFile.sessionId->JSON.Encode.string),
-    ("merchant_id", logFile.merchantId->JSON.Encode.string),
-    ("payment_id", logFile.paymentId->JSON.Encode.string),
-    ("app_id", logFile.appId->JSON.Encode.string),
-    ("platform", logFile.platform->convertToScreamingSnakeCase->JSON.Encode.string),
-    ("user_agent", logFile.userAgent->JSON.Encode.string),
-    ("event_name", logFile.eventName->eventNameToStrMapper->JSON.Encode.string),
-    ("browser_name", logFile.browserName->convertToScreamingSnakeCase->JSON.Encode.string),
-    ("browser_version", logFile.browserVersion->JSON.Encode.string),
-    ("latency", logFile.latency->JSON.Encode.string),
-    ("first_event", logFile.firstEvent->Utils.getStringFromBool->JSON.Encode.string),
-    ("payment_method", logFile.paymentMethod->convertToScreamingSnakeCase->JSON.Encode.string),
-  ]
-  ->Dict.fromArray
-  ->JSON.Encode.object
-}
-
 let getRefFromOption = val => {
   let innerValue = val->Option.getOr("")
   ref(innerValue)
@@ -140,10 +96,9 @@ let make = (~sessionId=?, ~source: source, ~clientSecret=?, ~merchantId=?, ~meta
   }
   let sendCachedLogsFromIDB = async () => {
     try {
-      let logs = await retrieveLogsFromIndexedDB()
+      let logs = await retrieveAndClearLogsFromIndexedDB()
       if logs->Array.length > 0 {
         beaconApiCall(logs)
-        await clearLogsFromIndexedDB()
       }
     } catch {
     | _ => ()
@@ -171,22 +126,36 @@ let make = (~sessionId=?, ~source: source, ~clientSecret=?, ~merchantId=?, ~meta
 
   let sendLogsToIndexedDB = async () => {
     try {
-      let _ = await saveLogsToIndexedDB(mainLogFile)
+      let logs = Array.copy(mainLogFile)
       clearLogFile(mainLogFile)
+      let _ = await saveLogsToIndexedDB(logs)
     } catch {
     | _ => ()
     }
   }
 
-  let sendLogsOverNetwork = async () => {
+  let fallbackToBeaconApiCall = logs => {
+    beaconApiCall(logs)
+    sendCachedLogsFromIDB()->ignore
+  }
+
+  let sendLogsOverNetwork = () => {
+    let logs = Array.copy(mainLogFile)
+    clearLogFile(mainLogFile)
     try {
-      await sendCachedLogsFromIDB()
-      beaconApiCall(mainLogFile)
-      clearLogFile(mainLogFile)
+      if ServiceWorkerHelpers.isAvailable() {
+        ServiceWorkerHelpers.sendMessage({
+          "type": "SEND_LOGS",
+          "logs": logs->Array.map(logFileToObj)->JSON.Encode.array,
+        })
+      } else {
+        logs->fallbackToBeaconApiCall
+      }
     } catch {
-    | _ => ()
+    | _ => logs->fallbackToBeaconApiCall
     }
   }
+
   let rec sendLogs = () => {
     switch timeOut.contents {
     | Some(val) => {
@@ -202,7 +171,7 @@ let make = (~sessionId=?, ~source: source, ~clientSecret=?, ~merchantId=?, ~meta
     }
 
     if networkStatus.isOnline {
-      sendLogsOverNetwork()->ignore
+      sendLogsOverNetwork()
     } else {
       sendLogsToIndexedDB()->ignore
     }

--- a/src/libraries/IndexedDB.res
+++ b/src/libraries/IndexedDB.res
@@ -6,8 +6,27 @@ type request<'a>
 type event
 
 module IndexedDB = {
-  @val @scope("window") external instance: 'a = "indexedDB"
+  @val @scope("window") external windowIndexedDB: option<'a> = "indexedDB"
+  @val @scope("self") external selfIndexedDB: option<'a> = "indexedDB"
   @send external open_: ('a, string, int) => openDBRequest = "open"
+
+  let getIndexedDBInstance = () => {
+    let windowIDB = try {windowIndexedDB} catch {
+    | _ => None
+    }
+    let selfIDB = try {selfIndexedDB} catch {
+    | _ => None
+    }
+
+    switch (windowIDB, selfIDB) {
+    | (Some(idb), _) => Some(idb)
+    | (_, Some(idb)) => Some(idb)
+    | _ => {
+        Console.error("IndexedDB is not supported in this environment:")
+        None
+      }
+    }
+  }
 }
 
 module OpenDBRequest = {
@@ -71,29 +90,35 @@ let getErrorMessageFromEvent = event => {
 }
 
 let openDBAndGetRequest = (~dbName, ~objectStoreName) => {
-  let request = IndexedDB.instance->IndexedDB.open_(dbName, 1)
+  switch IndexedDB.getIndexedDBInstance() {
+  | Some(idb) =>
+    let request = idb->IndexedDB.open_(dbName, 1)
 
-  request->OpenDBRequest.onupgradeneeded(event => {
-    let db = getDbFromEvent(event)
-    let _ =
-      db->DB.createObjectStore(objectStoreName, {"keyPath": "timestamp", "autoIncrement": true})
-  })
+    request->OpenDBRequest.onupgradeneeded(event => {
+      let db = getDbFromEvent(event)
+      let _ =
+        db->DB.createObjectStore(objectStoreName, {"keyPath": "timestamp", "autoIncrement": true})
+    })
 
-  request
+    Some(request)
+  | None => None
+  }
 }
 
 let setupDatabase = (~dbName, ~objectStoreName, ~onSuccess, ~onError) => {
-  let request = openDBAndGetRequest(~dbName, ~objectStoreName)
+  switch openDBAndGetRequest(~dbName, ~objectStoreName) {
+  | Some(request) =>
+    request->OpenDBRequest.onsuccess(event => {
+      let db = getDbFromEvent(event)
+      onSuccess(db)
+    })
 
-  request->OpenDBRequest.onsuccess(event => {
-    let db = getDbFromEvent(event)
-    onSuccess(db)
-  })
-
-  request->OpenDBRequest.onerror(event => {
-    let errorMessage = getErrorMessageFromEvent(event)
-    onError(errorMessage)
-  })
+    request->OpenDBRequest.onerror(event => {
+      let errorMessage = getErrorMessageFromEvent(event)
+      onError(errorMessage)
+    })
+  | None => onError("IndexedDB not available in this environment")
+  }
 }
 
 let addData = (db, objectStoreName, data) => {

--- a/src/libraries/IndexedDB.res
+++ b/src/libraries/IndexedDB.res
@@ -105,22 +105,6 @@ let openDBAndGetRequest = (~dbName, ~objectStoreName) => {
   }
 }
 
-let setupDatabase = (~dbName, ~objectStoreName, ~onSuccess, ~onError) => {
-  switch openDBAndGetRequest(~dbName, ~objectStoreName) {
-  | Some(request) =>
-    request->OpenDBRequest.onsuccess(event => {
-      let db = getDbFromEvent(event)
-      onSuccess(db)
-    })
-
-    request->OpenDBRequest.onerror(event => {
-      let errorMessage = getErrorMessageFromEvent(event)
-      onError(errorMessage)
-    })
-  | None => onError("IndexedDB not available in this environment")
-  }
-}
-
 let addData = (db, objectStoreName, data) => {
   let transaction = db->DB.transaction([objectStoreName], "readwrite")
   let store = transaction->Transaction.objectStore(objectStoreName)

--- a/src/service-worker/ServiceWorker.res
+++ b/src/service-worker/ServiceWorker.res
@@ -1,0 +1,70 @@
+@val @scope("self.clients") external claim: unit => unit = "claim"
+@val @scope("self") external skipWaiting: unit => unit = "skipWaiting"
+
+let sendLogs = async (logs: array<JSON.t>) => {
+  if logs->Array.length > 0 {
+    try {
+      let bodyStr = logs->JSON.Encode.array->JSON.stringify
+      let response = await Fetch.fetch(
+        GlobalVars.logEndpoint,
+        {
+          method: #POST,
+          body: Fetch.Body.string(bodyStr),
+          headers: Fetch.Headers.fromObject(
+            Dict.fromArray([("Content-Type", "application/json")])->Utils.dictToObj,
+          ),
+        },
+      )
+      let _ = response->Fetch.Response.ok
+    } catch {
+    | err => Console.error2("[ServiceWorker] Failed to send logs:", err)
+    }
+  }
+}
+
+let sendIdbLogs = async () => {
+  try {
+    let logs = await LoggerUtils.retrieveAndClearLogsFromIndexedDB()
+    if logs->Array.length > 0 {
+      logs->sendLogs->ignore
+    }
+  } catch {
+  | err => Console.error2("[ServiceWorker] Failed to send iDB logs:", err)
+  }
+}
+
+@val @scope("self") external addEventListener: (string, 'event => unit) => unit = "addEventListener"
+
+let processMessage = event => {
+  try {
+    let data = event["data"]
+    let type_ = data->Dict.get("type")->CommonUtils.getStringFromOptionalJson("")
+    if type_ === "SEND_LOGS" {
+      sendIdbLogs()->ignore
+      let newLogs = data->CommonUtils.getArray("logs")
+      if newLogs->Array.length > 0 {
+        newLogs->sendLogs->ignore
+      }
+    }
+  } catch {
+  | err => Console.error2("[ServiceWorker] Error:", err)
+  }
+}
+
+addEventListener("message", event => processMessage(event))
+
+let processActivate = async () => {
+  try {
+    let logs = await LoggerUtils.retrieveAndClearLogsFromIndexedDB()
+    logs->sendLogs->ignore
+  } catch {
+  | err => Console.error2("[ServiceWorker] Failed to send logs on activate:", err)
+  }
+}
+
+addEventListener("install", _ => skipWaiting())
+
+addEventListener("activate", _ => {
+  claim()
+  processActivate()->ignore
+})

--- a/src/service-worker/ServiceWorker.res
+++ b/src/service-worker/ServiceWorker.res
@@ -1,5 +1,7 @@
 @val @scope("self.clients") external claim: unit => unit = "claim"
 @val @scope("self") external skipWaiting: unit => unit = "skipWaiting"
+@val @scope("self")
+external selfAddEventListener: (string, 'event => unit) => unit = "addEventListener"
 
 let sendLogs = async (logs: array<JSON.t>) => {
   if logs->Array.length > 0 {
@@ -33,8 +35,6 @@ let sendIdbLogs = async () => {
   }
 }
 
-@val @scope("self") external addEventListener: (string, 'event => unit) => unit = "addEventListener"
-
 let processMessage = event => {
   try {
     let data = event["data"]
@@ -51,7 +51,7 @@ let processMessage = event => {
   }
 }
 
-addEventListener("message", event => processMessage(event))
+selfAddEventListener("message", event => processMessage(event))
 
 let processActivate = async () => {
   try {
@@ -62,9 +62,9 @@ let processActivate = async () => {
   }
 }
 
-addEventListener("install", _ => skipWaiting())
+selfAddEventListener("install", _ => skipWaiting())
 
-addEventListener("activate", _ => {
+selfAddEventListener("activate", _ => {
   claim()
   processActivate()->ignore
 })

--- a/src/service-worker/ServiceWorkerHelpers.res
+++ b/src/service-worker/ServiceWorkerHelpers.res
@@ -1,0 +1,34 @@
+let getContainer = () =>
+  try {
+    Window.Navigator.serviceWorker
+  } catch {
+  | _ => None
+  }
+
+let getController = () =>
+  getContainer()->Option.flatMap(container =>
+    container->Window.ServiceWorkerContainer.controller->Nullable.toOption
+  )
+
+let isAvailable = () =>
+  getController()
+  ->Option.map(controller =>
+    controller->Window.ServiceWorker.scriptURL->String.includes("hs-sdk-sw.js")
+  )
+  ->Option.getOr(false)
+
+let registerSW = async () =>
+  switch getContainer() {
+  | Some(container) =>
+    try {
+      let _ = await container->Window.ServiceWorkerContainer.register("/hs-sdk-sw.js")
+    } catch {
+    | _ => ()
+    }
+  | None => ()
+  }
+
+let sendMessage = message =>
+  getController()->Option.forEach(controller =>
+    controller->Window.ServiceWorker.postMessage(message)
+  )

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -146,7 +146,7 @@ const visaAPIKeyId = getEnvVariable("VISA_API_KEY_ID", "");
 const visaAPICertificatePem = getEnvVariable("VISA_API_CERTIFICATE_PEM", "");
 const repoVersion = getEnvVariable(
   "SDK_TAG_VERSION",
-  require("./package.json").version
+  require("./package.json").version,
 );
 
 /*
@@ -235,6 +235,7 @@ module.exports = (publicPath = "auto") => {
     HyperLoader: "./src/hyper-loader/HyperLoader.bs.js",
     ClickToPayAuthenticationSession:
       "./src/hyper-loader/AuthenticationSessionMethods.bs.js",
+    "hs-sdk-sw": "./src/service-worker/ServiceWorker.bs.js",
   };
 
   const definePluginValues = {
@@ -276,14 +277,14 @@ module.exports = (publicPath = "auto") => {
             "Content-Security-Policy": {
               "http-equiv": "Content-Security-Policy",
               content: `default-src 'self' ; script-src ${authorizedScriptSources.join(
-                " "
+                " ",
               )};
                 style-src ${authorizedStyleSources.join(" ")};
                 frame-src ${authorizedFrameSources.join(" ")};
                 img-src ${authorizedImageSources.join(" ")};
                 font-src ${authorizedFontSources.join(" ")};
                 connect-src ${authorizedConnectSources.join(
-                  " "
+                  " ",
                 )} ${logEndpoint} ${backendEndPoint};
       `,
             },
@@ -301,14 +302,14 @@ module.exports = (publicPath = "auto") => {
             "Content-Security-Policy": {
               "http-equiv": "Content-Security-Policy",
               content: `default-src 'self' ; script-src ${authorizedScriptSources.join(
-                " "
+                " ",
               )};
           style-src ${authorizedStyleSources.join(" ")};
           frame-src ${authorizedFrameSources.join(" ")};
           img-src ${authorizedImageSources.join(" ")};
           font-src ${authorizedFontSources.join(" ")};
           connect-src ${authorizedConnectSources.join(
-            " "
+            " ",
           )} ${logEndpoint} ${backendEndPoint};
           `,
             },
@@ -331,7 +332,7 @@ module.exports = (publicPath = "auto") => {
         analyzerMode: "static",
         reportFilename: "bundle-report.html",
         openAnalyzer: false,
-      })
+      }),
     );
   }
 
@@ -351,7 +352,7 @@ module.exports = (publicPath = "auto") => {
             paths: ["dist"],
           },
         },
-      })
+      }),
     );
   }
 


### PR DESCRIPTION
fixes: #1446 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
 Implements a Service Worker-based log proxy mechanism that enables reliable log transmission from the SDK iframe to the logging backend. The Service Worker acts as a middleman that can continue sending logs even when the iframe is unloaded
 
 ### Problem Statement
1. **Beacon API Limitations**: Logs were sent using `navigator.sendBeacon()` which has reliability issues
2. **Iframe Context Issues**: When the payment iframe unloads (e.g., during redirects), pending logs could be lost

### Merchant Page Logs (Hyper.res) - Always Beacon API

```
Merchant Page (Hyper.res) - runs on MERCHANT DOMAIN
         │
         │ 1. Logger initialized with source="hyper_loader"
         │
         ▼
    HyperLogger.make()
         │
         │ 2. Logs collected in mainLogFile array
         │
         ▼
    sendLogsOverNetwork()
         │
         │ 3. ServiceWorkerHelpers.isAvailable()?
         │    → Always FALSE (SW not registered on merchant domain)
         │
         ▼
    fallbackToBeaconApiCall()
         │
         │ 4. beaconApiCall(logs) - sendBeacon to log endpoint
         │
         │ 5. sendCachedLogsFromIDB() - try to send any cached logs
         │
         ▼
    Logs sent via Beacon API
```

### SDK Iframe Logs (Index.res) - Service Worker

```
SDK Iframe (Index.res)
         │
         │ 1. ServiceWorkerHelpers.registerSW() called on load
         │
         ▼
    Service Worker Registered (/hs-sdk-sw.js)
         │
         │ 2. HyperLogger initialized with source="hyper" or "headless"
         │
         ▼
    User interactions generate logs
         │
         │ 3. Logs collected and batched (20s interval or priority event)
         │
         ▼
    sendLogsOverNetwork()
         │
         │ 4. SW available?
         ▼
    ┌─────────────────┴─────────────────┐
    │ YES                               │ NO
    ▼                                   ▼
postMessage to SW         fallbackToBeaconApiCall()
    │                       (Beacon API + IDB cached)
    ▼                                   │
Service Worker                        ▼
processes SEND_LOGS         POST via sendBeacon
    │                                   │
    │ 5. SW sends new logs              │ 5. Beacon sends logs
    │    + cached IDB logs              │    + IDB cached logs
    ▼                                   ▼
    └──────────────┬────────────────────┘
                   ▼
           POST to GlobalVars.logEndpoint
```

## Bug fixes

### 1. Race Condition in iDB Retrieve + Clear

**Problem:** `sendCachedLogsFromIDB` used separate `retrieveLogsFromIndexedDB()` and `clearLogsFromIndexedDB()` calls. Logs added between these operations could be lost or cause duplicates.

**Fix:** Created `retrieveAndClearLogsFromIndexedDB()` - atomic operation using single readwrite transaction.

**File:** `src/Utilities/LoggerUtils.res`

### 2. Race Condition in sendLogsToIndexedDB

**Problem:** Same as above - new logs added during `await saveLogsToIndexedDB()` were cleared without being saved.

**Fix:** Same pattern - snapshot + clear before async.

**File:** `src/hyper-log-catcher/HyperLogger.res`

---


## How did you test it?
Tested locally 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
