### PR TITLE
fix(logger): fire sendCachedLogsFromIDB without blocking beacon call

### DIFF
--- a/src/hyper-log-catcher/HyperLogger.res
+++ b/src/hyper-log-catcher/HyperLogger.res
@@ -180,7 +180,7 @@ let make = (~sessionId=?, ~source: source, ~clientSecret=?, ~merchantId=?, ~meta
 
   let sendLogsOverNetwork = async () => {
     try {
-      await sendCachedLogsFromIDB()
+      sendCachedLogsFromIDB()->ignore
       beaconApiCall(mainLogFile)
       clearLogFile(mainLogFile)
     } catch {


### PR DESCRIPTION
Priority log events like CONFIRM_CALL invoke sendLogsOverNetwork() immediately. Previously, the function awaited sendCachedLogsFromIDB() before calling beaconApiCall(), so on Safari the beacon was dropped when the page tore down during payment confirmation before the IDB operation resolved.

Fix: remove the await so sendCachedLogsFromIDB() runs fire-and-forget via ->ignore. beaconApiCall() now executes synchronously, restoring the reliable delivery guarantee of navigator.sendBeacon.

Fixes #1521

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
