### PR TITLE
fix: dependency updation for new sdk authorization

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -47,7 +47,7 @@ let make = (
   )
   let isGuestCustomer = useIsGuestCustomer()
 
-  let {iframeId, clientSecret} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let {iframeId, clientSecret, sdkAuthorization} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
   let url = RescriptReactRouter.useUrl()
   let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
 
@@ -174,9 +174,19 @@ let make = (
 
   useHandlePostMessages(~complete, ~empty, ~paymentType=paymentMethodType, ~savedMethod=true)
 
-  GooglePayHelpers.useHandleGooglePayResponse(~connectors=[], ~intent, ~isSavedMethodsFlow=true)
+  GooglePayHelpers.useHandleGooglePayResponse(
+    ~connectors=[],
+    ~intent,
+    ~isSavedMethodsFlow=true,
+    ~sdkAuthorization,
+  )
 
-  ApplePayHelpers.useHandleApplePayResponse(~connectors=[], ~intent, ~isSavedMethodsFlow=true)
+  ApplePayHelpers.useHandleApplePayResponse(
+    ~connectors=[],
+    ~intent,
+    ~isSavedMethodsFlow=true,
+    ~sdkAuthorization,
+  )
 
   SamsungPayHelpers.useHandleSamsungPayResponse(~intent, ~isSavedMethodsFlow=true)
 

--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -9,7 +9,7 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
   let sdkHandleIsThere = Recoil.useRecoilValueFromAtom(
     RecoilAtoms.isPaymentButtonHandlerProvidedAtom,
   )
-  let {publishableKey} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let {publishableKey, sdkAuthorization} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
   let isApplePayReady = Recoil.useRecoilValueFromAtom(RecoilAtoms.isApplePayReady)
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(RecoilAtoms.isShowOrPayUsing)
   let (showApplePay, setShowApplePay) = React.useState(() => false)
@@ -295,6 +295,7 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
     ~isInvokeSDKFlow,
     ~isWallet,
     ~requiredFieldsBody,
+    ~sdkAuthorization,
   )
 
   React.useEffect(() => {

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -13,7 +13,7 @@ let make = (
   let url = RescriptReactRouter.useUrl()
   let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let isSDKHandleClick = Recoil.useRecoilValueFromAtom(isPaymentButtonHandlerProvidedAtom)
   let {publishableKey} = Recoil.useRecoilValueFromAtom(keys)
   let updateSession = Recoil.useRecoilValueFromAtom(updateSession)
@@ -70,7 +70,13 @@ let make = (
     ? paymentMethodListValue->PaymentUtils.getConnectors(Wallets(Gpay(SDK)))
     : paymentMethodListValue->PaymentUtils.getConnectors(Wallets(Gpay(Redirect)))
 
-  GooglePayHelpers.useHandleGooglePayResponse(~connectors, ~intent, ~isWallet, ~requiredFieldsBody)
+  GooglePayHelpers.useHandleGooglePayResponse(
+    ~connectors,
+    ~intent,
+    ~isWallet,
+    ~requiredFieldsBody,
+    ~sdkAuthorization,
+  )
 
   let (_, buttonType, _, _) = options.wallets.style.type_
   let (_, heightType, _, _, _) = options.wallets.style.height

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -152,7 +152,7 @@ let make = (~sessionObj: SessionsType.token) => {
       )
     }
     None
-  }, [])
+  }, [sdkAuthorization])
 
   <div
     id="paypal-button"

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -206,6 +206,7 @@ let useHandleApplePayResponse = (
   ~isSavedMethodsFlow=false,
   ~isWallet=true,
   ~requiredFieldsBody=Dict.make(),
+  ~sdkAuthorization,
 ) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let {publishableKey} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
@@ -306,6 +307,7 @@ let useHandleApplePayResponse = (
     isWallet,
     requiredFieldsBody,
     isSavedMethodsFlow,
+    sdkAuthorization,
   ))
 }
 

--- a/src/Utilities/GooglePayHelpers.res
+++ b/src/Utilities/GooglePayHelpers.res
@@ -75,6 +75,7 @@ let useHandleGooglePayResponse = (
   ~isSavedMethodsFlow=false,
   ~isWallet=true,
   ~requiredFieldsBody=Dict.make(),
+  ~sdkAuthorization,
 ) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let {publishableKey} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
@@ -132,7 +133,14 @@ let useHandleGooglePayResponse = (
     }
     Window.addEventListener("message", handle)
     Some(() => {Window.removeEventListener("message", handle)})
-  }, (paymentMethodTypes, isManualRetryEnabled, requiredFieldsBody, isWallet, isSavedMethodsFlow))
+  }, (
+    paymentMethodTypes,
+    isManualRetryEnabled,
+    requiredFieldsBody,
+    isWallet,
+    isSavedMethodsFlow,
+    sdkAuthorization,
+  ))
 }
 
 let handleGooglePayClicked = (


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed a stale closure bug where `sdkAuthorization` was not being read with its latest value inside the PaypalSDK `useEffect`, after an `updateIntent` flow refreshed the SDK credentials.

**Root Cause:**

The `intent` function returned by `usePaymentIntent` / `usePostSessionTokens` closes over the `keys` Recoil atom value (which includes `sdkAuthorization`) at render time. Several `useEffect` hooks in wallet SDK components (`GPay`, `ApplePay`, `PaypalSDK`, `SavedMethods`) registered event listeners or SDK callbacks that captured this closure — but their dependency arrays did not include `sdkAuthorization`. As a result, after `updateIntent` updated `sdkAuthorization`, these callbacks continued using the stale (old) value, causing API authorization failures.

**Fix:**

- Added `sdkAuthorization` as a parameter to `useHandleGooglePayResponse` and `useHandleApplePayResponse` helper hooks, and included it in their `useEffect` dependency arrays so the event listeners are re-registered with the fresh value after an `updateIntent`.
- Added `sdkAuthorization` to the `useEffect` dependency array in `PaypalSDK.res` so the Paypal SDK is re-mounted with updated credentials when `updateIntent` completes.
- Passed `sdkAuthorization` from the `keys` Recoil atom through to the affected helper hooks in `GPay.res`, `ApplePay.res`, and `SavedMethods.res`.

## How did you test it?

Tested manually by triggering an `updateIntent` flow while a wallet payment method (Google Pay / Apple Pay / PayPal) was mounted:
- Verified that the subsequent payment confirm / post-session-tokens call uses the refreshed `sdkAuthorization` value.
- Confirmed no authorization errors occur after `updateIntent` completes.
- Verified existing wallet flows (without `updateIntent`) continue to work as before.

Paypal SDK Flow
https://github.com/user-attachments/assets/ce94f476-79b0-48e2-a85c-bd65b670ce4b

https://github.com/user-attachments/assets/6b562d77-b468-4559-8532-c1a0d603ddf6

Google Pay Flow

https://github.com/user-attachments/assets/0ae31158-2138-4d8a-bc03-4388600092da


## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible