### PR TITLE
Fix/confirm call beacon idb await 1521

### DIFF
--- a/src/hyper-log-catcher/HyperLogger.res
+++ b/src/hyper-log-catcher/HyperLogger.res
@@ -180,7 +180,20 @@ let make = (~sessionId=?, ~source: source, ~clientSecret=?, ~merchantId=?, ~meta
 
   let sendLogsOverNetwork = async () => {
     try {
-      await sendCachedLogsFromIDB()
+      // Fire-and-forget: do NOT await sendCachedLogsFromIDB() before the beacon call.
+      // Priority events such as CONFIRM_CALL trigger sendLogsOverNetwork() immediately
+      // (via checkLogSizeAndSendData → sendLogs). Awaiting the IDB read/write here
+      // serialises the two operations, so if the merchant unmounts the SDK right after
+      // a payment response — which is the common case — the page context is destroyed
+      // before beaconApiCall ever executes. On Safari, whose IndexedDB implementation
+      // is significantly slower during page-lifecycle transitions, this race is
+      // deterministic: the beacon is never sent. On Chrome/Firefox it is intermittent.
+      //
+      // navigator.sendBeacon is specifically designed for reliable delivery during
+      // page unload. Running it first, without blocking on IDB, ensures CONFIRM_CALL
+      // (and every other priority event) is always dispatched regardless of IDB latency
+      // or how quickly the host page tears down the SDK's iframe context.
+      sendCachedLogsFromIDB()->ignore
       beaconApiCall(mainLogFile)
       clearLogFile(mainLogFile)
     } catch {

--- a/src/hyper-log-catcher/HyperLogger.res
+++ b/src/hyper-log-catcher/HyperLogger.res
@@ -180,19 +180,6 @@ let make = (~sessionId=?, ~source: source, ~clientSecret=?, ~merchantId=?, ~meta
 
   let sendLogsOverNetwork = async () => {
     try {
-      // Fire-and-forget: do NOT await sendCachedLogsFromIDB() before the beacon call.
-      // Priority events such as CONFIRM_CALL trigger sendLogsOverNetwork() immediately
-      // (via checkLogSizeAndSendData → sendLogs). Awaiting the IDB read/write here
-      // serialises the two operations, so if the merchant unmounts the SDK right after
-      // a payment response — which is the common case — the page context is destroyed
-      // before beaconApiCall ever executes. On Safari, whose IndexedDB implementation
-      // is significantly slower during page-lifecycle transitions, this race is
-      // deterministic: the beacon is never sent. On Chrome/Firefox it is intermittent.
-      //
-      // navigator.sendBeacon is specifically designed for reliable delivery during
-      // page unload. Running it first, without blocking on IDB, ensures CONFIRM_CALL
-      // (and every other priority event) is always dispatched regardless of IDB latency
-      // or how quickly the host page tears down the SDK's iframe context.
       sendCachedLogsFromIDB()->ignore
       beaconApiCall(mainLogFile)
       clearLogFile(mainLogFile)


### PR DESCRIPTION
## Type of Change
Description:
CONFIRM_CALL beacon logs were being silently dropped on Safari (and intermittently on Chrome/Firefox) during payment confirmation. The root cause was in sendLogsOverNetwork() inside [HyperLogger.res](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), where the function awaited sendCachedLogsFromIDB() before calling beaconApiCall(). Priority events like CONFIRM_CALL trigger this function immediately at the moment the user confirms payment. On Safari, the page begins teardown synchronously after payment confirmation, so the await on the IndexedDB flush caused beaconApiCall() to never be reached — the beacon was dropped before it could fire. The fix removes the await from sendCachedLogsFromIDB(), making it fire-and-forget using ->ignore. beaconApiCall() now executes synchronously before any IndexedDB I/O, restoring the reliable-delivery guarantee that navigator.sendBeacon is designed to provide during page unload. Fixes #1521.

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

## How did you test it?

Manually traced the log flush code path in [HyperLogger.res](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Verified that beaconApiCall is now called synchronously without waiting for the IndexedDB operation to complete. The change ensures navigator.sendBeacon — which is specifically designed for reliable delivery during page unload — is called immediately when a priority event like CONFIRM_CALL is logged, regardless of the state of the IndexedDB flush.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
