### PR TITLE
feat: added hidden payment methods for headless

### DIFF
--- a/src/hyper-loader/PaymentSession.res
+++ b/src/hyper-loader/PaymentSession.res
@@ -49,8 +49,9 @@ let make = (
   }
 
   let defaultInitPaymentSession = {
-    getCustomerSavedPaymentMethods: _ =>
+    getCustomerSavedPaymentMethods: options =>
       PaymentSessionMethods.getCustomerSavedPaymentMethods(
+        ~options,
         ~clientSecretRef,
         ~publishableKey,
         ~endpoint,

--- a/src/hyper-loader/PaymentSessionMethods.res
+++ b/src/hyper-loader/PaymentSessionMethods.res
@@ -6,6 +6,7 @@ let cvcWidgetNotFoundErrorType = "cvc_widget_not_found"
 let cvcValidationErrorType = "cvc_validation"
 
 let getCustomerSavedPaymentMethods = (
+  ~options: option<JSON.t>,
   ~clientSecretRef: ref<string>,
   ~publishableKey,
   ~endpoint,
@@ -19,6 +20,11 @@ let getCustomerSavedPaymentMethods = (
   open ApplePayTypes
   open GooglePayType
   let applePaySessionRef = ref(Nullable.null)
+  let hiddenPaymentMethods =
+    options
+    ->Option.flatMap(JSON.Decode.object)
+    ->Option.getOr(Dict.make())
+    ->getStrArray("hiddenPaymentMethods")
 
   PaymentHelpers.fetchCustomerPaymentMethodList(
     ~clientSecret=clientSecretRef.contents,
@@ -57,18 +63,23 @@ let getCustomerSavedPaymentMethods = (
     customerPaymentMethods->Array.sort((a, b) => compareLogic(a.lastUsedAt, b.lastUsedAt))
 
     let customerPaymentMethodsRef = ref(customerPaymentMethods)
+
+    customerPaymentMethodsRef :=
+      customerPaymentMethodsRef.contents->PaymentUtils.filterSavedMethodsByHiddenList(
+        ~hiddenPaymentMethods,
+      )
     let applePayTokenRef = ref(defaultHeadlessApplePayToken)
     let googlePayTokenRef = ref(JSON.Encode.null)
 
     let isApplePayPresent =
-      customerPaymentMethods
+      customerPaymentMethodsRef.contents
       ->Array.find(customerPaymentMethod =>
         customerPaymentMethod.paymentMethodType === Some("apple_pay")
       )
       ->Option.isSome
 
     let isGooglePayPresent =
-      customerPaymentMethods
+      customerPaymentMethodsRef.contents
       ->Array.find(customerPaymentMethod =>
         customerPaymentMethod.paymentMethodType === Some("google_pay")
       )
@@ -84,7 +95,7 @@ let getCustomerSavedPaymentMethods = (
     }
 
     let customerDefaultPaymentMethodRef = ref(
-      customerPaymentMethods
+      customerPaymentMethodsRef.contents
       ->Array.filter(customerPaymentMethod => {
         customerPaymentMethod.defaultPaymentMethodSet
       })

--- a/src/hyper-loader/Types.res
+++ b/src/hyper-loader/Types.res
@@ -54,7 +54,7 @@ type getCustomerSavedPaymentMethods = {
 }
 
 type initPaymentSession = {
-  getCustomerSavedPaymentMethods: unit => promise<JSON.t>,
+  getCustomerSavedPaymentMethods: option<JSON.t> => promise<JSON.t>,
   updateIntent: (unit => promise<JSON.t>) => promise<JSON.t>,
 }
 
@@ -183,7 +183,7 @@ let confirmWithLastUsedPaymentMethod = _confirmParams => {
   Promise.resolve(Dict.make()->JSON.Encode.object)
 }
 
-let defaultGetCustomerSavedPaymentMethods = () => {
+let defaultGetCustomerSavedPaymentMethods = (_options: option<JSON.t>) => {
   // TODO: After rescript migration to v11, add this without TAG using enums
   // Promise.resolve({
   //   getCustomerDefaultSavedPaymentMethodData,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a `hiddenPaymentMethods` prop that allows merchants to filter out specific saved payment methods. Supported in both the embedded (`PaymentElement`) and headless (`PaymentSession`) flows.
## Changes
- **`src/hyper-loader/Types.res`**
  - Changed `getCustomerSavedPaymentMethods` type from `unit => promise<JSON.t>` to `option<JSON.t> => promise<JSON.t>`
  - Updated `defaultGetCustomerSavedPaymentMethods` stub to accept optional param
- **`src/hyper-loader/PaymentSession.res`**
  - Forwards call-time `options` argument to `PaymentSessionMethods`
- **`src/hyper-loader/PaymentSessionMethods.res`**
  - Added `~options: option<JSON.t>` parameter; parses `hiddenPaymentMethods` internally
  - Applied `filterSavedMethodsByHiddenList` on `customerPaymentMethodsRef` after initial sort
  - `isApplePayPresent`, `isGooglePayPresent`, and `customerDefaultPaymentMethodRef` all derived from the filtered list
  - Removed stale debug `Console.log2`
## Filter Logic
| Input | Result |
|---|---|
| `["apple_pay"]` | Hides saved Apple Pay (matches `paymentMethodType`) |
| `["google_pay"]` | Hides saved Google Pay (matches `paymentMethodType`) |
| `["card"]` | Hides all saved cards — credit + debit (matches `paymentMethod`) |
| `["wallet"]` | No effect — silently ignored |
| `[]` / omitted | No filtering — existing behaviour preserved |
## Backwards Compatibility
- Embedded flow: omitting `hiddenPaymentMethods` preserves existing behaviour
- Headless flow: `getCustomerSavedPaymentMethods()` with no argument → no filtering

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Checked the customers call list response after passing hiddenPaymentMethods prop

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
