### PR TITLE
fix: installments selection reset on saved methods screen and checkbox alignment

### DIFF
--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -103,13 +103,17 @@ let make = (
   let {country, state, pinCode} = PaymentUtils.useNonPiiAddressData()
 
   React.useEffect(() => {
+    setSelectedInstallmentPlan(_ => None)
+    setShowInstallments(_ => false)
+    None
+  }, [paymentItem])
+
+  React.useEffect(() => {
     open CardUtils
 
     if isActive {
       // * Focus CVC
       focusCVC()
-      setSelectedInstallmentPlan(_ => None)
-      setShowInstallments(_ => false)
       // * Sending card expiry to handle cases where the card expires before the use date.
       `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
       ->CardValidations.formatCardExpiryNumber
@@ -321,7 +325,7 @@ let make = (
                     style={
                       paddingTop: themeObj.spacingUnit,
                     }
-                    className="w-full flex">
+                    className="w-full flex pl-1">
                     <InstallmentOptions
                       setSelectedInstallmentPlan
                       showInstallments


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Fixes: #1475 
<!-- Describe your changes in detail -->
1. The “Pay in installments” checkbox, dropdown, and selected plan were resetting whenever the CVC was changed.
2. Installments checkbox was not aligned with CVC label

## How did you test it?
Tested Locally
ISSUE:

https://github.com/user-attachments/assets/7dca56f4-cd22-4454-926e-bcfb2a27a3b2



FIX:
https://github.com/user-attachments/assets/da8d2129-2dc3-4b94-97bb-eed7c7f9c00b


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
