### PR TITLE
fix: send cardBrand as "Unknown" instead of "NOTFOUND" and add isCvcEmpty to payment method info event

### DIFF
--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -206,6 +206,11 @@ let getCardStringFromType = val => {
   }
 }
 
+let getCardBrandDisplayName = cardBrand => {
+  let cardBrandString = cardBrand->getCardStringFromType
+  cardBrandString == "NOTFOUND" ? "Unknown" : cardBrandString
+}
+
 let getCurrentMonthAndYear = (dateTimeIsoString: string) => {
   open CardValidations
   let tempTimeDateString = dateTimeIsoString->String.replace("Z", "")

--- a/src/Components/AccordionContainer.res
+++ b/src/Components/AccordionContainer.res
@@ -62,6 +62,7 @@ let make = (
   ~checkoutEle: React.element,
   ~cardProps: CardUtils.cardProps,
   ~expiryProps: CardUtils.expiryProps,
+  ~cvcProps: CardUtils.cvcProps,
 ) => {
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let paymentMethodList = Recoil.useRecoilValueFromAtom(paymentMethodList)
@@ -76,6 +77,7 @@ let make = (
     ~paymentMethods=paymentMethodListValue.payment_methods,
     ~cardProps,
     ~expiryProps,
+    ~cvcProps,
   )
 
   let cardOptionDetails =

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -72,6 +72,7 @@ let make = (
   let {hideCardExpiry} = CardUtils.getLayoutClass(layout).savedMethodCustomization
   let (cardBrand, setCardBrand) = Recoil.useRecoilState(RecoilAtoms.cardBrand)
   let {isCVCValid, setIsCVCValid, cvcNumber, changeCVCNumber, handleCVCBlur, cvcError} = cvcProps
+  let isCvcEmpty = cvcNumber->String.length == 0
   let cvcRef = React.useRef(Nullable.null)
   let pickerItemClass = isActive ? "PickerItem--selected" : ""
 
@@ -109,16 +110,7 @@ let make = (
   }, [paymentItem])
 
   React.useEffect(() => {
-    open CardUtils
-
     if isActive {
-      // * Focus CVC
-      focusCVC()
-      // * Sending card expiry to handle cases where the card expires before the use date.
-      `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
-      ->CardValidations.formatCardExpiryNumber
-      ->emitExpiryDate
-
       PaymentUtils.emitPaymentMethodInfo(
         ~paymentMethod=paymentItem.paymentMethod,
         ~paymentMethodType,
@@ -131,7 +123,21 @@ let make = (
         ~cardLast4,
         ~cardBin,
         ~isSavedPaymentMethod=true,
+        ~isCvcEmpty,
       )
+    }
+    None
+  }, (isActive, paymentItem, country, state, pinCode, isCvcEmpty))
+
+  React.useEffect(() => {
+    open CardUtils
+    if isActive {
+      // * Focus CVC
+      focusCVC()
+      // * Sending card expiry to handle cases where the card expires before the use date.
+      `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
+      ->CardValidations.formatCardExpiryNumber
+      ->emitExpiryDate
     }
     None
   }, (isActive, paymentItem, country, state, pinCode))

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -600,7 +600,8 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
             expiryProps
             cvcProps
           />
-        | Accordion => <AccordionContainer paymentOptions checkoutEle cardProps expiryProps cvcProps />
+        | Accordion =>
+          <AccordionContainer paymentOptions checkoutEle cardProps expiryProps cvcProps />
         }}
       </div>
     </RenderIf>

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -598,8 +598,9 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
             cardShimmerCount
             cardProps
             expiryProps
+            cvcProps
           />
-        | Accordion => <AccordionContainer paymentOptions checkoutEle cardProps expiryProps />
+        | Accordion => <AccordionContainer paymentOptions checkoutEle cardProps expiryProps cvcProps />
         }}
       </div>
     </RenderIf>

--- a/src/PaymentElementV2.res
+++ b/src/PaymentElementV2.res
@@ -162,8 +162,9 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
             cardShimmerCount
             cardProps
             expiryProps
+            cvcProps
           />
-        | Accordion => <AccordionContainer paymentOptions checkoutEle cardProps expiryProps />
+        | Accordion => <AccordionContainer paymentOptions checkoutEle cardProps expiryProps cvcProps />
         }}
       </div>
     </RenderIf>

--- a/src/PaymentElementV2.res
+++ b/src/PaymentElementV2.res
@@ -164,7 +164,8 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
             expiryProps
             cvcProps
           />
-        | Accordion => <AccordionContainer paymentOptions checkoutEle cardProps expiryProps cvcProps />
+        | Accordion =>
+          <AccordionContainer paymentOptions checkoutEle cardProps expiryProps cvcProps />
         }}
       </div>
     </RenderIf>

--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -55,6 +55,7 @@ let make = (
   ~cardShimmerCount: int,
   ~cardProps: CardUtils.cardProps,
   ~expiryProps: CardUtils.expiryProps,
+  ~cvcProps: CardUtils.cvcProps,
 ) => {
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {readOnly, customMethodNames, layout} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -120,6 +121,7 @@ let make = (
     ~paymentMethods=paymentMethodListValue.payment_methods,
     ~cardProps,
     ~expiryProps,
+    ~cvcProps,
   )
 
   let displayIcon = ele => {

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -658,6 +658,7 @@ let emitPaymentMethodInfo = (
   ~state="",
   ~pinCode="",
   ~isSavedPaymentMethod=false,
+  ~isCvcEmpty=true,
 ) => {
   let cardBrandString = cardBrand->CardUtils.getCardStringFromType
   let cardBrandValue = cardBrandString == "NOTFOUND" ? "Unknown" : cardBrandString
@@ -667,6 +668,7 @@ let emitPaymentMethodInfo = (
     ("cardBin", cardBin->JSON.Encode.string),
     ("cardExpiryMonth", cardExpiryMonth->JSON.Encode.string),
     ("cardExpiryYear", cardExpiryYear->JSON.Encode.string),
+    ("isCvcEmpty", isCvcEmpty->JSON.Encode.bool),
   ]
 
   let baseAddressFields = [
@@ -691,8 +693,13 @@ let emitPaymentMethodInfo = (
     [...basePaymentInfoFields, ...baseAddressFields, ...baseCardsFields]
   }
 
-  let finalMsg =
-    msg->Array.filter(((_, value)) => value->JSON.Decode.string->Option.getOr("") != "")
+  let finalMsg = msg->Array.filter(((_, value)) =>
+    switch JSON.Classify.classify(value) {
+    | String(_) => value->JSON.Decode.string->Option.getOr("") != ""
+    | Bool(_) => true
+    | _ => false
+    }
+  )
 
   emitMessage(finalMsg->Array.concat(baseSavedPaymentField)->Dict.fromArray)
 }
@@ -720,6 +727,7 @@ let useEmitPaymentMethodInfo = (
   ~paymentMethods: array<PaymentMethodsRecord.methods>,
   ~cardProps: CardUtils.cardProps,
   ~expiryProps: CardUtils.expiryProps,
+  ~cvcProps: CardUtils.cvcProps,
 ) => {
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
   let {country, state, pinCode} = useNonPiiAddressData()
@@ -728,10 +736,17 @@ let useEmitPaymentMethodInfo = (
   let cardBin = cardNumber->CardUtils.getCardBin
   let cardLast4 = cardNumber->CardUtils.getCardLast4
   let {cardExpiry} = expiryProps
+  let {cvcNumber} = cvcProps
+  let isCvcEmpty = cvcNumber->String.length === 0
   let isCardValid = cardProps.isCardValid->Option.getOr(false)
   let isExpiryValid = expiryProps.isExpiryValid->Option.getOr(false)
   let (cardExpiryMonth, cardExpiryYear) = cardExpiry->CardUtils.getExpiryDates
   let shouldEmitCardInfo = isCardValid && isExpiryValid && paymentMethodName == "card"
+
+  React.useEffect(() => {
+    Console.log2("isCvcEmpty", isCvcEmpty)
+    None
+  }, [isCvcEmpty])
 
   let emitPaymentMethodInfoWrapper = (~paymentMethod, ~paymentMethodType) => {
     if shouldEmitCardInfo {
@@ -746,6 +761,7 @@ let useEmitPaymentMethodInfo = (
         ~country,
         ~state,
         ~pinCode,
+        ~isCvcEmpty,
       )
     } else {
       emitPaymentMethodInfo(~paymentMethod, ~paymentMethodType, ~country, ~state, ~pinCode)
@@ -798,6 +814,7 @@ let useEmitPaymentMethodInfo = (
     paymentMethods,
     isCardValid,
     isExpiryValid,
+    isCvcEmpty,
     country,
     state,
     pinCode,

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -660,10 +660,8 @@ let emitPaymentMethodInfo = (
   ~isSavedPaymentMethod=false,
   ~isCvcEmpty=true,
 ) => {
-  let cardBrandString = cardBrand->CardUtils.getCardStringFromType
-  let cardBrandValue = cardBrandString == "NOTFOUND" ? "Unknown" : cardBrandString
   let baseCardsFields = [
-    ("cardBrand", cardBrandValue->JSON.Encode.string),
+    ("cardBrand", cardBrand->CardUtils.getCardBrandDisplayName->JSON.Encode.string),
     ("cardLast4", cardLast4->JSON.Encode.string),
     ("cardBin", cardBin->JSON.Encode.string),
     ("cardExpiryMonth", cardExpiryMonth->JSON.Encode.string),
@@ -736,8 +734,7 @@ let useEmitPaymentMethodInfo = (
   let cardBin = cardNumber->CardUtils.getCardBin
   let cardLast4 = cardNumber->CardUtils.getCardLast4
   let {cardExpiry} = expiryProps
-  let {cvcNumber} = cvcProps
-  let isCvcEmpty = cvcNumber->String.length === 0
+  let isCvcEmpty = cvcProps.cvcNumber->String.length === 0
   let isCardValid = cardProps.isCardValid->Option.getOr(false)
   let isExpiryValid = expiryProps.isExpiryValid->Option.getOr(false)
   let (cardExpiryMonth, cardExpiryYear) = cardExpiry->CardUtils.getExpiryDates

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -743,11 +743,6 @@ let useEmitPaymentMethodInfo = (
   let (cardExpiryMonth, cardExpiryYear) = cardExpiry->CardUtils.getExpiryDates
   let shouldEmitCardInfo = isCardValid && isExpiryValid && paymentMethodName == "card"
 
-  React.useEffect(() => {
-    Console.log2("isCvcEmpty", isCvcEmpty)
-    None
-  }, [isCvcEmpty])
-
   let emitPaymentMethodInfoWrapper = (~paymentMethod, ~paymentMethodType) => {
     if shouldEmitCardInfo {
       emitPaymentMethodInfo(

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -659,8 +659,10 @@ let emitPaymentMethodInfo = (
   ~pinCode="",
   ~isSavedPaymentMethod=false,
 ) => {
+  let cardBrandString = cardBrand->CardUtils.getCardStringFromType
+  let cardBrandValue = cardBrandString == "NOTFOUND" ? "Unknown" : cardBrandString
   let baseCardsFields = [
-    ("cardBrand", cardBrand->CardUtils.getCardStringFromType->JSON.Encode.string),
+    ("cardBrand", cardBrandValue->JSON.Encode.string),
     ("cardLast4", cardLast4->JSON.Encode.string),
     ("cardBin", cardBin->JSON.Encode.string),
     ("cardExpiryMonth", cardExpiryMonth->JSON.Encode.string),
@@ -683,7 +685,7 @@ let emitPaymentMethodInfo = (
     ]
   }
 
-  let msg = if cardBrand === CardUtils.NOTFOUND || paymentMethod !== "card" {
+  let msg = if paymentMethod !== "card" {
     [...basePaymentInfoFields, ...baseAddressFields]
   } else {
     [...basePaymentInfoFields, ...baseAddressFields, ...baseCardsFields]


### PR DESCRIPTION

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes #1500

This PR addresses two issues in the `emitPaymentMethodInfo` event:

### 1. cardBrand "NOTFOUND" fix
- **`cardBrand` was sent as `"NOTFOUND"`** — an internal enum value that should not be exposed to consumers. This PR maps it to `"Unknown"` instead.
- **Card fields were entirely excluded** from the event payload when the brand was `NOTFOUND`, even though the payment method is still a card. This PR removes the `cardBrand === NOTFOUND` check so card fields are always included for card payments.

### 2. Add `isCvcEmpty` field
- Added `isCvcEmpty` boolean field to the payment method info event payload, allowing consumers to know whether the CVC field has been filled.
- Threaded `cvcProps` through `AccordionContainer`, `PaymentOptions`, `PaymentElement`, and `PaymentElementV2` so the CVC state is available where needed.
- For saved cards (`SavedCardItem`), separated the CVC focus/expiry logic from the payment method info emission so the event re-emits when `isCvcEmpty` changes.
- Updated the `finalMsg` filter to preserve boolean values (previously it only kept non-empty strings, which would have filtered out `isCvcEmpty`).

## How did you test it?

- Manually verified that card payments with unrecognized brands now emit `cardBrand: "Unknown"` instead of `"NOTFOUND"`.
- Verified that card fields are always present in the event for card payment methods.
- Verified that `isCvcEmpty` is emitted as `true` when CVC is empty and `false` when filled.
- Verified that saved card selection re-emits the event when CVC input changes.


https://github.com/user-attachments/assets/da0292e0-8d1a-43ea-81c7-16a264a95d6e


## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible