### PR TITLE
feat: added hiddenPaymentMethods customization prop

### DIFF
--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -109,6 +109,9 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
         let finalSavedPaymentMethods =
           savedPaymentMethods
           ->Array.copy
+          ->filterSavedMethodsByHiddenList(
+            ~hiddenPaymentMethods=layoutClass.savedMethodCustomization.hiddenPaymentMethods,
+          )
           ->filterSavedMethodsByWalletReadiness(~isApplePayReady, ~isGooglePayReady=isGPayReady)
         finalSavedPaymentMethods->Array.sort(sortSavedPaymentMethods)
 
@@ -146,6 +149,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     isGPayReady,
     clickToPayConfig.isReady,
     isShowPaymentMethodsDependingOnClickToPay,
+    layoutClass.savedMethodCustomization.hiddenPaymentMethods,
   ))
 
   React.useEffect(() => {

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -12,6 +12,7 @@ type savedMethodCustomization = {
   maxItems: int,
   hideCardExpiry: bool,
   defaultCollapsed: bool,
+  hiddenPaymentMethods: array<string>,
 }
 open Utils
 open ErrorUtils
@@ -341,6 +342,7 @@ let defaultSavedMethodCustomization = {
   maxItems: 4,
   hideCardExpiry: false,
   defaultCollapsed: true,
+  hiddenPaymentMethods: [],
 }
 
 let defaultLayout = {
@@ -907,7 +909,13 @@ let getSavedMethodCustomization = (dict, str, logger) => {
   ->Option.flatMap(JSON.Decode.object)
   ->Option.map(json => {
     unknownKeysWarning(
-      ["groupingBehavior", "maxItems", "hideCardExpiry", "defaultCollapsed"],
+      [
+        "groupingBehavior",
+        "maxItems",
+        "hideCardExpiry",
+        "defaultCollapsed",
+        "hiddenPaymentMethods",
+      ],
       json,
       "options.layout.savedMethodCustomization",
     )
@@ -916,6 +924,7 @@ let getSavedMethodCustomization = (dict, str, logger) => {
       maxItems: getMaxItems(json, "maxItems", 4, ~logger),
       hideCardExpiry: getBool(json, "hideCardExpiry", false),
       defaultCollapsed: getBoolWithWarning(json, "defaultCollapsed", true, ~logger),
+      hiddenPaymentMethods: json->getStrArray("hiddenPaymentMethods"),
     }
   })
   ->Option.getOr(defaultSavedMethodCustomization)

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -362,6 +362,30 @@ let usePaypalFlowStatus = (~sessions, ~paymentMethodListValue) => {
   (isPaypalSDKFlow, isPaypalRedirectFlow, isPaypalTokenExist)
 }
 
+let filterSavedMethodsByHiddenList = (
+  savedMethods: array<PaymentType.customerMethods>,
+  ~hiddenPaymentMethods,
+) => {
+  if hiddenPaymentMethods->Array.length === 0 {
+    savedMethods
+  } else {
+    let lowerHidden =
+      hiddenPaymentMethods->Array.map(paymentMethod => paymentMethod->String.toLowerCase)
+    savedMethods->Array.filter(savedMethod => {
+      let paymentMethodTypeLower = switch savedMethod.paymentMethodType {
+      | Some(pmt) => pmt->String.toLowerCase
+      | None => ""
+      }
+      let paymentMethodLower = savedMethod.paymentMethod->String.toLowerCase
+      // Match against paymentMethodType (e.g. "apple_pay", "google_pay", "credit", "debit")
+      let hiddenByType = lowerHidden->Array.includes(paymentMethodTypeLower)
+      // Only allow paymentMethod-level matching for "card" — wallet-level ("wallet") is ignored
+      let hiddenByMethod = paymentMethodLower == "card" && lowerHidden->Array.includes("card")
+      !(hiddenByType || hiddenByMethod)
+    })
+  }
+}
+
 let filterSavedMethodsByWalletReadiness = (
   savedMethods: array<PaymentType.customerMethods>,
   ~isApplePayReady,
@@ -457,7 +481,11 @@ let useGetPaymentMethodList = (~paymentType: CardThemeType.mode, ~sessions) => {
 
     let filteredSaved = switch savedPaymentMethods {
     | Some(methods) =>
-      methods->filterSavedMethodsByWalletReadiness(~isApplePayReady, ~isGooglePayReady)
+      methods
+      ->filterSavedMethodsByHiddenList(
+        ~hiddenPaymentMethods=layoutClass.savedMethodCustomization.hiddenPaymentMethods,
+      )
+      ->filterSavedMethodsByWalletReadiness(~isApplePayReady, ~isGooglePayReady)
     | None => []
     }
 
@@ -539,6 +567,7 @@ let useGetPaymentMethodList = (~paymentType: CardThemeType.mode, ~sessions) => {
     optionAtomValue.customerPaymentMethods,
     optionAtomValue.displaySavedPaymentMethods,
     displayGroupedSavedMethods,
+    layoutClass.savedMethodCustomization.hiddenPaymentMethods,
   ))
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Adds a new `hiddenPaymentMethods` prop inside `savedMethodCustomization` that allows merchants to filter out specific payment methods from the **SavedMethods section only**. The new payment methods list is unaffected.
## Changes
- **`src/Types/PaymentType.res`**
  - Added `hiddenPaymentMethods: array<string>` field to the `savedMethodCustomization` type
  - Added `hiddenPaymentMethods: []` to `defaultSavedMethodCustomization`
  - Added `"hiddenPaymentMethods"` to `unknownKeysWarning` to avoid spurious console warnings
  - Parsed the new field in `getSavedMethodCustomization` using `getStrArray`
- **`src/Utilities/PaymentUtils.res`**
  - Added `filterSavedMethodsByHiddenList` utility function
  - Applied filter at both saved-methods pipeline call sites (standard + grouped)
  - Added `hiddenPaymentMethods` to `useMemo` dependency array in `useGetPaymentMethodList`
- **`src/PaymentElement.res`**
  - Chained `filterSavedMethodsByHiddenList` before `filterSavedMethodsByWalletReadiness` in the saved methods `useEffect` pipeline
  - Added `hiddenPaymentMethods` to the `useEffect` dependency array
  - Removed redundant `Array.copy` (dead code since `Array.filter` returns a new array)
## Behaviour
| Input | Result |
|---|---|
| `["apple_pay"]` | Hides saved Apple Pay entries |
| `["google_pay"]` | Hides saved Google Pay entries |
| `["card"]` | Hides all saved cards (credit + debit) |
| `["google_pay", "card"]` | Hides saved Google Pay and all saved cards |
| `["wallet"]` | No effect — silently ignored |
| `[]` / omitted | No filtering, existing behaviour preserved |
## Notes
- Filter runs **before** `filterSavedMethodsByWalletReadiness` so merchant intent takes priority
- Matching is **case-insensitive**
- `["wallet"]` is explicitly not supported — merchants must pass specific method names like `"apple_pay"` or `"google_pay"`

## How did you test it?

Passing all these payment_methods in the prop one by one to verify whether that payment method has been removed or not

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
