### PR TITLE
fix: added floating labels support to saved screen

### DIFF
--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -169,21 +169,27 @@ let make = (
 
   let billingDetailsArrayLength = Array.length(billingDetailsArray)
 
-  let cvcInputElement =
+  let isFloating = config.appearance.labels == Floating
+  let cvcContainerClassName = isFloating ? "flex w-24" : "flex w-16 opacity-50"
+  let cvcHeight = isFloating ? "" : "1.8rem"
+  let cvcFieldName = isFloating ? localeString.cvcTextLabel : ""
+
+  let makeCvcInput = (~fieldName="", ~height="1.8rem", ~inputFieldClassName="flex justify-start") =>
     <PaymentInputField
+      fieldName
       isValid=isCVCValid
       setIsValid=setIsCVCValid
       value=cvcNumber
       onChange=changeCVCNumber
       onBlur=handleCVCBlur
       errorString=""
-      inputFieldClassName="flex justify-start"
+      inputFieldClassName
       type_="tel"
-      className={`tracking-widest justify-start w-full`}
+      className={`tracking-widest w-full`}
       maxLength=4
       inputRef=cvcRef
       placeholder="123"
-      height="1.8rem"
+      height
       name={TestUtils.cardCVVInputTestId}
       autocomplete="cc-csc"
     />
@@ -264,10 +270,18 @@ let make = (
             </RenderIf>
             <RenderIf condition={hideCardExpiry && isActive && isRenderCvv}>
               <div className="flex flex-row items-center gap-2 mr-2">
-                <div className="tracking-widest opacity-50">
-                  {React.string(`${localeString.cvcTextLabel}:`)}
+                <RenderIf condition={!isFloating}>
+                  <div className="tracking-widest opacity-50">
+                    {React.string(`${localeString.cvcTextLabel}:`)}
+                  </div>
+                </RenderIf>
+                <div className={cvcContainerClassName}>
+                  {makeCvcInput(
+                    ~fieldName=cvcFieldName,
+                    ~height=cvcHeight,
+                    ~inputFieldClassName="",
+                  )}
                 </div>
-                <div className="flex w-16 opacity-50"> cvcInputElement </div>
               </div>
             </RenderIf>
           </div>
@@ -284,7 +298,7 @@ let make = (
                     className={`flex h mx-4 justify-start w-16 ${isActive
                         ? "opacity-1 mt-4"
                         : "opacity-0"}`}>
-                    cvcInputElement
+                    {makeCvcInput()}
                   </div>
                 </div>
               </RenderIf>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds floating label support for the inline CVC field shown on saved card items when `savedMethodCustomization.hideCardExpiry: true` and `appearance.labels: "floating"` are both configured.
Previously, the CVC input in this flow always rendered with a static external label regardless of the `appearance.labels` setting. This change brings it in line with how `CardElement` handles floating labels.
## Changes
**`src/Components/SavedCardItem.res`**
- Replaced the standalone `cvcInputElement` binding and a separate `makeCvcInput` helper with a single unified `makeCvcInput` function that accepts optional `~fieldName`, `~height`, and `~inputFieldClassName` parameters, eliminating prop duplication.
- In the `hideCardExpiry && isActive && isRenderCvv` render block, added a conditional branch on `config.appearance.labels`:
  - **`Floating`**: renders `makeCvcInput` with `fieldName=localeString.cvcTextLabel`, no explicit height (natural CSS-controlled height), and no `inputFieldClassName` override — matching the `CardCVCElement` reference implementation exactly.
  - **`Above` / `Never`**: renders the existing static external label with the compact `1.8rem` height input, unchanged.
## What is intentionally not changed
- The `!hideCardExpiry` CVC path — left unchanged to avoid affecting existing merchants.
- `SavedMethodItemV2.res` — out of scope for this change.
- `CardCVCElement.res` — already supports floating labels correctly, no changes needed.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
| Scenario | Expected |
|---|---|
| `labels: "floating"` + `hideCardExpiry: true` | CVC label animates inside input on focus |
| `labels: "above"` + `hideCardExpiry: true` | Static external label, no change |
| `labels: "never"` + `hideCardExpiry: true` | No label, no change |
| `hideCardExpiry: false` (any `labels` value) | Unaffected |

<img width="483" height="297" alt="Screenshot 2026-05-22 at 11 42 57 AM" src="https://github.com/user-attachments/assets/f2abe3d9-011c-4603-afc2-17d98c1d54f3" />
<img width="476" height="282" alt="Screenshot 2026-05-22 at 11 43 16 AM" src="https://github.com/user-attachments/assets/f7b0c448-218e-4244-a292-1d0626cde4ae" />

### Passing hideCardExpiry = false
<img width="504" height="337" alt="Screenshot 2026-05-22 at 11 43 54 AM" src="https://github.com/user-attachments/assets/17be87e6-f7e4-4540-9055-ccd41a363f48" />

### Not passing labels = floating
<img width="474" height="303" alt="Screenshot 2026-05-22 at 11 45 05 AM" src="https://github.com/user-attachments/assets/e854338d-d8c3-49ba-9ec7-6a3e225d09f5" />

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
