### PR TITLE
feat: added support to add color-scheme meta tag dynamically on merchant preference

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -62,6 +62,27 @@ let make = () => {
         | None => ()
         }
       }
+
+      let appearanceJson = if dict->Utils.getDictIsSome("paymentElementCreate") {
+        dict->Utils.getDictFromObj("paymentOptions")->Dict.get("appearance")
+      } else if dict->Utils.getDictIsSome("fullScreenIframeMounted") {
+        dict->Dict.get("appearance")
+      } else {
+        None
+      }
+
+      switch appearanceJson {
+      | Some(appearanceJson) =>
+        let colorScheme =
+          appearanceJson
+          ->Utils.getDictFromJson
+          ->Utils.getString("colorScheme", "default")
+          ->CardTheme.getColorScheme
+        if colorScheme == Auto {
+          Window.setColorSchemeMeta()
+        }
+      | None => ()
+      }
     }
     Window.addEventListener("message", handleMetaDataPostMessage)
     Some(() => Window.removeEventListener("message", handleMetaDataPostMessage))

--- a/src/App.res
+++ b/src/App.res
@@ -67,6 +67,8 @@ let make = () => {
         dict->Utils.getDictFromObj("paymentOptions")->Dict.get("appearance")
       } else if dict->Utils.getDictIsSome("fullScreenIframeMounted") {
         dict->Dict.get("appearance")
+      } else if dict->Utils.getDictIsSome("ElementsUpdate") {
+        dict->Utils.getDictFromObj("options")->Dict.get("appearance")
       } else {
         None
       }

--- a/src/CardTheme.res
+++ b/src/CardTheme.res
@@ -2,7 +2,7 @@ open CardThemeType
 open Utils
 open ErrorUtils
 
-let getTheme = val => {
+let getTheme = (val): theme => {
   switch val->String.toLowerCase {
   | "default" => Default
   | "brutal" => Brutal
@@ -28,6 +28,13 @@ let getInnerLayout = str => {
   }
 }
 
+let getColorScheme = (str): colorScheme => {
+  switch str->String.toLowerCase {
+  | "auto" => Auto
+  | _ => Default
+  }
+}
+
 let getShowLoader = str => {
   switch str {
   | "auto" => Auto
@@ -47,6 +54,7 @@ let defaultAppearance = {
   labels: Above,
   rules: Dict.make()->JSON.Encode.object,
   innerLayout: Spaced,
+  colorScheme: Default,
 }
 let defaultFonts = {
   cssSrc: "",
@@ -353,7 +361,11 @@ let getAppearance = (
   ->Dict.get(str)
   ->Option.flatMap(JSON.Decode.object)
   ->Option.map(json => {
-    unknownKeysWarning(["theme", "variables", "rules", "labels", "innerLayout"], json, "appearance")
+    unknownKeysWarning(
+      ["theme", "variables", "rules", "labels", "innerLayout", "colorScheme"],
+      json,
+      "appearance",
+    )
 
     let rulesJson = defaultRules(getVariables("variables", json, default, logger))
 
@@ -372,6 +384,7 @@ let getAppearance = (
           Above
         }
       },
+      colorScheme: getWarningString(json, "colorScheme", "default", ~logger)->getColorScheme,
     }
   })
   ->Option.getOr(defaultAppearance)

--- a/src/Types/CardThemeType.res
+++ b/src/Types/CardThemeType.res
@@ -1,5 +1,7 @@
 type theme = Default | Brutal | Midnight | Soft | Charcoal | Bubblegum | NONE
 
+type colorScheme = Default | Auto
+
 type innerLayout = Spaced | Compressed
 
 type showLoader = Auto | Always | Never
@@ -79,6 +81,7 @@ type appearance = {
   rules: JSON.t,
   labels: label,
   innerLayout: innerLayout,
+  colorScheme: colorScheme,
 }
 type fonts = {
   cssSrc: string,

--- a/src/Window.res
+++ b/src/Window.res
@@ -51,6 +51,21 @@ type elementRef
 @val @scope("document") external querySelectorAll: string => array<Dom.element> = "querySelectorAll"
 @module("/package.json") @val external packageJson: packageJson = "default"
 @val @scope("document") external body: body = "body"
+@val @scope("document") external head: Dom.element = "head"
+@send external appendChildElement: (Dom.element, Dom.element) => unit = "appendChild"
+@send external setAttribute: (Dom.element, string, string) => unit = "setAttribute"
+
+let setColorSchemeMeta = () => {
+  let meta = switch querySelector(`meta[name="color-scheme"]`)->Nullable.toOption {
+  | Some(el) => el
+  | None =>
+    let el = createElement("meta")
+    el->setAttribute("name", "color-scheme")
+    head->appendChildElement(el)
+    el
+  }
+  meta->setAttribute("content", "light dark")
+}
 @val @scope("window") external getHyper: Nullable.t<Types.hyperInstance> = "HyperMethod"
 @val @scope("window") external addEventListener: (string, _ => unit) => unit = "addEventListener"
 @send
@@ -81,7 +96,6 @@ external removeEventListener: (string, 'ev => unit) => unit = "removeEventListen
 @send external preventDefault: (event, unit) => unit = "preventDefault"
 @send external appendChild: (body, Dom.element) => unit = "appendChild"
 @send external remove: Dom.element => unit = "remove"
-@send external setAttribute: (Dom.element, string, string) => unit = "setAttribute"
 @send external paymentRequest: (JSON.t, JSON.t, JSON.t) => JSON.t = "PaymentRequest"
 @send external click: Dom.element => unit = "click"
 @set external innerHTML: (Dom.element, string) => unit = "innerHTML"

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -1495,6 +1495,7 @@ let make = (
         setIframeRefForComponent,
         iframeRef,
         mountPostMessage,
+        ~appearance,
         ~redirectionFlags: RecoilAtomTypes.redirectionFlags,
         ~logger=Some(logger),
       )

--- a/src/hyper-loader/LoaderPaymentElement.res
+++ b/src/hyper-loader/LoaderPaymentElement.res
@@ -14,6 +14,7 @@ let make = (
   setIframeRef,
   iframeRef,
   mountPostMessage,
+  ~appearance,
   ~isPaymentManagementElement=false,
   ~redirectionFlags: RecoilAtomTypes.redirectionFlags,
   ~logger: option<HyperLoggerTypes.loggerMake>,
@@ -336,6 +337,7 @@ let make = (
                             ("fullScreenIframeMounted", true->JSON.Encode.bool),
                             ("metadata", fullscreenMetadata.contents),
                             ("options", options),
+                            ("appearance", appearance),
                           ]->Dict.fromArray,
                         )
                       }

--- a/src/hyper-loader/PaymentMethodsManagementElements.res
+++ b/src/hyper-loader/PaymentMethodsManagementElements.res
@@ -238,6 +238,7 @@ let make = (
         setElementIframeRef,
         iframeRef,
         mountPostMessage,
+        ~appearance,
         ~isPaymentManagementElement=true,
         ~redirectionFlags=RecoilAtoms.defaultRedirectionFlags,
         ~logger=Some(logger),


### PR DESCRIPTION
Fixes #1544

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a `colorScheme` field to the `appearance` options in the Hyperswitch Web SDK. When merchants pass `colorScheme: "auto"`, the SDK injects `<meta name="color-scheme" content="light dark">` into every UI-rendering iframe, enabling the browser's native dark mode support without any custom theme switching logic.

**Two values supported:**
- `"auto"` — injects the meta tag; browser handles light/dark automatically
- `"default"` (or omitted) — no change, preserves existing behaviour

## How did you test it?

Tested manually via the demo app (`Hyperswitch-React-Demo-App`) with `colorScheme: "auto"` set in `appearance`. Verified:
- `<meta name="color-scheme" content="light dark">` is injected into UI iframes
- `colorScheme: "default"` (or omitted) produces no change in behaviour

https://github.com/user-attachments/assets/e6f296be-42bc-4751-9c5e-0b382e909d35


## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible