### PR TITLE
feat: added support for showing deny message returned by backend for eligibility call

### DIFF
--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -27,7 +27,7 @@ type cardProps = {
   setCardError: (string => string) => unit,
   maxCardLength: int,
   cardBrand: string,
-  isCardEligible: bool,
+  cardEligibilityError: option<string>,
 }
 
 let useDefaultCardProps = () => {
@@ -45,7 +45,7 @@ let useDefaultCardProps = () => {
     setCardError: _ => (),
     maxCardLength: 0,
     cardBrand: "",
-    isCardEligible: true,
+    cardEligibilityError: None,
   }
 }
 

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -11,7 +11,7 @@ let useCardForm = (~logger, ~paymentType) => {
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
   let {clientSecret, publishableKey, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let customPodUri = Recoil.useRecoilValueFromAtom(customPodUri)
-  let (isCardEligible, setIsCardEligible) = React.useState(_ => true)
+  let (cardEligibilityError, setCardEligibilityError) = React.useState(_ => None)
   let (cardNumber, setCardNumber) = React.useState(_ => "")
   let (cardExpiry, setCardExpiry) = React.useState(_ => "")
   let (cvcNumber, setCvcNumber) = React.useState(_ => "")
@@ -136,8 +136,8 @@ let useCardForm = (~logger, ~paymentType) => {
           ~endpoint,
           ~signal,
         )
-        let isEligible = PaymentMethodsRecord.parseEligibilityResponse(json)
-        setIsCardEligible(_ => isEligible)
+        let eligibilityError = PaymentMethodsRecord.parseEligibilityResponse(json)
+        setCardEligibilityError(_ => eligibilityError)
       } catch {
       | exn =>
         logger.setLogError(
@@ -149,7 +149,7 @@ let useCardForm = (~logger, ~paymentType) => {
           ->Option.getOr(""),
           ~eventName=PAYMENT_METHOD_ELIGIBILITY_CALL,
         )
-        setIsCardEligible(_ => true)
+        setCardEligibilityError(_ => None)
       }
     | None => ()
     }
@@ -186,7 +186,7 @@ let useCardForm = (~logger, ~paymentType) => {
 
     if paymentMethodListValue.sdk_next_action === Some("eligibility_check") {
       cancelEligibilityDebounce()
-      setIsCardEligible(_ => true)
+      setCardEligibilityError(_ => None)
       if !isCardSupportedAndValid {
         eligibilityControllerRef.current->Option.forEach(c => Fetch.AbortController.abort(c))
         eligibilityControllerRef.current = None
@@ -264,7 +264,7 @@ let useCardForm = (~logger, ~paymentType) => {
         setExpiryError(_ => "")
         setIsExpiryValid(_ => None)
         setIsCVCValid(_ => None)
-        setIsCardEligible(_ => true)
+        setCardEligibilityError(_ => None)
       }
     }
     handleMessage(handleFun, "Error in parsing sent Data")
@@ -321,18 +321,18 @@ let useCardForm = (~logger, ~paymentType) => {
       isCardSupported->Option.getOr(true),
       isCardValid->Option.getOr(true),
       cardNumber->String.length == 0,
-      isCardEligible,
+      cardEligibilityError,
     ) {
-    | (_, _, _, false) => localeString.cardNotEligibleText
-    | (_, _, true, _) => ""
-    | (true, true, _, _) => ""
-    | (true, _, _, _) => localeString.inValidCardErrorText
+    | (_, _, _, Some(msg)) => msg->String.length > 0 ? msg : localeString.cardNotEligibleText
+    | (_, _, true, None) => ""
+    | (true, true, _, None) => ""
+    | (true, _, _, None) => localeString.inValidCardErrorText
     | _ => CardUtils.getCardBrandInvalidError(~cardBrand, ~localeString)
     }
     let cardError = isCardValid->Option.isSome ? cardError : ""
     setCardError(_ => cardError)
     None
-  }, (isCardValid, isCardSupported, cardNumber, isCardEligible))
+  }, (isCardValid, isCardSupported, cardNumber, cardEligibilityError))
 
   React.useEffect(() => {
     setCvcError(_ => isCVCValid->Option.getOr(true) ? "" : localeString.inCompleteCVCErrorText)
@@ -381,7 +381,7 @@ let useCardForm = (~logger, ~paymentType) => {
     setCardError,
     maxCardLength,
     cardBrand,
-    isCardEligible,
+    cardEligibilityError,
   }
 
   let expiryProps: CardUtils.expiryProps = {

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -323,7 +323,8 @@ let useCardForm = (~logger, ~paymentType) => {
       cardNumber->String.length == 0,
       cardEligibilityError,
     ) {
-    | (_, _, _, Some(msg)) => msg->String.length > 0 ? msg : localeString.cardNotEligibleText
+    | (_, _, _, Some(msg)) =>
+      PaymentHelpers.getCardEligibilityErrorText(~cardEligibilityError=Some(msg), ~localeString)
     | (_, _, true, None) => ""
     | (true, true, _, None) => ""
     | (true, _, _, None) => localeString.inValidCardErrorText

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -24,7 +24,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   }, [paymentMode])
 
   let {cardProps, expiryProps, cvcProps, zipProps, blurState} = useCardForm(~logger, ~paymentType)
-  let {isCardValid, setCardError, cardNumber, cardBrand, isCardEligible} = cardProps
+  let {isCardValid, setCardError, cardNumber, cardBrand, cardEligibilityError} = cardProps
   let {isExpiryValid, setExpiryError, cardExpiry} = expiryProps
   let {isCVCValid, setCvcError, cvcNumber} = cvcProps
   let {isZipValid} = zipProps
@@ -54,12 +54,12 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       isCardValid->Option.getOr(false) &&
       isExpiryValid->Option.getOr(false) &&
       isCVCValid->Option.getOr(false) &&
-      isCardEligible
+      cardEligibilityError->Option.isNone
     | CardNumberElement =>
       isCardValid->Option.getOr(false) &&
       checkCardCVC(getCardElementValue(iframeId, "card-cvc"), cardBrand) &&
       checkCardExpiry(getCardElementValue(iframeId, "card-expiry")) &&
-      isCardEligible
+      cardEligibilityError->Option.isNone
     | _ => true
     }
     let cardNetwork = [
@@ -102,9 +102,13 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       if cardNumber === "" {
         setCardError(_ => localeString.cardNumberEmptyText)
         setUserError(localeString.enterFieldsText)
-      } else if !isCardEligible {
-        setCardError(_ => localeString.cardNotEligibleText)
-        setUserError(localeString.cardNotEligibleText)
+      } else if cardEligibilityError->Option.isSome {
+        let msg =
+          cardEligibilityError->Option.getOr("")->String.length > 0
+            ? cardEligibilityError->Option.getOr("")
+            : localeString.cardNotEligibleText
+        setCardError(_ => msg)
+        setUserError(msg)
       }
       if cardExpiry === "" {
         setExpiryError(_ => localeString.cardExpiryDateEmptyText)
@@ -131,7 +135,15 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       }
     }
     handleMessage(handleDoSubmit, "")
-  }, (cardNumber, cvcNumber, cardExpiry, isCVCValid, isExpiryValid, isCardValid, isCardEligible))
+  }, (
+    cardNumber,
+    cvcNumber,
+    cardExpiry,
+    isCVCValid,
+    isExpiryValid,
+    isCardValid,
+    cardEligibilityError,
+  ))
 
   if integrateError {
     <ErrorOccured />

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -103,10 +103,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
         setCardError(_ => localeString.cardNumberEmptyText)
         setUserError(localeString.enterFieldsText)
       } else if cardEligibilityError->Option.isSome {
-        let msg =
-          cardEligibilityError->Option.getOr("")->String.length > 0
-            ? cardEligibilityError->Option.getOr("")
-            : localeString.cardNotEligibleText
+        let msg = PaymentHelpers.getCardEligibilityErrorText(~cardEligibilityError, ~localeString)
         setCardError(_ => msg)
         setUserError(msg)
       }

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -52,7 +52,7 @@ let make = (
     setCardError,
     maxCardLength,
     cardBrand,
-    isCardEligible,
+    cardEligibilityError,
   } = cardProps
 
   let {
@@ -215,7 +215,7 @@ let make = (
         (isBancontact || isCardDetailsValid) &&
         isNicknameValid &&
         areRequiredFieldsValid &&
-        isCardEligible &&
+        cardEligibilityError->Option.isNone &&
         isInstallmentValid
 
       if validFormat && (showPaymentMethodsScreen || isBancontact) {
@@ -402,9 +402,13 @@ let make = (
         if cardNumber === "" {
           setCardError(_ => localeString.cardNumberEmptyText)
           setUserError(localeString.enterFieldsText)
-        } else if !isCardEligible {
-          setCardError(_ => localeString.cardNotEligibleText)
-          setUserError(localeString.cardNotEligibleText)
+        } else if cardEligibilityError->Option.isSome {
+          let msg =
+            cardEligibilityError->Option.getOr("")->String.length > 0
+              ? cardEligibilityError->Option.getOr("")
+              : localeString.cardNotEligibleText
+          setCardError(_ => msg)
+          setUserError(msg)
         } else if isCardSupported->Option.getOr(true)->not {
           if cardBrand == "" {
             setCardError(_ => localeString.enterValidCardNumberErrorText)
@@ -446,7 +450,7 @@ let make = (
     isClickToPayRememberMe,
     selectedInstallmentPlan,
     showInstallments,
-    isCardEligible,
+    cardEligibilityError,
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -403,10 +403,7 @@ let make = (
           setCardError(_ => localeString.cardNumberEmptyText)
           setUserError(localeString.enterFieldsText)
         } else if cardEligibilityError->Option.isSome {
-          let msg =
-            cardEligibilityError->Option.getOr("")->String.length > 0
-              ? cardEligibilityError->Option.getOr("")
-              : localeString.cardNotEligibleText
+          let msg = PaymentHelpers.getCardEligibilityErrorText(~cardEligibilityError, ~localeString)
           setCardError(_ => msg)
           setUserError(msg)
         } else if isCardSupported->Option.getOr(true)->not {

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -1301,17 +1301,30 @@ let getPaymentExperienceTypeFromPML = (
   ->Option.getOr([])
 }
 
-let parseEligibilityResponse = (json: JSON.t): bool => {
+let parseEligibilityResponse = (json: JSON.t): option<string> => {
   let dict = json->getDictFromJson
   let sdkNextActionDict = dict->getDictFromDict("sdk_next_action")
   let nextAction = sdkNextActionDict->Dict.get("next_action")
   switch nextAction {
   | Some(nextActionJson) =>
     switch nextActionJson->JSON.Classify.classify {
-    | String(str) => str !== "deny"
-    | Object(nextActionDict) => nextActionDict->Dict.get("deny")->Option.isNone
-    | _ => true
+    | String(str) =>
+      if str === "deny" {
+        Some("")
+      } else {
+        None
+      }
+    | Object(nextActionDict) =>
+      switch nextActionDict->Dict.get("deny") {
+      | Some(denyJson) =>
+        let denyDict = denyJson->getDictFromJson
+        let message =
+          denyDict->Dict.get("message")->Option.flatMap(JSON.Decode.string)->Option.getOr("")
+        Some(message)
+      | None => None
+      }
+    | _ => None
     }
-  | None => true
+  | None => None
   }
 }

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -1301,28 +1301,18 @@ let getPaymentExperienceTypeFromPML = (
   ->Option.getOr([])
 }
 
-let parseEligibilityResponse = (json: JSON.t): option<string> => {
+let parseEligibilityResponse = json => {
   let dict = json->getDictFromJson
   let sdkNextActionDict = dict->getDictFromDict("sdk_next_action")
   let nextAction = sdkNextActionDict->Dict.get("next_action")
   switch nextAction {
   | Some(nextActionJson) =>
     switch nextActionJson->JSON.Classify.classify {
-    | String(str) =>
-      if str === "deny" {
-        Some("")
-      } else {
-        None
-      }
+    | String(str) => str === "deny" ? Some("") : None
     | Object(nextActionDict) =>
-      switch nextActionDict->Dict.get("deny") {
-      | Some(denyJson) =>
-        let denyDict = denyJson->getDictFromJson
-        let message =
-          denyDict->Dict.get("message")->Option.flatMap(JSON.Decode.string)->Option.getOr("")
-        Some(message)
-      | None => None
-      }
+      nextActionDict
+      ->Dict.get("deny")
+      ->Option.map(denyJson => denyJson->getDictFromJson->getString("message", ""))
     | _ => None
     }
   | None => None

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -2319,3 +2319,15 @@ let getConstructedPaymentMethodName = (~paymentMethod, ~paymentMethodType) => {
   | _ => paymentMethodType
   }
 }
+
+let getCardEligibilityErrorText = (
+  ~cardEligibilityError,
+  ~localeString: LocaleStringTypes.localeStrings,
+) => {
+  switch cardEligibilityError {
+  | Some("")
+  | None =>
+    localeString.cardNotEligibleText
+  | Some(eligibilityErrorText) => eligibilityErrorText
+  }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
## Description
<!-- Describe your changes in detail -->
Updated card eligibility deny handling to use the server-provided `deny.message` from `/payments/{payment_id}/eligibility` instead of always showing the generic fallback error.
Changes included:
- Updating eligibility response parsing to return the deny message when present
- Replacing the boolean `isCardEligible` flow with `cardEligibilityError: option<string>` so the SDK can carry the actual deny reason
- Wiring the message through card state and submit flows in both `Payment.res` and `CardPayment.res`
- Preserving the existing `localeString.cardNotEligibleText` as a fallback when the backend returns `deny` without a message or the legacy string-based `deny` response
This keeps the change minimal while making the UI reflect the backend denial reason directly.
## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Ran `npm run re:build` successfully to verify the ReScript build and type safety
- Verified the updated deny message flow through the affected eligibility parsing and card submission paths
- No new unit tests were added for this change

<img width="491" height="470" alt="image" src="https://github.com/user-attachments/assets/c8e0ab04-b0fa-4185-9e6c-93a3b30a1ab6" />

## Checklist
<!-- Put an `x` in the boxes that apply -->
- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible