### PR TITLE
fix: added overflow hidden and border radius to fix paypal background

### DIFF
--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -209,8 +209,9 @@ let make = (~sessionObj: SessionsType.token) => {
     style={
       pointerEvents: updateSession ? "none" : "auto",
       opacity: updateSession ? "0.5" : "1.0",
+      borderRadius: `${buttonStyle.borderRadius->Int.toString}px`,
     }
-    className="w-full flex flex-row justify-center h-auto"
+    className="w-full flex flex-row justify-center h-auto overflow-hidden"
   />
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

After passing border radius to PayPal button in a dark theme background, there was a white background still visible. Added back the overflow hidden which got removed in the last wallet customization

## How did you test it?

Before - 

<img width="402" height="393" alt="Screenshot 2026-05-17 at 5 49 08 PM" src="https://github.com/user-attachments/assets/f8da2f5d-4528-4874-852d-b23e66a43bc5" />

After -
<img width="399" height="265" alt="Screenshot 2026-05-17 at 5 48 41 PM" src="https://github.com/user-attachments/assets/875f7245-5fd7-433c-a995-f71822daa3da" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
