### PR TITLE
feat: add installment UI customization with configurable interest rate display

### DIFF
--- a/src/Components/InstallmentOptionItem.res
+++ b/src/Components/InstallmentOptionItem.res
@@ -7,6 +7,7 @@ let make = (
   ~isLastItem,
 ) => {
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let installmentConfig = CustomPaymentMethodsConfig.useInstallmentConfig(~paymentMethod="card")
 
   let formatInterestRate = interestRate => Utils.formatAmountWithTwoDecimals(interestRate)
 
@@ -21,6 +22,9 @@ let make = (
   let totalAmount = Utils.formatAmountWithTwoDecimals(plan.amount_details.total_amount)
   let numberOfInstallments = plan.number_of_installments
   let interestLabel = getInterestLabel(plan.interest_rate)
+  let showInterestRates = installmentConfig
+    ->Option.map(c => c.showInterestRates == Auto)
+    ->Option.getOr(true)
 
   let mainInstallmentLabel = localeString.installmentPaymentLabel(
     numberOfInstallments,
@@ -52,13 +56,15 @@ let make = (
         </div>
       </div>
       <div className="flex flex-row w-full justify-between">
-        <span
-          className="opacity-60"
-          style={
-            fontSize: themeObj.fontSizeSm,
-          }>
-          {interestLabel->React.string}
-        </span>
+        <RenderIf condition={showInterestRates}>
+          <span
+            className="opacity-60"
+            style={
+              fontSize: themeObj.fontSizeSm,
+            }>
+            {interestLabel->React.string}
+          </span>
+        </RenderIf>
         <span
           style={
             color: themeObj.colorText,

--- a/src/Hooks/CustomPaymentMethodsConfig.res
+++ b/src/Hooks/CustomPaymentMethodsConfig.res
@@ -13,3 +13,13 @@ let useCustomPaymentMethodConfigs = (~paymentMethod, ~paymentMethodType) => {
     ->Array.get(0)
   }, (paymentMethod, paymentMethodType, paymentMethodsConfig))
 }
+
+let useInstallmentConfig = (~paymentMethod) => {
+  let {paymentMethodsConfig} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  React.useMemo2(() => {
+    paymentMethodsConfig
+    ->Array.filter(config => config.paymentMethod == paymentMethod)
+    ->Array.get(0)
+    ->Option.flatMap(c => c.installments)
+  }, (paymentMethod, paymentMethodsConfig))
+}

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -257,8 +257,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% فائدة`,
   installmentTotalPayable: "المبلغ الإجمالي المستحق",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `دفعة واحدة بقيمة ${currency} ${amount}`
-      : `${numPayments->Int.toString} دفعات بقيمة ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "يرجى اختيار خطة تقسيط",
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -256,8 +256,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% interessos`,
   installmentTotalPayable: "Total a pagar",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 termini de ${currency} ${amount}`
-      : `${numPayments->Int.toString} terminis de ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Si us plau, seleccioneu un pla de terminis",
 }

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -254,6 +254,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}%利息`,
   installmentTotalPayable: "应付总额",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    `${numPayments->Int.toString}期付款，每期 ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "请选择分期计划",
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -255,8 +255,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% Zinsen`,
   installmentTotalPayable: "Gesamtbetrag",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 Zahlung à ${currency} ${amount}`
-      : `${numPayments->Int.toString} Zahlungen à ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Bitte wählen Sie einen Ratenplan",
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -254,8 +254,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% rente`,
   installmentTotalPayable: "Totaal te betalen",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 betaling van ${currency} ${amount}`
-      : `${numPayments->Int.toString} betalingen van ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Selecteer een aflossingsplan",
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -254,8 +254,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% interest`,
   installmentTotalPayable: "Total payable",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 payment of ${currency} ${amount}`
-      : `${numPayments->Int.toString} payments of ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Please select an instalment plan",
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -254,8 +254,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% interest`,
   installmentTotalPayable: "Total payable",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 payment of ${currency} ${amount}`
-      : `${numPayments->Int.toString} payments of ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Please select an installment plan",
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -256,8 +256,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% d'intérêts`,
   installmentTotalPayable: "Total à payer",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 paiement à ${currency} ${amount}`
-      : `${numPayments->Int.toString} paiements à ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Veuillez sélectionner un plan de paiement",
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -256,8 +256,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% d'intérêt`,
   installmentTotalPayable: "Total à payer",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 paiement à ${currency} ${amount}`
-      : `${numPayments->Int.toString} paiements à ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Veuillez sélectionner un plan de paiement",
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -255,8 +255,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% ריבית`,
   installmentTotalPayable: "סה\"כ לתשלום",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `תשלום אחד של ${currency} ${amount}`
-      : `${numPayments->Int.toString} תשלומים של ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "אנא בחר תוכנית תשלומים",
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -256,8 +256,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% di interessi`,
   installmentTotalPayable: "Totale da pagare",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 rata da ${currency} ${amount}`
-      : `${numPayments->Int.toString} rate da ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Seleziona un piano a rate",
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -255,6 +255,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}%利息`,
   installmentTotalPayable: "お支払い総額",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    `${currency} ${amount} × ${numPayments->Int.toString}回払い`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "分割払いプランを選択してください",
 }

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -255,8 +255,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% odsetek`,
   installmentTotalPayable: "Do zapłaty",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 rata po ${currency} ${amount}`
-      : `${numPayments->Int.toString} raty po ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Proszę wybrać plan rat",
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -255,8 +255,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% de juros`,
   installmentTotalPayable: "Total a pagar",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 parcela de ${currency} ${amount}`
-      : `${numPayments->Int.toString} parcelas de ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Por favor, selecione um plano de parcelamento",
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -263,8 +263,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% процентов`,
   installmentTotalPayable: "Итого к оплате",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 платёж ${currency} ${amount}`
-      : `${numPayments->Int.toString} платежа по ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Пожалуйста, выберите план рассрочки",
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -255,8 +255,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% de interés`,
   installmentTotalPayable: "Total a pagar",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 pago de ${currency} ${amount}`
-      : `${numPayments->Int.toString} pagos de ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Por favor seleccione un plan de cuotas",
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -254,8 +254,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}% ränta`,
   installmentTotalPayable: "Totalt att betala",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    numPayments == 1
-      ? `1 betalning à ${currency} ${amount}`
-      : `${numPayments->Int.toString} betalningar à ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "Välj ett avbetalningsplan",
 }

--- a/src/LocaleStrings/TraditionalChineseLocale.res
+++ b/src/LocaleStrings/TraditionalChineseLocale.res
@@ -254,6 +254,6 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   installmentInterestRate: interestRate => `${interestRate}%利息`,
   installmentTotalPayable: "應付總額",
   installmentPaymentLabel: (numPayments, currency, amount) =>
-    `${numPayments->Int.toString}期付款，每期 ${currency} ${amount}`,
+    `${numPayments->Int.toString} x ${currency} ${amount}`,
   installmentSelectPlanError: "請選擇分期計劃",
 }

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -189,6 +189,8 @@ type paymentMethodMessage = {
   displayMode: messageDisplayMode,
 }
 
+type installmentConfig = {showInterestRates: showType}
+
 type paymentMethodTypeConfig = {
   paymentMethodType: string,
   message: paymentMethodMessage,
@@ -196,6 +198,7 @@ type paymentMethodTypeConfig = {
 
 type paymentMethodConfig = {
   paymentMethod: string,
+  installments: option<installmentConfig>,
   paymentMethodTypes: array<paymentMethodTypeConfig>,
 }
 
@@ -419,6 +422,17 @@ let getMessageDisplayMode = (str, key) => {
   }
 }
 
+let getShowType = (str, key) => {
+  switch str {
+  | "auto" => Auto
+  | "never" => Never
+  | str => {
+      str->unknownPropValueWarning(["auto", "never"], key)
+      Auto
+    }
+  }
+}
+
 let defaultPaymentMethodMessage = {
   value: None,
   displayMode: DefaultSdkMessage,
@@ -457,11 +471,30 @@ let getPaymentMethodTypeConfig = (json, logger, paymentMethod) => {
   }
 }
 
+let getInstallmentConfig = (json, logger, context) => {
+  let installmentDict = json->getDictFromDict("installments")
+  if installmentDict->Dict.toArray->Array.length > 0 {
+    unknownKeysWarning(["showInterestRates"], installmentDict, context ++ ".installments")
+    Some({
+      showInterestRates: getWarningString(
+        installmentDict,
+        "showInterestRates",
+        "auto",
+        ~logger,
+      )->getShowType(context ++ ".installments.showInterestRates"),
+    })
+  } else {
+    None
+  }
+}
+
 let getPaymentMethodConfig = (json, logger) => {
-  unknownKeysWarning(["paymentMethod", "paymentMethodTypes"], json, "options.paymentMethodsConfig")
   let paymentMethod = json->getWarningString("paymentMethod", "", ~logger)
+  let context = "options.paymentMethodsConfig." ++ paymentMethod
+  unknownKeysWarning(["paymentMethod", "installments", "paymentMethodTypes"], json, context)
   {
     paymentMethod,
+    installments: getInstallmentConfig(json, logger, context),
     paymentMethodTypes: json
     ->getArrayOfObjectsFromDict("paymentMethodTypes")
     ->Array.map(pmTypeJson => getPaymentMethodTypeConfig(pmTypeJson, logger, paymentMethod)),
@@ -571,16 +604,6 @@ let getBusiness = (dict, str, logger) => {
     }
   })
   ->Option.getOr(defaultBusiness)
-}
-let getShowType = (str, key) => {
-  switch str {
-  | "auto" => Auto
-  | "never" => Never
-  | str => {
-      str->unknownPropValueWarning(["auto", "never"], key)
-      Auto
-    }
-  }
 }
 let getApplePayType = str => {
   switch str {


### PR DESCRIPTION
Closes #1452

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Two improvements to the installment payment UI:

1. **Simplified label format**: Changed from "2 payments of INR 100" to "2 x INR 100" for cleaner display across all 18 supported locales

2. **Configurable interest rate visibility**: Added `installments` config option at payment method level to hide interest rates when needed

**Configuration example:**
```json
{
  "paymentMethodsConfig": [{
    "paymentMethod": "card",
    "installments": { "showInterestRates": "never" },
    "paymentMethodTypes": [...]
  }]
}
```

**Options:**
- `auto` (default) - Show interest rates normally
- `never` - Hide interest rates entirely

**Files changed:**
- `src/Types/PaymentType.res` - Added `installmentConfig` type
- `src/Hooks/CustomPaymentMethodsConfig.res` - Added `useInstallmentConfig` hook
- `src/Components/InstallmentOptionItem.res` - Conditional interest rate rendering
- 18 locale files - Updated `installmentPaymentLabel` to new format

## How did you test it?

- [x] Verified build passes (`npm run build`)
- [x] Verified interest rates show by default
- [x] Verified interest rates hidden when `showInterestRates: "never"`
- [x] Verified label format displays as "X x CUR AMT"

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible