### PR TITLE
fix: wallets confirm in merged view

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -276,6 +276,7 @@ let make = (
               ~componentName,
               ~iframeId,
               ~readOnly,
+              ~isSavedMethodsFlow=true,
             )
           | _ =>
             // TODO - To be replaced with proper error message
@@ -293,6 +294,7 @@ let make = (
               ~sessionObj=optToken,
               ~componentName,
               ~paymentMethodListValue,
+              ~isSavedMethodsFlow=true,
             )
           | _ =>
             // TODO - To be replaced with proper error message
@@ -311,6 +313,7 @@ let make = (
               ~sessionObj=optToken->Option.getOr(JSON.Encode.null)->getDictFromJson,
               ~iframeId,
               ~readOnly,
+              ~isSavedMethodsFlow=true,
             )
           | _ =>
             // TODO - To be replaced with proper error message

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -227,7 +227,10 @@ let useHandleApplePayResponse = (
       let json = ev.data->safeParse
       try {
         let dict = json->getDictFromJson
-        if dict->Dict.get("applePayPaymentToken")->Option.isSome {
+        if (
+          dict->Dict.get("applePayPaymentToken")->Option.isSome &&
+            dict->Utils.getBool("isSavedMethodsFlow", false) === isSavedMethodsFlow
+        ) {
           let token =
             dict->Dict.get("applePayPaymentToken")->Option.getOr(Dict.make()->JSON.Encode.object)
 
@@ -296,13 +299,14 @@ let useHandleApplePayResponse = (
         Window.removeEventListener("message", handleApplePayMessages)
       },
     )
-  }, (isInvokeSDKFlow, processPayment, isManualRetryEnabled, isWallet, requiredFieldsBody))
+  }, (isInvokeSDKFlow, processPayment, isManualRetryEnabled, isWallet, requiredFieldsBody, isSavedMethodsFlow))
 }
 
 let handleApplePayButtonClicked = (
   ~sessionObj,
   ~componentName,
   ~paymentMethodListValue: PaymentMethodsRecord.paymentMethodList,
+  ~isSavedMethodsFlow=false,
 ) => {
   let paymentRequest = ApplePayTypes.getPaymentRequestFromSession(~sessionObj, ~componentName)
   let authToken =
@@ -323,6 +327,7 @@ let handleApplePayButtonClicked = (
     ("componentName", componentName->JSON.Encode.string),
     ("authToken", authToken->JSON.Encode.string),
     ("connector", connector->JSON.Encode.string),
+    ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
   ]
   messageParentWindow(message)
 }

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -299,7 +299,14 @@ let useHandleApplePayResponse = (
         Window.removeEventListener("message", handleApplePayMessages)
       },
     )
-  }, (isInvokeSDKFlow, processPayment, isManualRetryEnabled, isWallet, requiredFieldsBody, isSavedMethodsFlow))
+  }, (
+    isInvokeSDKFlow,
+    processPayment,
+    isManualRetryEnabled,
+    isWallet,
+    requiredFieldsBody,
+    isSavedMethodsFlow,
+  ))
 }
 
 let handleApplePayButtonClicked = (

--- a/src/Utilities/GooglePayHelpers.res
+++ b/src/Utilities/GooglePayHelpers.res
@@ -93,7 +93,11 @@ let useHandleGooglePayResponse = (
     let handle = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->getDictFromJson
-      if dict->Dict.get("gpayResponse")->Option.isSome {
+
+      if (
+        dict->Dict.get("gpayResponse")->Option.isSome &&
+          dict->Utils.getBool("isSavedMethodsFlow", false) === isSavedMethodsFlow
+      ) {
         let metadata = dict->getJsonObjectFromDict("gpayResponse")
         let body = getGooglePayBodyFromResponse(
           ~gPayResponse=metadata,
@@ -128,10 +132,16 @@ let useHandleGooglePayResponse = (
     }
     Window.addEventListener("message", handle)
     Some(() => {Window.removeEventListener("message", handle)})
-  }, (paymentMethodTypes, isManualRetryEnabled, requiredFieldsBody, isWallet))
+  }, (paymentMethodTypes, isManualRetryEnabled, requiredFieldsBody, isWallet, isSavedMethodsFlow))
 }
 
-let handleGooglePayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly) => {
+let handleGooglePayClicked = (
+  ~sessionObj,
+  ~componentName,
+  ~iframeId,
+  ~readOnly,
+  ~isSavedMethodsFlow=false,
+) => {
   let paymentDataRequest = GooglePayType.getPaymentDataFromSession(~sessionObj, ~componentName)
   messageParentWindow([
     ("fullscreen", true->JSON.Encode.bool),
@@ -142,6 +152,7 @@ let handleGooglePayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly)
     messageParentWindow([
       ("GpayClicked", true->JSON.Encode.bool),
       ("GpayPaymentDataRequest", paymentDataRequest->Identity.anyTypeToJson),
+      ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
     ])
   }
 }

--- a/src/Utilities/SamsungPayHelpers.res
+++ b/src/Utilities/SamsungPayHelpers.res
@@ -19,7 +19,7 @@ let getTransactionDetail = dict => {
   }
 }
 
-let handleSamsungPayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly) => {
+let handleSamsungPayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly, ~isSavedMethodsFlow=false) => {
   messageParentWindow([
     ("fullscreen", true->JSON.Encode.bool),
     ("param", "paymentloader"->JSON.Encode.string),
@@ -31,6 +31,7 @@ let handleSamsungPayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly
     messageParentWindow([
       ("SamsungPayClicked", true->JSON.Encode.bool),
       ("SPayPaymentDataRequest", getTransactionDetail(sessionObj)->Identity.anyTypeToJson),
+      ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
     ])
   }
 }
@@ -71,11 +72,14 @@ let useHandleSamsungPayResponse = (
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
   let isGuestCustomer = UtilityHooks.useIsGuestCustomer()
 
-  React.useEffect0(() => {
+  React.useEffect(() => {
     let handleSamsung = (ev: Window.event) => {
       let json = ev.data->safeParse
       let dict = json->getDictFromJson
-      if dict->Dict.get("samsungPayResponse")->Option.isSome {
+      if (
+        dict->Dict.get("samsungPayResponse")->Option.isSome &&
+          dict->Utils.getBool("isSavedMethodsFlow", false) === isSavedMethodsFlow
+      ) {
         let metadata = dict->getJsonObjectFromDict("samsungPayResponse")
         let getBody = getSamsungPayBodyFromResponse(~sPayResponse=metadata)
         let body = PaymentBody.samsungPayBody(
@@ -107,5 +111,5 @@ let useHandleSamsungPayResponse = (
     }
     Window.addEventListener("message", handleSamsung)
     Some(() => {Window.removeEventListener("message", handleSamsung)})
-  })
+  }, (isSavedMethodsFlow, isManualRetryEnabled, isWallet))
 }

--- a/src/Utilities/SamsungPayHelpers.res
+++ b/src/Utilities/SamsungPayHelpers.res
@@ -19,7 +19,13 @@ let getTransactionDetail = dict => {
   }
 }
 
-let handleSamsungPayClicked = (~sessionObj, ~componentName, ~iframeId, ~readOnly, ~isSavedMethodsFlow=false) => {
+let handleSamsungPayClicked = (
+  ~sessionObj,
+  ~componentName,
+  ~iframeId,
+  ~readOnly,
+  ~isSavedMethodsFlow=false,
+) => {
   messageParentWindow([
     ("fullscreen", true->JSON.Encode.bool),
     ("param", "paymentloader"->JSON.Encode.string),

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -1024,6 +1024,8 @@ let make = (
                         ~paymentMethod="APPLE_PAY",
                       )
 
+                      let isSavedMethodsFlow = dict->getBool("isSavedMethodsFlow", false)
+
                       let msg = [
                         ("hyperApplePayButtonClicked", true->JSON.Encode.bool),
                         ("paymentRequest", paymentRequest),
@@ -1035,6 +1037,7 @@ let make = (
                         ("sdkSessionId", sdkSessionId->JSON.Encode.string),
                         ("analyticsMetadata", analyticsMetadata),
                         ("componentName", componentName->JSON.Encode.string),
+                        ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
                       ]
                       messageTopWindow(msg)
                     }
@@ -1048,12 +1051,14 @@ let make = (
                     dict->getJsonFromDict("applePayBillingContact", JSON.Encode.null)
                   let shippingContact =
                     dict->getJsonFromDict("applePayShippingContact", JSON.Encode.null)
+                  let isSavedMethodsFlow = dict->getBool("isSavedMethodsFlow", false)
 
                   let msg =
                     [
                       ("applePayPaymentToken", token),
                       ("applePayBillingContact", billingContact),
                       ("applePayShippingContact", shippingContact),
+                      ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
                     ]->Dict.fromArray
 
                   handleIframePostMessageForWallets(msg, componentName, mountedIframeRef)
@@ -1262,13 +1267,22 @@ let make = (
                     ->getOptionalJsonFromJson("GpayPaymentDataRequest")
                     ->Option.getOr(JSON.Encode.null)
 
+                  let isSavedMethodsFlow =
+                    evJson
+                    ->getOptionalJsonFromJson("isSavedMethodsFlow")
+                    ->getBoolFromOptionalJson(false)
+
                   if gpayClicked && paymentDataRequest !== JSON.Encode.null {
                     switch gPayClient {
                     | Some(client) => setTimeout(() => {
                         client.loadPaymentData(paymentDataRequest)
                         ->then(
                           json => {
-                            let msg = [("gpayResponse", json->anyTypeToJson)]->Dict.fromArray
+                            let msg =
+                              [
+                                ("gpayResponse", json->anyTypeToJson),
+                                ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
+                              ]->Dict.fromArray
                             event.source->Window.sendPostMessage(msg)
                             let value = "Payment Data Filled: New Payment Method"
                             logger.setLogInfo(
@@ -1400,10 +1414,18 @@ let make = (
                     ->getOptionalJsonFromJson("SPayPaymentDataRequest")
                     ->Option.getOr(JSON.Encode.null)
 
+                  let isSavedMethodsFlow =
+                    evJson
+                    ->getOptionalJsonFromJson("isSavedMethodsFlow")
+                    ->getBoolFromOptionalJson(false)
+
                   if samsungPayClicked && paymentDataRequest !== JSON.Encode.null {
                     samsungPayClient.loadPaymentSheet(payRequest, paymentDataRequest)
                     ->then(json => {
-                      let msg = [("samsungPayResponse", json->anyTypeToJson)]->Dict.fromArray
+                      let msg = [
+                        ("samsungPayResponse", json->anyTypeToJson),
+                        ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
+                      ]->Dict.fromArray
                       event.source->Window.sendPostMessage(msg)
                       resolve()
                     })

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -1422,10 +1422,11 @@ let make = (
                   if samsungPayClicked && paymentDataRequest !== JSON.Encode.null {
                     samsungPayClient.loadPaymentSheet(payRequest, paymentDataRequest)
                     ->then(json => {
-                      let msg = [
-                        ("samsungPayResponse", json->anyTypeToJson),
-                        ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
-                      ]->Dict.fromArray
+                      let msg =
+                        [
+                          ("samsungPayResponse", json->anyTypeToJson),
+                          ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
+                        ]->Dict.fromArray
                       event.source->Window.sendPostMessage(msg)
                       resolve()
                     })

--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -86,6 +86,7 @@ let handleHyperApplePayMounted = (event: Types.event) => {
     let isTaxCalculationEnabled = dict->getBool("isTaxCalculationEnabled", false)
     let sdkSessionId = dict->getString("sdkSessionId", "")
     let analyticsMetadata = dict->getJsonFromDict("analyticsMetadata", JSON.Encode.null)
+    let isSavedMethodsFlow = dict->getBool("isSavedMethodsFlow", false)
 
     let logger = HyperLogger.make(
       ~sessionId=sdkSessionId,
@@ -102,6 +103,7 @@ let handleHyperApplePayMounted = (event: Types.event) => {
           ("applePayBillingContact", payment.billingContact),
           ("applePayShippingContact", payment.shippingContact),
           ("componentName", componentName->JSON.Encode.string),
+          ("isSavedMethodsFlow", isSavedMethodsFlow->JSON.Encode.bool),
         ]
         ->Dict.fromArray
         ->JSON.Encode.object


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

#1534 
Fixes a double payment confirmation bug that occurs in the merged/grouped saved methods view when `savedMethodCustomization.groupingBehavior.displayInSeparateScreen` is set to `false`.

**Root Cause:**

When `displayInSeparateScreen: false`, both the wallet button components (`GPay`, `ApplePay`, `SamsungPay`) and the `SavedMethods` component are mounted simultaneously. Both register event listeners for the same wallet response messages (`gpayResponse`, `applePayPaymentToken`, `samsungPayResponse`), causing the payment confirm call to fire twice when a saved wallet method (e.g. Google Pay one-click) is used.

**Fix:**

The fix introduces an `isSavedMethodsFlow` flag that is stamped onto outgoing wallet click messages and echoed back in the wallet response messages by the parent frame. Each `useHandle*Response` hook then filters incoming events by matching its own `isSavedMethodsFlow` value against the flag in the event, ensuring only the correct handler processes the response.

## How did you test it?

Tested manually by:

1. Configuring the SDK with `savedMethodCustomization: { groupingBehavior: { displayInSeparateScreen: false } }` and a customer with saved Google Pay / Apple Pay / Samsung Pay methods.
2. Selecting the saved methods view and triggering payment via the wallet one-click button.
3. Confirmed via network logs and console output that the `/confirm` call is made exactly once (previously it was called twice).
4. Verified that the regular (non-saved-methods) wallet button flow at the top of the payment form continues to work correctly and also triggers confirm exactly once.

https://github.com/user-attachments/assets/48f937d1-21c8-408c-abb2-c9ad1dde7ada


https://github.com/user-attachments/assets/6ca90ce5-4259-4492-aa95-8675c2bd1107



## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
