### PR TITLE
[DRAFT] fix: malformed redirect url when return_url has query params

### DIFF
--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -3,6 +3,7 @@ open ErrorUtils
 open Identity
 open Utils
 open EventListenerManager
+open URLModule
 
 type trustPayFunctions = {
   finishApplePaymentV2: (string, ApplePayTypes.paymentRequestData, string) => promise<JSON.t>,
@@ -809,7 +810,10 @@ let make = (
             let dict = json->getDictFromJson
             let status = dict->getString("status", "")
             let returnUrl = dict->getString("return_url", "")
-            let redirectUrl = `${returnUrl}?payment_intent_client_secret=${clientSecretRef.contents}&status=${status}`
+            let url = makeUrl(returnUrl)
+            url.searchParams.set("payment_intent_client_secret", clientSecretRef.contents)
+            url.searchParams.set("status", status)
+            let redirectUrl = url.href
             if redirect.contents === "always" {
               Utils.replaceRootHref(redirectUrl, redirectionFlags)
               resolve(JSON.Encode.null)


### PR DESCRIPTION
When poll status completes in Elements, the redirect URL was built by appending `?payment_intent_client_secret=...&status=...` to return_url. If return_url already contained query parameters, this produced a malformed URL with two `?` characters.

Use URLModule.makeUrl and searchParams.set instead, matching the approach already used in PaymentHelpers.

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

In `Elements.res`, poll-status redirect URLs were built via string
concatenation:

`return_url + "?payment_intent_client_secret=...&status=..."`

When `return_url` already had query params (e.g. `https://example.com?a=b&c=d`), the result was malformed: `https://example.com?a=b&c=d?payment_intent_client_secret=...&status=...`

This change builds the URL with `makeUrl` and `searchParams.set`, consistent with `PaymentHelpers.res`.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
