### PR TITLE
fix: preserve camelCase keys and numeric values in merchant session validation

### DIFF
--- a/src/Types/ApplePayTypes.res
+++ b/src/Types/ApplePayTypes.res
@@ -163,7 +163,7 @@ let getPaymentRequestFromSession = (~sessionObj, ~componentName) => {
     ->Option.getOr(Dict.make())
     ->Dict.get("payment_request_data")
     ->Option.getOr(Dict.make()->JSON.Encode.object)
-    ->transformKeys(CamelCase)
+    ->transformKeysWithoutModifyingValue(CamelCase)
 
   let requiredShippingContactFields =
     paymentRequest

--- a/src/Types/GooglePayType.res
+++ b/src/Types/GooglePayType.res
@@ -130,15 +130,15 @@ let jsonToPaymentRequestDataType: (paymentDataRequest, Dict.t<JSON.t>) => paymen
   paymentRequest.allowedPaymentMethods =
     jsonDict
     ->getArray("allowed_payment_methods")
-    ->Array.map(json => transformKeys(json, CamelCase))
+    ->Array.map(json => transformKeysWithoutModifyingValue(json, CamelCase))
   paymentRequest.transactionInfo =
     jsonDict
     ->getJsonFromDict("transaction_info", JSON.Encode.null)
-    ->transformKeys(CamelCase)
+    ->transformKeysWithoutModifyingValue(CamelCase)
   paymentRequest.merchantInfo =
     jsonDict
     ->getJsonFromDict("merchant_info", JSON.Encode.null)
-    ->transformKeys(CamelCase)
+    ->transformKeysWithoutModifyingValue(CamelCase)
 
   paymentRequest
 }
@@ -173,14 +173,16 @@ let getPaymentDataFromSession = (~sessionObj, ~componentName) => {
     baseRequest->Identity.anyTypeToJson,
   )
   paymentDataRequest.allowedPaymentMethods = gpayobj.allowed_payment_methods->arrayJsonToCamelCase
-  paymentDataRequest.transactionInfo = gpayobj.transaction_info->transformKeys(CamelCase)
-  paymentDataRequest.merchantInfo = gpayobj.merchant_info->transformKeys(CamelCase)
+  paymentDataRequest.transactionInfo =
+    gpayobj.transaction_info->transformKeysWithoutModifyingValue(CamelCase)
+  paymentDataRequest.merchantInfo =
+    gpayobj.merchant_info->transformKeysWithoutModifyingValue(CamelCase)
   paymentDataRequest.emailRequired = gpayobj.emailRequired
 
   if componentName->getIsExpressCheckoutComponent {
     paymentDataRequest.shippingAddressRequired = gpayobj.shippingAddressRequired
     paymentDataRequest.shippingAddressParameters =
-      gpayobj.shippingAddressParameters->transformKeys(CamelCase)
+      gpayobj.shippingAddressParameters->transformKeysWithoutModifyingValue(CamelCase)
     paymentDataRequest.callbackIntents = ["SHIPPING_ADDRESS"->JSON.Encode.string]
   }
 

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -89,7 +89,7 @@ let startApplePaySession = (
       ->Option.getOr(Dict.make())
       ->Dict.get("session_token_data")
       ->Option.getOr(Dict.make()->JSON.Encode.object)
-      ->transformKeys(CamelCase)
+      ->transformKeysWithoutModifyingValue(CamelCase)
     ssn.completeMerchantValidation(merchantSession)
   }
 

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -451,8 +451,11 @@ let gpayBody = (~payObj: GooglePayType.paymentData, ~connectors: array<string>) 
     [
       ("type", paymentMethodData.\"type"->JSON.Encode.string),
       ("description", paymentMethodData.description->JSON.Encode.string),
-      ("info", paymentMethodData.info->transformKeys(SnakeCase)),
-      ("tokenization_data", paymentMethodData.tokenizationData->transformKeys(SnakeCase)),
+      ("info", paymentMethodData.info->transformKeysWithoutModifyingValue(SnakeCase)),
+      (
+        "tokenization_data",
+        paymentMethodData.tokenizationData->transformKeysWithoutModifyingValue(SnakeCase),
+      ),
     ]->getJsonFromArrayOfJson
   }
 
@@ -525,7 +528,10 @@ let applePayBody = (~token, ~connectors) => {
         (
           "wallet",
           [
-            ("apple_pay", dict->JSON.Encode.object->Utils.transformKeys(SnakeCase)),
+            (
+              "apple_pay",
+              dict->JSON.Encode.object->Utils.transformKeysWithoutModifyingValue(SnakeCase),
+            ),
           ]->Utils.getJsonFromArrayOfJson,
         ),
       ]

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -451,11 +451,8 @@ let gpayBody = (~payObj: GooglePayType.paymentData, ~connectors: array<string>) 
     [
       ("type", paymentMethodData.\"type"->JSON.Encode.string),
       ("description", paymentMethodData.description->JSON.Encode.string),
-      ("info", paymentMethodData.info->transformKeysWithoutModifyingValue(SnakeCase)),
-      (
-        "tokenization_data",
-        paymentMethodData.tokenizationData->transformKeysWithoutModifyingValue(SnakeCase),
-      ),
+      ("info", paymentMethodData.info->transformKeys(SnakeCase)),
+      ("tokenization_data", paymentMethodData.tokenizationData->transformKeys(SnakeCase)),
     ]->getJsonFromArrayOfJson
   }
 
@@ -528,10 +525,7 @@ let applePayBody = (~token, ~connectors) => {
         (
           "wallet",
           [
-            (
-              "apple_pay",
-              dict->JSON.Encode.object->Utils.transformKeysWithoutModifyingValue(SnakeCase),
-            ),
+            ("apple_pay", dict->JSON.Encode.object->Utils.transformKeys(SnakeCase)),
           ]->Utils.getJsonFromArrayOfJson,
         ),
       ]

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -390,15 +390,13 @@ let getFailedSubmitResponse = (~errorType, ~message) => {
 let toCamelCase = str => {
   if str->String.includes(":") {
     str
-  } else if str->String.includes("_") {
+  } else {
     str
     ->String.toLowerCase
     ->Js.String2.unsafeReplaceBy0(%re(`/([-_][a-z])/g`), (letter, _, _) => {
       letter->String.toUpperCase
     })
     ->String.replaceRegExp(%re(`/[^a-zA-Z]/g`), "")
-  } else {
-    str->String.replaceRegExp(%re(`/[^a-zA-Z]/g`), "")
   }
 }
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -390,7 +390,7 @@ let getFailedSubmitResponse = (~errorType, ~message) => {
 let toCamelCase = str => {
   if str->String.includes(":") {
     str
-  } else if str->String.includes("_") || str->String.includes("-") {
+  } else if str->String.includes("_") {
     str
     ->String.toLowerCase
     ->Js.String2.unsafeReplaceBy0(%re(`/([-_][a-z])/g`), (letter, _, _) => {
@@ -405,7 +405,7 @@ let toCamelCase = str => {
 let toCamelCaseWithNumberSupport = str => {
   if str->String.includes(":") {
     str
-  } else if str->String.includes("_") || str->String.includes("-") {
+  } else if str->String.includes("_") {
     str
     ->String.toLowerCase
     ->Js.String2.unsafeReplaceBy0(%re(`/([-_][a-z])/g`), (letter, _, _) => {

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -478,14 +478,14 @@ let rec transformKeysWithoutModifyingValue = (json: JSON.t, to: case) => {
   ->Dict.toArray
   ->Array.map(((key, value)) => {
     let x = switch JSON.Classify.classify(value) {
-    | Object(obj) => (key->toCase, obj->JSON.Encode.object->transformKeys(to))
+    | Object(obj) => (key->toCase, obj->JSON.Encode.object->transformKeysWithoutModifyingValue(to))
     | Array(arr) => (
         key->toCase,
         {
           arr
           ->Array.map(item =>
             if item->JSON.Decode.object->Option.isSome {
-              item->transformKeys(to)
+              item->transformKeysWithoutModifyingValue(to)
             } else {
               item
             }

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -390,26 +390,30 @@ let getFailedSubmitResponse = (~errorType, ~message) => {
 let toCamelCase = str => {
   if str->String.includes(":") {
     str
-  } else {
+  } else if str->String.includes("_") || str->String.includes("-") {
     str
     ->String.toLowerCase
     ->Js.String2.unsafeReplaceBy0(%re(`/([-_][a-z])/g`), (letter, _, _) => {
       letter->String.toUpperCase
     })
     ->String.replaceRegExp(%re(`/[^a-zA-Z]/g`), "")
+  } else {
+    str->String.replaceRegExp(%re(`/[^a-zA-Z]/g`), "")
   }
 }
 
 let toCamelCaseWithNumberSupport = str => {
   if str->String.includes(":") {
     str
-  } else {
+  } else if str->String.includes("_") || str->String.includes("-") {
     str
     ->String.toLowerCase
     ->Js.String2.unsafeReplaceBy0(%re(`/([-_][a-z])/g`), (letter, _, _) => {
       letter->String.toUpperCase
     })
     ->String.replaceRegExp(%re(`/[^a-zA-Z0-9]/g`), "")
+  } else {
+    str->String.replaceRegExp(%re(`/[^a-zA-Z0-9]/g`), "")
   }
 }
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1175,7 +1175,7 @@ let fetchApiWithLogging = async (
 
 let arrayJsonToCamelCase = arr => {
   arr->Array.map(item => {
-    item->transformKeys(CamelCase)
+    item->transformKeysWithoutModifyingValue(CamelCase)
   })
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description


Fixes two related bugs in Apple Pay merchant session validation that caused onvalidatemerchant to fail.

### Problem
The Apple Pay session token data returned from the backend is already in camelCase (e.g. epochTimestamp, merchantSessionIdentifier). When transformKeys(CamelCase) was applied:
1. toCamelCase called String.toLowerCase unconditionally before applying the camelCase regex. Since the regex only capitalizes letters after _ or -, keys without separators were fully lowercased (epochTimestamp → epochtimestamp), causing Apple Pay's completeMerchantValidation to fail with malformed session data.
2. transformKeys coerces all Number values to strings (val->Float.toString), corrupting numeric fields like epochTimestamp and expiresAt that Apple Pay expects as integers.
Changes
- toCamelCase / toCamelCaseWithNumberSupport (Utils.res): Only apply the lowercase + regex transform when the string contains _ or -. Otherwise pass through as-is (stripping non-alpha characters only), preserving existing camelCase keys.
- startApplePaySession (ApplePayHelpers.res): Replace transformKeys(CamelCase) with transformKeysWithoutModifyingValue(CamelCase) so numeric values remain as numbers instead of being stringified.
Testing
- Verify Apple Pay merchant validation succeeds end-to-end on a supported device/browser
- Verify snake_case → camelCase conversion still works correctly for other use cases of transformKeys

## How did you test it?

I have tested it locally, by comparing the merchant session before and after transformation and also e2e testing.

before:
<img width="1725" height="936" alt="image" src="https://github.com/user-attachments/assets/acdb3c88-0e3d-4173-91f6-82b78bef6b1b" />

after:

<img width="1664" height="1011" alt="image" src="https://github.com/user-attachments/assets/b8acbea9-0dc5-4296-b973-b666be97b664" />


https://github.com/user-attachments/assets/2bc69d4d-a24e-4976-8472-c82a9ae9a7ae




## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
