### PR TITLE
feat: update intent callback return signature change

### DIFF
--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -297,7 +297,7 @@ let make = (
       })
     }
 
-    let updateIntent = async (callback: unit => promise<string>) => {
+    let updateIntent = async (callback: unit => promise<JSON.t>) => {
       open UpdateIntentHelpersNew
 
       if isUpdateIntentInProgress.contents {

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -297,7 +297,7 @@ let make = (
       })
     }
 
-    let updateIntent = async (callback: unit => promise<JSON.t>) => {
+    let updateIntent = async (callback: unit => promise<Types.updateIntentReturnObject>) => {
       open UpdateIntentHelpersNew
 
       if isUpdateIntentInProgress.contents {

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -297,7 +297,7 @@ let make = (
       })
     }
 
-    let updateIntent = async (callback: unit => promise<Types.updateIntentReturnObject>) => {
+    let updateIntent = async (callback: unit => promise<JSON.t>) => {
       open UpdateIntentHelpersNew
 
       if isUpdateIntentInProgress.contents {

--- a/src/hyper-loader/PaymentSession.res
+++ b/src/hyper-loader/PaymentSession.res
@@ -28,7 +28,7 @@ let make = (
 
   let localSelectorString = "hyper-preMountLoader-session-iframe"
 
-  let updateIntent = (callback: unit => promise<string>) => {
+  let updateIntent = (callback: unit => promise<JSON.t>) => {
     UpdateIntentHelpersNew.performUpdateIntent(
       ~isUpdateIntentInProgress,
       ~clientSecretRef,

--- a/src/hyper-loader/PaymentSession.res
+++ b/src/hyper-loader/PaymentSession.res
@@ -28,7 +28,7 @@ let make = (
 
   let localSelectorString = "hyper-preMountLoader-session-iframe"
 
-  let updateIntent = (callback: unit => promise<Types.updateIntentReturnObject>) => {
+  let updateIntent = (callback: unit => promise<JSON.t>) => {
     UpdateIntentHelpersNew.performUpdateIntent(
       ~isUpdateIntentInProgress,
       ~clientSecretRef,

--- a/src/hyper-loader/PaymentSession.res
+++ b/src/hyper-loader/PaymentSession.res
@@ -28,7 +28,7 @@ let make = (
 
   let localSelectorString = "hyper-preMountLoader-session-iframe"
 
-  let updateIntent = (callback: unit => promise<JSON.t>) => {
+  let updateIntent = (callback: unit => promise<Types.updateIntentReturnObject>) => {
     UpdateIntentHelpersNew.performUpdateIntent(
       ~isUpdateIntentInProgress,
       ~clientSecretRef,

--- a/src/hyper-loader/Types.res
+++ b/src/hyper-loader/Types.res
@@ -38,12 +38,14 @@ type paymentElement = {
   onSDKHandleClick: option<unit => Promise.t<unit>> => unit,
 }
 
+type updateIntentReturnObject = {sdkAuthorization: string}
+
 type element = {
   getElement: string => option<paymentElement>,
   update: JSON.t => unit,
   fetchUpdates: unit => promise<JSON.t>,
   create: (string, JSON.t) => paymentElement,
-  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
+  updateIntent: (unit => promise<updateIntentReturnObject>) => promise<JSON.t>,
 }
 
 type getCustomerSavedPaymentMethods = {
@@ -55,7 +57,7 @@ type getCustomerSavedPaymentMethods = {
 
 type initPaymentSession = {
   getCustomerSavedPaymentMethods: unit => promise<JSON.t>,
-  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
+  updateIntent: (unit => promise<updateIntentReturnObject>) => promise<JSON.t>,
 }
 
 type isCustomerPresentInput = {email: string}

--- a/src/hyper-loader/Types.res
+++ b/src/hyper-loader/Types.res
@@ -38,14 +38,12 @@ type paymentElement = {
   onSDKHandleClick: option<unit => Promise.t<unit>> => unit,
 }
 
-type updateIntentReturnObject = {sdkAuthorization: string}
-
 type element = {
   getElement: string => option<paymentElement>,
   update: JSON.t => unit,
   fetchUpdates: unit => promise<JSON.t>,
   create: (string, JSON.t) => paymentElement,
-  updateIntent: (unit => promise<updateIntentReturnObject>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 type getCustomerSavedPaymentMethods = {
@@ -57,7 +55,7 @@ type getCustomerSavedPaymentMethods = {
 
 type initPaymentSession = {
   getCustomerSavedPaymentMethods: unit => promise<JSON.t>,
-  updateIntent: (unit => promise<updateIntentReturnObject>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 type isCustomerPresentInput = {email: string}

--- a/src/hyper-loader/Types.res
+++ b/src/hyper-loader/Types.res
@@ -43,7 +43,7 @@ type element = {
   update: JSON.t => unit,
   fetchUpdates: unit => promise<JSON.t>,
   create: (string, JSON.t) => paymentElement,
-  updateIntent: (unit => promise<string>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 type getCustomerSavedPaymentMethods = {
@@ -55,7 +55,7 @@ type getCustomerSavedPaymentMethods = {
 
 type initPaymentSession = {
   getCustomerSavedPaymentMethods: unit => promise<JSON.t>,
-  updateIntent: (unit => promise<string>) => promise<JSON.t>,
+  updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
 type isCustomerPresentInput = {email: string}

--- a/src/hyper-loader/UpdateIntentHelpersNew.res
+++ b/src/hyper-loader/UpdateIntentHelpersNew.res
@@ -35,9 +35,12 @@ let waitForReady = () => {
 
 // --- Credential parsing ---
 
-let getNewCredentials = async (~callback, ~currentClientSecret) => {
+let getNewCredentials = async (
+  ~callback: unit => promise<Types.updateIntentReturnObject>,
+  ~currentClientSecret,
+) => {
   let callbackResult = await callback()
-  let newSdkAuthorization = callbackResult->getDictFromJson->getString("sdkAuthorization", "")
+  let newSdkAuthorization = callbackResult.sdkAuthorization
   let sdkAuthorizationData = newSdkAuthorization->getSdkAuthorizationData
   let newClientSecret = switch sdkAuthorizationData.clientSecret->getNonEmptyOption {
   | Some(cs) => cs
@@ -274,7 +277,7 @@ let performUpdateIntent = async (
   ~customerPaymentMethodsDataPromise: ref<promise<JSON.t>>,
   ~sessionTokensDataPromise: ref<promise<JSON.t>>,
   ~iframes: array<Nullable.t<Dom.element>>,
-  ~callback: unit => promise<JSON.t>,
+  ~callback: unit => promise<Types.updateIntentReturnObject>,
   ~publishableKey,
   ~profileId,
   ~sdkSessionId,

--- a/src/hyper-loader/UpdateIntentHelpersNew.res
+++ b/src/hyper-loader/UpdateIntentHelpersNew.res
@@ -35,12 +35,9 @@ let waitForReady = () => {
 
 // --- Credential parsing ---
 
-let getNewCredentials = async (
-  ~callback: unit => promise<Types.updateIntentReturnObject>,
-  ~currentClientSecret,
-) => {
+let getNewCredentials = async (~callback: unit => promise<JSON.t>, ~currentClientSecret) => {
   let callbackResult = await callback()
-  let newSdkAuthorization = callbackResult.sdkAuthorization
+  let newSdkAuthorization = callbackResult->getDictFromJson->getString("sdkAuthorization", "")
   let sdkAuthorizationData = newSdkAuthorization->getSdkAuthorizationData
   let newClientSecret = switch sdkAuthorizationData.clientSecret->getNonEmptyOption {
   | Some(cs) => cs
@@ -277,7 +274,7 @@ let performUpdateIntent = async (
   ~customerPaymentMethodsDataPromise: ref<promise<JSON.t>>,
   ~sessionTokensDataPromise: ref<promise<JSON.t>>,
   ~iframes: array<Nullable.t<Dom.element>>,
-  ~callback: unit => promise<Types.updateIntentReturnObject>,
+  ~callback: unit => promise<JSON.t>,
   ~publishableKey,
   ~profileId,
   ~sdkSessionId,

--- a/src/hyper-loader/UpdateIntentHelpersNew.res
+++ b/src/hyper-loader/UpdateIntentHelpersNew.res
@@ -36,7 +36,8 @@ let waitForReady = () => {
 // --- Credential parsing ---
 
 let getNewCredentials = async (~callback, ~currentClientSecret) => {
-  let newSdkAuthorization = await callback()
+  let callbackResult = await callback()
+  let newSdkAuthorization = callbackResult->getDictFromJson->getString("sdkAuthorization", "")
   let sdkAuthorizationData = newSdkAuthorization->getSdkAuthorizationData
   let newClientSecret = switch sdkAuthorizationData.clientSecret->getNonEmptyOption {
   | Some(cs) => cs
@@ -273,7 +274,7 @@ let performUpdateIntent = async (
   ~customerPaymentMethodsDataPromise: ref<promise<JSON.t>>,
   ~sessionTokensDataPromise: ref<promise<JSON.t>>,
   ~iframes: array<Nullable.t<Dom.element>>,
-  ~callback: unit => promise<string>,
+  ~callback: unit => promise<JSON.t>,
   ~publishableKey,
   ~profileId,
   ~sdkSessionId,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
#1511 
Updated the `updateIntent` callback return type from a plain `string` (sdkAuthorization) to an object `{ sdkAuthorization: string }`.

## How did you test it?
Tested manually by invoking `updateIntent` with a callback returning `{ sdkAuthorization: "..." }` and verified the SDK correctly extracts the value and proceeds with the intent update flow.

https://github.com/user-attachments/assets/983a9cc1-1dd9-4b6f-93eb-41ace6d38464


## Checklist
- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible