### PR TITLE
fix: premount loader race condition

### DIFF
--- a/src/Payments/PreMountLoader.res
+++ b/src/Payments/PreMountLoader.res
@@ -32,7 +32,16 @@ let useMessageHandler = getMessageHandler => {
       }
     }
 
+    let handleResendMountedCallback = (ev: Window.event) => {
+      open Utils
+      let dict = ev.data->safeParse->getDictFromJson
+      if dict->Dict.get("requestPreMountLoaderMountedCallback")->Option.isSome {
+        messageParentWindow([("preMountLoaderIframeMountedCallback", true->JSON.Encode.bool)])
+      }
+    }
+
     Window.addEventListener("message", handleCleanUpEventListener)
+    Window.addEventListener("message", handleResendMountedCallback)
 
     setupMessageListener()
 
@@ -40,6 +49,7 @@ let useMessageHandler = getMessageHandler => {
       () => {
         cleanupMessageListener()
         Window.removeEventListener("message", handleCleanUpEventListener)
+        Window.removeEventListener("message", handleResendMountedCallback)
       },
     )
   }, [])

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -1461,6 +1461,8 @@ let make = (
             preMountLoaderIframeDiv->Window.iframePostMessage(msg)
           })
         }
+        let msg = [("requestPreMountLoaderMountedCallback", true->JSON.Encode.bool)]->Dict.fromArray
+        preMountLoaderIframeDiv->Window.iframePostMessage(msg)
         preMountLoaderMountedPromise
         ->then(_ => {
           let disableSavedPaymentMethods =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

**Root cause:** When `hyper.elements()` is called multiple times in rapid succession (e.g. during screen switching), `Elements.make` is invoked each time. Each call creates a new `preMountLoaderMountedPromise` and registers a new event listener via `addSmartEventListener` using the hardcoded key `"onPreMountLoaderIframeCallback"`. Because `addSmartEventListener` deduplicates by key, each new registration silently removes the previous listener.

The pre-mount loader iframe — which only sends `preMountLoaderIframeMountedCallback` once on initial mount — never re-sends it. As a result, all previously created promises lose their listeners and hang indefinitely, and the new promise also hangs because the iframe won't re-fire its mount callback. This causes the payment element to never initialize: no payment methods, session tokens, or customer data are ever fetched.

**Fix:** When `mountPreMountLoaderIframe` detects that the iframe already exists in the DOM, it now sends a `requestPreMountLoaderMountedCallback` message to the existing iframe, asking it to re-emit its `preMountLoaderIframeMountedCallback` message. A new handler (`handleResendMountedCallback`) was added to `PreMountLoader.res` to listen for this request and re-send the callback. This unblocks the newly created promise without recreating the iframe.

Additionally, `mountPreMountLoaderIframe` in `Elements.res` was corrected to always return the live DOM element via a fresh `querySelector` at the end of the function, preventing a regression where the returned value would be `null` on the first call (since the initial query runs before the iframe is appended to the DOM).

The same fix is applied to `PaymentMethodsManagementElements.res`, which had the identical issue.

**Files changed:**
- `src/hyper-loader/Elements.res` — send `requestPreMountLoaderMountedCallback` when iframe already exists; fix return value to always be the live DOM element
- `src/hyper-loader/PaymentMethodsManagementElements.res` — same rapid-switch fix
- `src/Payments/PreMountLoader.res` — add `handleResendMountedCallback` to re-emit the mounted callback on request

## How did you test it?

- Manually tested rapid `hyper.elements()` calls (simulating screen switching) to confirm the payment element initializes correctly on each call
- Verified that payment methods, session tokens, and customer payment methods are fetched successfully after rapid switching
- Confirmed no regression on the initial (first) load path

Before - 

<img width="561" height="304" alt="image" src="https://github.com/user-attachments/assets/6985d2db-4979-4cdc-b54b-3e7d371091f4" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
