### PR TITLE
fix: harden getSdkAuthorizationData against injection and parsing bugs

### DIFF
--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1910,22 +1910,47 @@ let rec maskStringValuesInJson = (~value, ~currentPath, ~depth, ~shouldMaskField
 let getSdkAuthorizationData = sdkAuthorization => {
   open Types
 
-  let arrOfKeys =
-    sdkAuthorization
-    ->Window.atob
-    ->String.split(",")
-
-  let getValueFromArrayOfKeys = keyName => {
-    let keyStr = arrOfKeys->Array.find(key => key->String.includes(keyName))
-    let value = keyStr->Option.flatMap(key => key->String.split("=")->Array.get(1))
-
-    value
+  let emptyResult = {
+    publishableKey: None,
+    clientSecret: None,
+    customerId: None,
+    profileId: None,
   }
 
-  {
-    publishableKey: getValueFromArrayOfKeys("publishable_key"),
-    clientSecret: getValueFromArrayOfKeys("client_secret"),
-    customerId: getValueFromArrayOfKeys("customer_id"),
-    profileId: getValueFromArrayOfKeys("profile_id"),
+  try {
+    let arrOfKeys = sdkAuthorization->Window.atob->String.split(",")
+
+    let getValueFromArrayOfKeys = (~keyName, ~regex) => {
+      let prefix = keyName ++ "="
+      let keyStr = arrOfKeys->Array.find(key => key->String.startsWith(prefix))
+      keyStr->Option.flatMap(key => {
+        let idx = key->String.indexOf("=")
+        if idx !== -1 {
+          let value = key->String.sliceToEnd(~start=idx + 1)
+          if RegExp.test(regex, value) {
+            Some(value)
+          } else {
+            None
+          }
+        } else {
+          None
+        }
+      })
+    }
+
+    {
+      publishableKey: getValueFromArrayOfKeys(
+        ~keyName="publishable_key",
+        ~regex=%re("/^pk_(prd|snd|dev)_[a-zA-Z0-9]+$/"),
+      ),
+      clientSecret: getValueFromArrayOfKeys(
+        ~keyName="client_secret",
+        ~regex=%re("/^[A-Za-z0-9_-]+_secret_[A-Za-z0-9]+$/"),
+      ),
+      customerId: getValueFromArrayOfKeys(~keyName="customer_id", ~regex=%re("/^[a-zA-Z0-9_-]+$/")),
+      profileId: getValueFromArrayOfKeys(~keyName="profile_id", ~regex=%re("/^[a-zA-Z0-9_-]+$/")),
+    }
+  } catch {
+  | _ => emptyResult
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

## Description

Hardened the `getSdkAuthorizationData` function in `Utils.res` against injection and XSS attacks. The function decodes a base64-encoded SDK authorization token and extracts key-value pairs (`publishableKey`, `clientSecret`, `customerId`, `profileId`) that flow into downstream consumers. Previously, no input validation was applied to these user-controlled values, and several parsing bugs existed.

**Vulnerabilities fixed:**

1. **Unhandled `atob` exception** -- `Window.atob` throws `DOMException` on invalid base64 input. Added `try/catch` around the entire function body, returning an empty result (all `None`) on failure.

2. **Value truncation on `=` characters** -- `String.split("=") -> Array.get(1)` discarded everything after the first `=`, silently corrupting values containing `=` (e.g., base64 padding). Replaced with `indexOf("=") + sliceToEnd` to capture the full value.

3. **False-positive key matching** -- `String.includes(keyName)` used substring matching, so a key like `"key"` would match `"publishable_key"`. Replaced with `String.startsWith(keyName ++ "=")` for exact prefix matching.

4. **No input validation** -- Extracted values were passed directly to downstream code with no sanitization. Added per-field allowlist regex validation using anchored (`^...$`) patterns:
   - `publishableKey`: `^pk_(prd|snd|dev)_[a-zA-Z0-9]+$`
   - `clientSecret`: `^[A-Za-z0-9_-]+_secret_[A-Za-z0-9]+$`
   - `customerId`: `^[a-zA-Z0-9_-]+$`
   - `profileId`: `^[a-zA-Z0-9_-]+$`

   Fields that fail validation are returned as `None`, preventing malicious payloads from propagating.

**Design decisions:**
- Regexes are intentionally format-agnostic (not tied to specific backend ID formats) since those formats may change.
- CSP is deployed via `<meta>` tag as defense-in-depth but is NOT relied upon as the sole XSS mitigation.
- `JSON.stringify` was evaluated and rejected as an XSS mitigation since it does not escape `<`, `>`, `(`, `)`.

## Changes Summary

**Modified Files:**
- `src/Utilities/Utils.res` -- `getSdkAuthorizationData` function (lines 1910-1956): added `try/catch` for `atob`, fixed value extraction, fixed key matching, added per-field regex validation.

## How did you test it?

Normal Flow: 
<img width="1728" height="799" alt="image" src="https://github.com/user-attachments/assets/9fde610e-f283-47f3-aa6a-e43d7ac615a8" />


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
