### PR TITLE
fix: sdk authorization dependency across all the flows

### DIFF
--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -377,6 +377,7 @@ let make = (
     isManualRetryEnabled,
     selectedInstallmentPlan,
     showInstallments,
+    sdkAuthorization,
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -12,7 +12,7 @@ let setUserError = message => {
 @react.component
 let make = (~paymentMode, ~integrateError, ~logger) => {
   let {localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(areRequiredFieldsValid)
   let (isFocus, setIsFocus) = React.useState(_ => false)
@@ -140,6 +140,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     isExpiryValid,
     isCardValid,
     cardEligibilityError,
+    sdkAuthorization,
   ))
 
   if integrateError {

--- a/src/Payments/ACHBankDebit.res
+++ b/src/Payments/ACHBankDebit.res
@@ -8,6 +8,7 @@ let make = () => {
   let {displaySavedPaymentMethods, layout} = Recoil.useRecoilValueFromAtom(optionAtom)
   let layoutClass = CardUtils.getLayoutClass(layout)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
+  let {sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
 
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
 
@@ -101,7 +102,7 @@ let make = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, modalData, fullName, isManualRetryEnabled))
+  }, (email, modalData, fullName, isManualRetryEnabled, sdkAuthorization))
   useSubmitPaymentData(submitCallback)
 
   let paymentMethodType = "ach"

--- a/src/Payments/ACHBankTransfer.res
+++ b/src/Payments/ACHBankTransfer.res
@@ -3,7 +3,7 @@ open Utils
 
 @react.component
 let make = () => {
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let {layout} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -45,7 +45,7 @@ let make = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, isManualRetryEnabled))
+  }, (email, isManualRetryEnabled, sdkAuthorization))
   useSubmitPaymentData(submitCallback)
 
   let paymentMethodType = "ach"

--- a/src/Payments/BacsBankTransfer.res
+++ b/src/Payments/BacsBankTransfer.res
@@ -3,7 +3,7 @@ open Utils
 
 @react.component
 let default = () => {
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
@@ -49,7 +49,7 @@ let default = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (isManualRetryEnabled, email, fullName))
+  }, (isManualRetryEnabled, email, fullName, sdkAuthorization))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingTab}>

--- a/src/Payments/BecsBankDebit.res
+++ b/src/Payments/BecsBankDebit.res
@@ -21,6 +21,7 @@ let make = () => {
   let state = Recoil.useRecoilValueFromAtom(userAddressState)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), BankDebits)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
+  let {sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let countryCode = Utils.getCountryCode(country.value).isoAlpha2
   let stateCode = Utils.getStateCodeFromStateName(state.value, countryCode)
 
@@ -80,7 +81,7 @@ let make = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (email, fullName, modalData, isManualRetryEnabled))
+  }, (email, fullName, modalData, isManualRetryEnabled, sdkAuthorization))
   useSubmitPaymentData(submitCallback)
 
   let paymentMethod = "bank_debit"

--- a/src/Payments/Boleto.res
+++ b/src/Payments/Boleto.res
@@ -26,7 +26,7 @@ let formatSocialSecurityNumber = socialSecurityNumber => {
 let make = () => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Other)
   let setComplete = Recoil.useSetRecoilState(fieldsComplete)
@@ -70,7 +70,7 @@ let make = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (socialSecurityNumber, isManualRetryEnabled))
+  }, (socialSecurityNumber, isManualRetryEnabled, sdkAuthorization))
   useSubmitPaymentData(submitCallback)
 
   let changeSocialSecurityNumber = ev => {

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -30,7 +30,7 @@ let make = (
   let (isClickToPayRememberMe, setIsClickToPayRememberMe) = React.useState(_ => false)
   let ctpCards = clickToPayConfig.clickToPayCards->Option.getOr([])
   let nickname = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCardNickName)
-  let {clientSecret} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let {clientSecret, sdkAuthorization} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
   let url = RescriptReactRouter.useUrl()
   let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
   let paymentTypeFromUrl = componentName->CardThemeType.getPaymentMode
@@ -454,6 +454,7 @@ let make = (
     selectedInstallmentPlan,
     showInstallments,
     cardEligibilityError,
+    sdkAuthorization,
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payments/InstantBankTransfer.res
+++ b/src/Payments/InstantBankTransfer.res
@@ -3,7 +3,7 @@ open Utils
 
 @react.component
 let make = () => {
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(areRequiredFieldsValid)
@@ -46,7 +46,13 @@ let make = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (requiredFieldsBody, areRequiredFieldsValid, areRequiredFieldsEmpty, isManualRetryEnabled))
+  }, (
+    requiredFieldsBody,
+    areRequiredFieldsValid,
+    areRequiredFieldsEmpty,
+    isManualRetryEnabled,
+    sdkAuthorization,
+  ))
   useSubmitPaymentData(submitCallback)
 
   <div className="flex flex-col animate-slowShow" style={gridGap: themeObj.spacingTab}>

--- a/src/Payments/InstantBankTransferFinland.res
+++ b/src/Payments/InstantBankTransferFinland.res
@@ -3,7 +3,7 @@ open Utils
 
 @react.component
 let make = () => {
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(areRequiredFieldsValid)
@@ -52,6 +52,7 @@ let make = () => {
     areRequiredFieldsEmpty,
     isManualRetryEnabled,
     iframeId,
+    sdkAuthorization,
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payments/InstantBankTransferPoland.res
+++ b/src/Payments/InstantBankTransferPoland.res
@@ -3,7 +3,7 @@ open Utils
 
 @react.component
 let make = () => {
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let {layout} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -52,6 +52,7 @@ let make = () => {
     areRequiredFieldsEmpty,
     isManualRetryEnabled,
     iframeId,
+    sdkAuthorization,
   ))
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payments/KlarnaSDK.res
+++ b/src/Payments/KlarnaSDK.res
@@ -13,11 +13,10 @@ let make = (~sessionObj: SessionsType.token) => {
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
   let sdkHandleIsThere = Recoil.useRecoilValueFromAtom(isPaymentButtonHandlerProvidedAtom)
   let updateSession = Recoil.useRecoilValueFromAtom(updateSession)
-  let {publishableKey} = Recoil.useRecoilValueFromAtom(keys)
+  let {publishableKey, iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let intent = PaymentHelpers.usePaymentIntent(Some(loggerState), Other)
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let status = CommonHooks.useScript("https://x.klarnacdn.net/kp/lib/v1/api.js") // Klarna SDK script
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
   let (isCompleted, setIsCompleted) = React.useState(_ => false)
@@ -151,7 +150,7 @@ let make = (~sessionObj: SessionsType.token) => {
       )
     }
     None
-  }, (status, paymentMethodTypes))
+  }, (status, paymentMethodTypes, sdkAuthorization))
 
   <div
     style={

--- a/src/Payments/PayPal.res
+++ b/src/Payments/PayPal.res
@@ -15,7 +15,7 @@ let make = (~walletOptions) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let (paypalClicked, setPaypalClicked) = React.useState(_ => false)
   let sdkHandleIsThere = Recoil.useRecoilValueFromAtom(isPaymentButtonHandlerProvidedAtom)
-  let {publishableKey} = Recoil.useRecoilValueFromAtom(keys)
+  let {publishableKey, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
   let areOneClickWalletsRendered = Recoil.useSetRecoilState(areOneClickWalletsRendered)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
@@ -159,7 +159,7 @@ let make = (~walletOptions) => {
           )
         }
       }
-    }, (areRequiredFieldsValid, areRequiredFieldsEmpty, isWallet, iframeId))
+    }, (areRequiredFieldsValid, areRequiredFieldsEmpty, isWallet, iframeId, sdkAuthorization))
   }
 
   let submitCallback = useSubmitCallback(~isWallet)

--- a/src/Payments/PaymentMethodsWrapper.res
+++ b/src/Payments/PaymentMethodsWrapper.res
@@ -4,7 +4,7 @@ open Utils
 
 @react.component
 let make = (~paymentMethodName: string) => {
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let blikCode = Recoil.useRecoilValueFromAtom(userBlikCode)
   let phoneNumber = Recoil.useRecoilValueFromAtom(userPhoneNumber)
@@ -112,6 +112,7 @@ let make = (~paymentMethodName: string) => {
     currency,
     requiredFieldsBody,
     areRequiredFieldsValid,
+    sdkAuthorization,
   ))
   useSubmitPaymentData(submitCallback)
   let paymentMethod = paymentMethodDetails.methodType

--- a/src/Payments/PazeButton.res
+++ b/src/Payments/PazeButton.res
@@ -6,7 +6,7 @@ let make = (~token: SessionsType.token) => {
   let url = RescriptReactRouter.useUrl()
   let componentName = CardUtils.getQueryParamsDictforKey(url.search, "componentName")
 
-  let {iframeId, publishableKey, clientSecret} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, publishableKey, clientSecret, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let updateSession = Recoil.useRecoilValueFromAtom(updateSession)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -93,7 +93,7 @@ let make = (~token: SessionsType.token) => {
     setIsShowOrPayUsing(_ => true)
     Window.addEventListener("message", handlePazeCallback)
     Some(() => Window.removeEventListener("message", handlePazeCallback))
-  }, [])
+  }, [sdkAuthorization])
   <button
     disabled={showLoader}
     onClick

--- a/src/Payments/SepaBankDebit.res
+++ b/src/Payments/SepaBankDebit.res
@@ -7,6 +7,7 @@ let make = () => {
 
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
+  let {sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let {config, themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let {displaySavedPaymentMethods, layout} = Recoil.useRecoilValueFromAtom(optionAtom)
   let layoutClass = CardUtils.getLayoutClass(layout)
@@ -56,7 +57,13 @@ let make = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (isManualRetryEnabled, areRequiredFieldsValid, areRequiredFieldsEmpty, requiredFieldsBody))
+  }, (
+    isManualRetryEnabled,
+    areRequiredFieldsValid,
+    areRequiredFieldsEmpty,
+    requiredFieldsBody,
+    sdkAuthorization,
+  ))
 
   useSubmitPaymentData(submitCallback)
 

--- a/src/Payments/SepaBankTransfer.res
+++ b/src/Payments/SepaBankTransfer.res
@@ -3,7 +3,7 @@ open Utils
 
 @react.component
 let make = () => {
-  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {iframeId, sdkAuthorization} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let {layout} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -43,7 +43,13 @@ let make = () => {
         postFailedSubmitResponse(~errortype="validation_error", ~message="Please enter all fields")
       }
     }
-  }, (areRequiredFieldsValid, areRequiredFieldsEmpty, isManualRetryEnabled, requiredFieldsBody))
+  }, (
+    areRequiredFieldsValid,
+    areRequiredFieldsEmpty,
+    isManualRetryEnabled,
+    requiredFieldsBody,
+    sdkAuthorization,
+  ))
   useSubmitPaymentData(submitCallback)
 
   let paymentMethodType = "sepa_bank_transfer"

--- a/src/Utilities/SamsungPayHelpers.res
+++ b/src/Utilities/SamsungPayHelpers.res
@@ -72,7 +72,7 @@ let useHandleSamsungPayResponse = (
   ~isWallet=true,
 ) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
-  let {publishableKey} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let {publishableKey, sdkAuthorization} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(RecoilAtoms.isManualRetryEnabled)
 
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
@@ -118,5 +118,5 @@ let useHandleSamsungPayResponse = (
     }
     Window.addEventListener("message", handleSamsung)
     Some(() => {Window.removeEventListener("message", handleSamsung)})
-  }, (isSavedMethodsFlow, isManualRetryEnabled, isWallet))
+  }, (isSavedMethodsFlow, isManualRetryEnabled, isWallet, sdkAuthorization))
 }


### PR DESCRIPTION
## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
#1575 
After an `updateIntent` flow completes, the SDK returns a new `sdkAuthorization`. All subsequent confirm calls must use this updated token. Inside the iframe, `usePaymentIntent` reads `sdkAuthorization` from the Recoil `keys` atom at render time and closes over it in the returned `intent` function. Each payment method component memoizes its `submitCallback` via `React.useCallback` — if `sdkAuthorization` is not in the dependency array, the callback captures a stale `intent` with the old token even after the Recoil atom is updated.

**Root cause:** `sdkAuthorization` was missing from the `useCallback` dependency array in all payment method `submitCallback` hooks. This caused the confirm API call to be made with the pre-`updateIntent` authorization token, resulting in an auth failure.

**Fix:** Added `sdkAuthorization` (from the `keys` Recoil atom) to the `useCallback` dependency array in all affected payment method components. For components that did not already destructure `sdkAuthorization` from `keys`, the destructuring was updated accordingly.

## How did you test it?

Tested manually using the Hyperswitch React Demo App:
1. Loaded the payment form with EPS selected (required fields pre-filled, no user input needed)
2. Clicked **"update use elements + confirm"** — which calls `elements.updateIntent(...)` then `hyper.confirmPayment(...)`
3. **Before fix:** confirm API call used the old `sdkAuthorization`, resulting in an auth error
4. **After fix:** confirm API call correctly used the new `sdkAuthorization` returned by `updateIntent`, payment proceeded successfully
Also verified the same flow with Trustly (no required fields) and other bank redirect / bank debit / bank transfer payment methods continued to work correctly.

https://github.com/user-attachments/assets/e44d5d77-b9f4-46c8-bcbf-63b524adff99


## Checklist
- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible