### PR TITLE
feat: added support for light and dark mode as well in colorScheme

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -78,11 +78,9 @@ let make = () => {
         let colorScheme =
           appearanceJson
           ->Utils.getDictFromJson
-          ->Utils.getString("colorScheme", "default")
+          ->Utils.getString("colorScheme", "light")
           ->CardTheme.getColorScheme
-        if colorScheme == Auto {
-          Window.setColorSchemeMeta()
-        }
+        CardTheme.setColorSchemeMeta(colorScheme)
       | None => ()
       }
     }

--- a/src/CardTheme.res
+++ b/src/CardTheme.res
@@ -31,8 +31,30 @@ let getInnerLayout = str => {
 let getColorScheme = (str): colorScheme => {
   switch str->String.toLowerCase {
   | "auto" => Auto
-  | _ => Default
+  | "dark" => Dark
+  | "light" => Light
+  | str =>
+    str->unknownPropValueWarning(["light", "dark", "auto"], "appearance.colorScheme")
+    Light
   }
+}
+
+let setColorSchemeMeta = (colorScheme: colorScheme) => {
+  open Window
+  let meta = switch querySelector(`meta[name="color-scheme"]`)->Nullable.toOption {
+  | Some(el) => el
+  | None =>
+    let el = createElement("meta")
+    el->setAttribute("name", "color-scheme")
+    head->appendChildElement(el)
+    el
+  }
+  let colorSchemeVal = switch colorScheme {
+  | Auto => "light dark"
+  | Dark => "dark"
+  | Light => "light"
+  }
+  meta->setAttribute("content", colorSchemeVal)
 }
 
 let getShowLoader = str => {
@@ -54,7 +76,7 @@ let defaultAppearance = {
   labels: Above,
   rules: Dict.make()->JSON.Encode.object,
   innerLayout: Spaced,
-  colorScheme: Default,
+  colorScheme: Light,
 }
 let defaultFonts = {
   cssSrc: "",
@@ -384,7 +406,7 @@ let getAppearance = (
           Above
         }
       },
-      colorScheme: getWarningString(json, "colorScheme", "default", ~logger)->getColorScheme,
+      colorScheme: getWarningString(json, "colorScheme", "light", ~logger)->getColorScheme,
     }
   })
   ->Option.getOr(defaultAppearance)

--- a/src/Types/CardThemeType.res
+++ b/src/Types/CardThemeType.res
@@ -1,6 +1,6 @@
 type theme = Default | Brutal | Midnight | Soft | Charcoal | Bubblegum | NONE
 
-type colorScheme = Default | Auto
+type colorScheme = Light | Auto | Dark
 
 type innerLayout = Spaced | Compressed
 

--- a/src/Window.res
+++ b/src/Window.res
@@ -55,17 +55,6 @@ type elementRef
 @send external appendChildElement: (Dom.element, Dom.element) => unit = "appendChild"
 @send external setAttribute: (Dom.element, string, string) => unit = "setAttribute"
 
-let setColorSchemeMeta = () => {
-  let meta = switch querySelector(`meta[name="color-scheme"]`)->Nullable.toOption {
-  | Some(el) => el
-  | None =>
-    let el = createElement("meta")
-    el->setAttribute("name", "color-scheme")
-    head->appendChildElement(el)
-    el
-  }
-  meta->setAttribute("content", "light dark")
-}
 @val @scope("window") external getHyper: Nullable.t<Types.hyperInstance> = "HyperMethod"
 @val @scope("window") external addEventListener: (string, _ => unit) => unit = "addEventListener"
 @send


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR extends the `colorScheme` appearance option to support explicit `light` and `dark` values (in addition to the existing `auto`), and ensures the `<meta name="color-scheme">` tag is always set — not just when `auto` is selected.

## Changes

- **`CardThemeType.res`**: Replaced `Default` variant with `Light` and added `Dark` to the `colorScheme` type.
  - Before: `Default | Auto`
  - After: `Light | Auto | Dark`
- **`CardTheme.res`**:
  - Updated `getColorScheme` to map `"dark"` → `Dark` and unknown values → `Light`
  - Moved `setColorSchemeMeta` from `Window.res` into `CardTheme.res` with extended logic to set appropriate meta content (`"light"`, `"dark"`, or `"light dark"`) for each variant
  - Updated default `colorScheme` from `Default` to `Light`
- **`App.res`**: Replaced conditional `Window.setColorSchemeMeta()` (only called for `Auto`) with unconditional `CardTheme.setColorSchemeMeta(colorScheme)` for all schemes.
- **`Window.res`**: Removed the old `setColorSchemeMeta` function (superseded by the implementation in `CardTheme.res`).

## How did you test it?

- [x] `colorScheme: "auto"` → `<meta name="color-scheme" content="light dark">`
- [x] `colorScheme: "dark"` → `<meta name="color-scheme" content="dark">`
- [x] `colorScheme: "light"` → `<meta name="color-scheme" content="light">`

If the merchantPasses colorScheme as "light" it should be light in the meta tag and the background will be light or transparent and in scenarios where the merchant passes colorScheme as "dark" it should be dark in the meta tag and the background will be dark by default.


https://github.com/user-attachments/assets/9e55ee52-526c-4848-84a7-1f22ab0c8b36



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
