### PR TITLE
fix(logger): unblock confirm beacon from IndexedDB flush

### DIFF
--- a/src/hyper-log-catcher/HyperLogger.res
+++ b/src/hyper-log-catcher/HyperLogger.res
@@ -180,7 +180,20 @@ let make = (~sessionId=?, ~source: source, ~clientSecret=?, ~merchantId=?, ~meta
 
   let sendLogsOverNetwork = async () => {
     try {
-      await sendCachedLogsFromIDB()
+      // Fire-and-forget: do NOT await sendCachedLogsFromIDB() before the beacon call.
+      // Priority events such as CONFIRM_CALL trigger sendLogsOverNetwork() immediately
+      // (via checkLogSizeAndSendData → sendLogs). Awaiting the IDB read/write here
+      // serialises the two operations, so if the merchant unmounts the SDK right after
+      // a payment response — which is the common case — the page context is destroyed
+      // before beaconApiCall ever executes. On Safari, whose IndexedDB implementation
+      // is significantly slower during page-lifecycle transitions, this race is
+      // deterministic: the beacon is never sent. On Chrome/Firefox it is intermittent.
+      //
+      // navigator.sendBeacon is specifically designed for reliable delivery during
+      // page unload. Running it first, without blocking on IDB, ensures CONFIRM_CALL
+      // (and every other priority event) is always dispatched regardless of IDB latency
+      // or how quickly the host page tears down the SDK's iframe context.
+      sendCachedLogsFromIDB()->ignore
       beaconApiCall(mainLogFile)
       clearLogFile(mainLogFile)
     } catch {


### PR DESCRIPTION
Priority events such as CONFIRM_CALL were awaiting sendCachedLogsFromIDB before sending the current in-memory batch. During fast teardown flows, especially on Safari, that IndexedDB latency prevented navigator.sendBeacon from running before the SDK context was destroyed.

Run the cached log flush as fire-and-forget so beacon delivery for the current batch is not blocked by IndexedDB work.

Refs: #1521

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
