### PR TITLE
fix: eslint configuration for all directories and JSX parsing

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -3,10 +3,15 @@ const reactHooks = require("eslint-plugin-react-hooks");
 
 module.exports = [
   {
-    files: ["src/**/*.{js,jsx,ts,tsx}"],
+    files: ["**/*.{js,jsx,ts,tsx}"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
     },
     plugins: {
       promise,
@@ -15,7 +20,10 @@ module.exports = [
     rules: {
       "react-hooks/rules-of-hooks": "error",
       "promise/catch-or-return": "error",
-      "no-console": ["error", { allow: ["warn", "error", "info", "log", "debug"] }],
+      "no-console": [
+        "error",
+        { allow: ["warn", "error", "info", "log", "debug"] },
+      ],
       "no-useless-escape": "off",
     },
   },


### PR DESCRIPTION
> [!NOTE]
> This PR was created programmatically via GitHub CLI and is linked to issue #1448.

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed ESLint configuration to properly apply to all directories in the project and enabled JSX parsing for JavaScript files.

### Changes Made:

1. **Broadened File Pattern**: Changed `files: ["src/**/*.{js,jsx,ts,tsx}"]` to `files: ["**/*.{js,jsx,ts,tsx}"]` to match all JS/TS files in any directory within the project.

2. **Enabled JSX Parsing**: Added `ecmaFeatures: { jsx: true }` to parser options so ESLint's default Espree parser can understand JSX syntax.

### Root Cause:
- The original file pattern only matched files in the root-level `src/` directory
- Files in other directories (e.g., `Hyperswitch-React-Demo-App/src/`) had no ESLint configuration applied
- JSX parsing was not explicitly enabled

Fixes #1448

## How did you test it?

Ran ESLint on the project and verified it correctly parses JSX files in all directories without errors.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible