### PR TITLE
fix: added isSaveCardsChecked functionality to isCustomerAcceptance for card payments

### DIFF
--- a/src/Hooks/UtilityHooks.res
+++ b/src/Hooks/UtilityHooks.res
@@ -43,7 +43,7 @@ let useIsCustomerAcceptanceRequired = (
     if displaySavedPaymentMethodsCheckbox {
       isSaveCardsChecked || paymentMethodListValue.payment_type === SETUP_MANDATE
     } else {
-      !(isGuestCustomer || paymentMethodListValue.payment_type === NORMAL)
+      !isGuestCustomer && (isSaveCardsChecked || paymentMethodListValue.payment_type !== NORMAL)
     }
   }, (
     isSaveCardsChecked,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes the `customerAcceptance` not being sent when a merchant hides the save payment method checkbox but wants it checked by default.
### Changes
- **`src/Hooks/UtilityHooks.res`** — Fixed `useIsCustomerAcceptanceRequired` logic for the `displaySavedPaymentMethodsCheckbox: false` path to respect `isSaveCardsChecked` (driven by `savedPaymentMethodsCheckboxCheckedByDefault`)
### Behavior
| `displaySavedPaymentMethodsCheckbox` | `savedPaymentMethodsCheckboxCheckedByDefault` | `customerAcceptance` sent? |
|---|---|---|
| `false` | `true` | Yes ✅ |
| `false` | `false` (or not set) | No ✅ |
| `true` | N/A (checkbox visible) | Depends on user interaction ✅ |
### Backward Compatibility
Existing merchants who do not pass `savedPaymentMethodsCheckboxCheckedByDefault` are **not affected** — the value defaults to `false`, preserving existing behavior.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

https://github.com/user-attachments/assets/3efce446-1b54-4e95-b78f-237f146fa32a


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
