### PR TITLE
chore: Add color-scheme meta tag for responsive themes

### DIFF
--- a/public/build.html
+++ b/public/build.html
@@ -8,6 +8,7 @@
       content="width=device-width, initial-scale=1, maximum-scale=5, user-scalable=yes"
     />
     <meta name="theme-color" content="#000000" />
+    <meta name="color-scheme" content="light dark">
     <link
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700;800&display=swap"
       rel="stylesheet"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
This pull request makes a small update to the `public/build.html` file by adding support for both light and dark color schemes through a new meta tag. This helps browsers automatically adjust the UI based on the user's system preference.

* Added `<meta name="color-scheme" content="light dark">` to support automatic light/dark theme adaptation.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Integrate in vite app and pass apprearance.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="939" height="780" alt="image" src="https://github.com/user-attachments/assets/3dc244dd-d0f3-44a4-9bf0-3d9db8500381" /></td>
<td><img width="939" height="776" alt="image" src="https://github.com/user-attachments/assets/9140d906-8eb1-4bd6-8092-28a2522dd513" /></td>
</tr>
</table>


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
