### PR TITLE
fix: google pay failing in headless flow in case the script fails to load

### DIFF
--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -1197,26 +1197,57 @@ let make = (
                       : "TEST",
                   }->anyTypeToJson
                 }
-                let gPayClient = GooglePayType.google(gpayClientRequest)
-
-                gPayClient.isReadyToPay(payRequest)
-                ->then(res => {
-                  let dict = res->getDictFromJson
-                  let isReadyToPay = getBool(dict, "result", false)
-                  let msg = [("isReadyToPay", isReadyToPay->JSON.Encode.bool)]->Dict.fromArray
-                  mountedIframeRef->Window.iframePostMessage(msg)
-                  resolve()
-                })
-                ->catch(err => {
-                  logger.setLogInfo(
-                    ~value=err->anyTypeToJson->JSON.stringify,
-                    ~eventName=GOOGLE_PAY_FLOW,
+                let gPayClient = try {
+                  Some(GooglePayType.google(gpayClientRequest))
+                } catch {
+                | _ =>
+                  logger.setLogError(
+                    ~value="ERROR DURING LOADING GOOGLE PAY SCRIPT - Client creation failed",
+                    ~eventName=GOOGLE_PAY_SCRIPT,
                     ~paymentMethod="GOOGLE_PAY",
-                    ~logType=DEBUG,
                   )
-                  resolve()
-                })
-                ->ignore
+                  let msg = [("isReadyToPay", false->JSON.Encode.bool)]->Dict.fromArray
+                  mountedIframeRef->Window.iframePostMessage(msg)
+                  None
+                }
+
+                switch gPayClient {
+                | Some(client) =>
+                  try {
+                    client.isReadyToPay(payRequest)
+                    ->then(res => {
+                      let dict = res->getDictFromJson
+                      let isReadyToPay = getBool(dict, "result", false)
+                      let msg = [("isReadyToPay", isReadyToPay->JSON.Encode.bool)]->Dict.fromArray
+                      mountedIframeRef->Window.iframePostMessage(msg)
+                      resolve()
+                    })
+                    ->catch(err => {
+                      logger.setLogInfo(
+                        ~value=err->anyTypeToJson->JSON.stringify,
+                        ~eventName=GOOGLE_PAY_FLOW,
+                        ~paymentMethod="GOOGLE_PAY",
+                        ~logType=DEBUG,
+                      )
+                      let msg = [("isReadyToPay", false->JSON.Encode.bool)]->Dict.fromArray
+                      mountedIframeRef->Window.iframePostMessage(msg)
+                      resolve()
+                    })
+                    ->ignore
+                  } catch {
+                  | exn =>
+                    logger.setLogInfo(
+                      ~value=exn->Identity.anyTypeToJson->JSON.stringify,
+                      ~eventName=GOOGLE_PAY_FLOW,
+                      ~paymentMethod="GOOGLE_PAY",
+                      ~logType=DEBUG,
+                    )
+                    let msg = [("isReadyToPay", false->JSON.Encode.bool)]->Dict.fromArray
+                    mountedIframeRef->Window.iframePostMessage(msg)
+                    Promise.resolve()->catch(_ => resolve())->ignore
+                  }
+                | None => Promise.resolve()->catch(_ => resolve())->ignore
+                }
 
                 let handleGooglePayMessages = (event: Types.event) => {
                   let evJson = event.data->anyTypeToJson
@@ -1232,42 +1263,64 @@ let make = (
                     ->Option.getOr(JSON.Encode.null)
 
                   if gpayClicked && paymentDataRequest !== JSON.Encode.null {
-                    setTimeout(() => {
-                      gPayClient.loadPaymentData(paymentDataRequest)
-                      ->then(
-                        json => {
-                          let msg = [("gpayResponse", json->anyTypeToJson)]->Dict.fromArray
-                          event.source->Window.sendPostMessage(msg)
-                          let value = "Payment Data Filled: New Payment Method"
-                          logger.setLogInfo(
-                            ~value,
-                            ~eventName=PAYMENT_DATA_FILLED,
-                            ~paymentMethod="GOOGLE_PAY",
-                          )
-                          resolve()
-                        },
-                      )
-                      ->catch(
-                        err => {
-                          logger.setLogInfo(
-                            ~value=err->anyTypeToJson->JSON.stringify,
-                            ~eventName=GOOGLE_PAY_FLOW,
-                            ~paymentMethod="GOOGLE_PAY",
-                            ~logType=DEBUG,
-                          )
+                    switch gPayClient {
+                    | Some(client) => setTimeout(() => {
+                        client.loadPaymentData(paymentDataRequest)
+                        ->then(
+                          json => {
+                            let msg = [("gpayResponse", json->anyTypeToJson)]->Dict.fromArray
+                            event.source->Window.sendPostMessage(msg)
+                            let value = "Payment Data Filled: New Payment Method"
+                            logger.setLogInfo(
+                              ~value,
+                              ~eventName=PAYMENT_DATA_FILLED,
+                              ~paymentMethod="GOOGLE_PAY",
+                            )
+                            resolve()
+                          },
+                        )
+                        ->catch(
+                          err => {
+                            logger.setLogInfo(
+                              ~value=err->anyTypeToJson->JSON.stringify,
+                              ~eventName=GOOGLE_PAY_FLOW,
+                              ~paymentMethod="GOOGLE_PAY",
+                              ~logType=DEBUG,
+                            )
 
-                          let msg = [("gpayError", err->anyTypeToJson)]->Dict.fromArray
-                          event.source->Window.sendPostMessage(msg)
-                          resolve()
-                        },
+                            let msg = [("gpayError", err->anyTypeToJson)]->Dict.fromArray
+                            event.source->Window.sendPostMessage(msg)
+                            resolve()
+                          },
+                        )
+                        ->ignore
+                      }, 0)->ignore
+                    | None =>
+                      logger.setLogInfo(
+                        ~value="GooglePay client unavailable for loadPaymentData",
+                        ~eventName=GOOGLE_PAY_FLOW,
+                        ~paymentMethod="GOOGLE_PAY",
+                        ~logType=DEBUG,
                       )
-                      ->ignore
-                    }, 0)->ignore
+                      let msg =
+                        [
+                          ("gpayError", "GooglePay client unavailable"->JSON.Encode.string),
+                        ]->Dict.fromArray
+                      event.source->Window.sendPostMessage(msg)
+                      Promise.resolve()->then(_ => resolve())->catch(_ => resolve())->ignore
+                    }
                   }
                 }
                 addSmartEventListener("message", handleGooglePayMessages, "onGooglePayMessages")
               } catch {
-              | _ => Console.error("Error loading Gpay")
+              | err =>
+                logger.setLogError(
+                  ~value=`ERROR DURING LOADING GOOGLE PAY SCRIPT - ${err
+                    ->formatException
+                    ->JSON.stringify}`,
+                  ~eventName=GOOGLE_PAY_SCRIPT,
+                  ~paymentMethod="GOOGLE_PAY",
+                )
               }
             } else if wallets.googlePay === Never {
               logger.setLogInfo(

--- a/src/hyper-loader/PaymentSessionMethods.res
+++ b/src/hyper-loader/PaymentSessionMethods.res
@@ -30,11 +30,23 @@ let getCustomerSavedPaymentMethods = (
     ~sdkAuthorization={Some(sdkAuthorizationRef.contents)->getNonEmptyOption},
   )
   ->then(customerDetails => {
-    let gPayClient = google(
-      {
-        "environment": publishableKey->String.startsWith("pk_prd_") ? "PRODUCTION" : "TEST",
-      }->Identity.anyTypeToJson,
-    )
+    let gPayClientOpt = try {
+      Some(
+        google(
+          {
+            "environment": publishableKey->String.startsWith("pk_prd_") ? "PRODUCTION" : "TEST",
+          }->Identity.anyTypeToJson,
+        ),
+      )
+    } catch {
+    | _ =>
+      logger.setLogError(
+        ~value="ERROR DURING LOADING GOOGLE PAY SCRIPT - Client creation failed",
+        ~eventName=GOOGLE_PAY_SCRIPT,
+        ~paymentMethod="GOOGLE_PAY",
+      )
+      None
+    }
 
     let customerDetailsDict = customerDetails->JSON.Decode.object->Option.getOr(Dict.make())
     let (customerPaymentMethods, isGuestCustomer) =
@@ -69,15 +81,16 @@ let getCustomerSavedPaymentMethods = (
     | _ => false
     }
 
-    let customerDefaultPaymentMethod =
+    let customerDefaultPaymentMethodRef = ref(
       customerPaymentMethods
       ->Array.filter(customerPaymentMethod => {
         customerPaymentMethod.defaultPaymentMethodSet
       })
-      ->Array.get(0)
+      ->Array.get(0),
+    )
 
     let getCustomerDefaultSavedPaymentMethodData = () => {
-      switch customerDefaultPaymentMethod {
+      switch customerDefaultPaymentMethodRef.contents {
       | Some(defaultPaymentMethod) => defaultPaymentMethod->Identity.anyTypeToJson
       | None =>
         handleFailureResponse(
@@ -237,7 +250,7 @@ let getCustomerSavedPaymentMethods = (
       if isUpdateIntentInProgress.contents {
         UpdateIntentHelpersNew.confirmBlockedResponseForSession()->resolve
       } else {
-        switch customerDefaultPaymentMethod {
+        switch customerDefaultPaymentMethodRef.contents {
         | Some(defaultPaymentMethod) => {
             let paymentToken = defaultPaymentMethod.paymentToken
             let paymentMethod = defaultPaymentMethod.paymentMethod
@@ -335,54 +348,68 @@ let getCustomerSavedPaymentMethods = (
       lastUsedPaymentMethod: PaymentType.customerMethods,
       payload,
     ) => {
-      let paymentDataRequest = googlePayTokenRef.contents
+      switch gPayClientOpt {
+      | Some(client) =>
+        let paymentDataRequest = googlePayTokenRef.contents
 
-      gPayClient.loadPaymentData(paymentDataRequest)
-      ->then(json => {
-        let metadata = json->Identity.anyTypeToJson
+        client.loadPaymentData(paymentDataRequest)
+        ->then(json => {
+          let metadata = json->Identity.anyTypeToJson
 
-        let value = "Payment Data Filled: New Payment Method"
-        logger.setLogInfo(~value, ~eventName=PAYMENT_DATA_FILLED, ~paymentMethod="GOOGLE_PAY")
+          let value = "Payment Data Filled: New Payment Method"
+          logger.setLogInfo(~value, ~eventName=PAYMENT_DATA_FILLED, ~paymentMethod="GOOGLE_PAY")
 
-        let completeGooglePayPayment = () => {
-          let body = GooglePayHelpers.getGooglePayBodyFromResponse(
-            ~gPayResponse=metadata,
-            ~isGuestCustomer,
-            ~connectors=[],
-            ~isPaymentSession=true,
+          let completeGooglePayPayment = () => {
+            let body = GooglePayHelpers.getGooglePayBodyFromResponse(
+              ~gPayResponse=metadata,
+              ~isGuestCustomer,
+              ~connectors=[],
+              ~isPaymentSession=true,
+            )
+
+            let paymentMethodType = lastUsedPaymentMethod.paymentMethodType->Option.getOr("")
+            let paymentType = paymentMethodType->PaymentHelpers.getPaymentType
+
+            PaymentHelpers.paymentIntentForPaymentSession(
+              ~body,
+              ~paymentType,
+              ~payload,
+              ~publishableKey,
+              ~clientSecret=clientSecretRef.contents,
+              ~logger,
+              ~customPodUri,
+              ~redirectionFlags,
+              ~sdkAuthorization={Some(sdkAuthorizationRef.contents)->getNonEmptyOption},
+            )
+          }
+
+          completeGooglePayPayment()
+        })
+        ->catch(err => {
+          logger.setLogInfo(
+            ~value=err->Identity.anyTypeToJson->JSON.stringify,
+            ~eventName=GOOGLE_PAY_FLOW,
+            ~paymentMethod="GOOGLE_PAY",
+            ~logType=DEBUG,
           )
 
-          let paymentMethodType = lastUsedPaymentMethod.paymentMethodType->Option.getOr("")
-          let paymentType = paymentMethodType->PaymentHelpers.getPaymentType
-
-          PaymentHelpers.paymentIntentForPaymentSession(
-            ~body,
-            ~paymentType,
-            ~payload,
-            ~publishableKey,
-            ~clientSecret=clientSecretRef.contents,
-            ~logger,
-            ~customPodUri,
-            ~redirectionFlags,
-            ~sdkAuthorization={Some(sdkAuthorizationRef.contents)->getNonEmptyOption},
-          )
-        }
-
-        completeGooglePayPayment()
-      })
-      ->catch(err => {
+          handleFailureResponse(
+            ~message=err->Identity.anyTypeToJson->JSON.stringify,
+            ~errorType="google_pay",
+          )->resolve
+        })
+      | None =>
         logger.setLogInfo(
-          ~value=err->Identity.anyTypeToJson->JSON.stringify,
+          ~value="GooglePay client unavailable for loadPaymentData",
           ~eventName=GOOGLE_PAY_FLOW,
           ~paymentMethod="GOOGLE_PAY",
           ~logType=DEBUG,
         )
-
         handleFailureResponse(
-          ~message=err->Identity.anyTypeToJson->JSON.stringify,
+          ~message="Google Pay is not available",
           ~errorType="google_pay",
         )->resolve
-      })
+      }
     }
 
     let confirmWithLastUsedPaymentMethod = payload => {
@@ -451,9 +478,15 @@ let getCustomerSavedPaymentMethods = (
         })
 
       customerPaymentMethodsRef := updatedCustomerDetails
+      customerDefaultPaymentMethodRef :=
+        updatedCustomerDetails
+        ->Array.filter(m => m.defaultPaymentMethodSet)
+        ->Array.get(0)
     }
 
-    if (isApplePayPresent && canMakePayments) || isGooglePayPresent {
+    let isGooglePayUsable = isGooglePayPresent && gPayClientOpt->Option.isSome
+
+    if (isApplePayPresent && canMakePayments) || isGooglePayUsable {
       PaymentHelpers.fetchSessions(
         ~clientSecret=clientSecretRef.contents,
         ~publishableKey,
@@ -493,35 +526,39 @@ let getCustomerSavedPaymentMethods = (
           }->Identity.anyTypeToJson,
         )
 
-        let isGooglePayReadyPromise = try {
-          gPayClient.isReadyToPay(payRequest)
-          ->then(
-            res => {
-              let dict = res->getDictFromJson
-              getBool(dict, "result", false)->resolve
-            },
-          )
-          ->catch(
-            err => {
+        let isGooglePayReadyPromise = switch gPayClientOpt {
+        | Some(client) =>
+          try {
+            client.isReadyToPay(payRequest)
+            ->then(
+              res => {
+                let dict = res->getDictFromJson
+                getBool(dict, "result", false)->resolve
+              },
+            )
+            ->catch(
+              err => {
+                logger.setLogInfo(
+                  ~value=err->Identity.anyTypeToJson->JSON.stringify,
+                  ~eventName=GOOGLE_PAY_FLOW,
+                  ~paymentMethod="GOOGLE_PAY",
+                  ~logType=DEBUG,
+                )
+                false->resolve
+              },
+            )
+          } catch {
+          | exn => {
               logger.setLogInfo(
-                ~value=err->Identity.anyTypeToJson->JSON.stringify,
+                ~value=exn->Identity.anyTypeToJson->JSON.stringify,
                 ~eventName=GOOGLE_PAY_FLOW,
                 ~paymentMethod="GOOGLE_PAY",
                 ~logType=DEBUG,
               )
               false->resolve
-            },
-          )
-        } catch {
-        | exn => {
-            logger.setLogInfo(
-              ~value=exn->Identity.anyTypeToJson->JSON.stringify,
-              ~eventName=GOOGLE_PAY_FLOW,
-              ~paymentMethod="GOOGLE_PAY",
-              ~logType=DEBUG,
-            )
-            false->resolve
+            }
           }
+        | None => false->resolve
         }
 
         isGooglePayReadyPromise


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
## Description
When the Google Pay script fails to load (or is blocked), `new google.payments.api.PaymentsClient(...)` throws `ReferenceError: google is not defined`, crashing the entire saved-payment-methods flow and returning an unstructured error to the merchant.
### Changes in `src/hyper-loader/PaymentSessionMethods.res`
- Wrapped `gPayClient` creation in `try/catch`, stored as `option<client>` (`gPayClientOpt`) — returns `None` instead of crashing when the script is unavailable
- Guarded `isReadyToPay` with `switch gPayClientOpt` — skips the call and resolves `false` when client is `None`
- Guarded `handleGooglePayConfirmPayment` with `switch gPayClientOpt` — returns `handleFailureResponse` instead of calling `loadPaymentData` on a non-existent client
- Changed `customerDefaultPaymentMethod` from `let` to `ref` — recomputed after filtering so it never points to a filtered-out Google Pay method
- Gated `fetchSessions` on `isGooglePayUsable = isGooglePayPresent && gPayClientOpt !== None` — avoids unnecessary network call when Google Pay script is unavailable
### Changes in `src/hyper-loader/Elements.res`
- Wrapped `GooglePayType.google(...)` in `try/catch` → `option<client>` — posts `isReadyToPay=false` to iframe on failure
- Guarded `isReadyToPay` with `switch gPayClient` and `try/catch` — posts `isReadyToPay=false` to iframe on both sync exceptions and async rejections
- Guarded `loadPaymentData` with `switch gPayClient` — sends `gpayError` message to `event.source` on `None` so the caller doesn't hang
- Replaced outer `Console.error("Error loading Gpay")` with structured `logger.setLogError` using `GOOGLE_PAY_SCRIPT`
### Result
When the Google Pay script is unavailable, `google_pay` is filtered from the saved payment methods list, `confirmWithLastUsedPaymentMethod` falls through to the next available method, and `confirmWithCustomerDefaultPaymentMethod` returns a `"no_data"` error if Google Pay was the default. No unhandled exceptions are thrown.
## How did you test it?
- `npm run re:build` — compiles with zero errors
- `npm run build` — webpack production build succeeds
- Manual validation required (cannot be automated from CLI):
  - Block `pay.google.com` in DevTools → `getCustomerSavedPaymentMethods` resolves without throwing, `google_pay` filtered from list
  - Block script → `confirmWithLastUsedPaymentMethod` uses next available non-Google method
  - Block script → `confirmWithCustomerDefaultPaymentMethod` returns `"no_data"` error if Google Pay was default
  - Block script → Elements iframe receives `{"isReadyToPay": false}`, click flow receives `gpayError`
  - Script present (regression) → existing Google Pay behavior unchanged
## Checklist
<!-- Put an `x` in the boxes that apply -->
- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible