### PR TITLE
feat: added cvcIcon prop

### DIFF
--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -674,9 +674,17 @@ let postalRegex = (postalCodes: array<PostalCodeType.postalCodes>, ~country=?) =
   countryPostal.regex
 }
 
-let setRightIconForCvc = (~cardEmpty, ~cardInvalid, ~color, ~cardComplete) => {
+let setRightIconForCvc = (
+  ~cardEmpty,
+  ~cardInvalid,
+  ~color,
+  ~cardComplete,
+  ~cvcIcon: PaymentType.cvcIconStyle=Default,
+) => {
   open Utils
-  if cardEmpty {
+  if cvcIcon === Hidden {
+    React.null
+  } else if cardEmpty {
     <Icon size=brandIconSize name="cvc-empty" />
   } else if cardInvalid {
     <div style={color: color}>

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -46,7 +46,7 @@ let make = (
     None
   }, [paymentMethodType])
 
-  let {billingAddress, redirectionInfo} = Recoil.useRecoilValueFromAtom(optionAtom)
+  let {billingAddress, redirectionInfo, cvcIcon} = Recoil.useRecoilValueFromAtom(optionAtom)
 
   //<...>//
   let paymentMethodTypes = PaymentUtils.usePaymentMethodTypeFromList(
@@ -388,6 +388,7 @@ let make = (
                 ~cardInvalid,
                 ~color=themeObj.colorIconCardCvcError,
                 ~cardComplete,
+                ~cvcIcon,
               )}
               type_="tel"
               className="tracking-widest w-full"
@@ -427,6 +428,7 @@ let make = (
                   ~cardInvalid,
                   ~color=themeObj.colorIconCardCvcError,
                   ~cardComplete,
+                  ~cvcIcon,
                 )}
                 type_="tel"
                 className="tracking-widest w-full"

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -546,6 +546,7 @@ let make = (
                     ~cardEmpty,
                     ~cardInvalid,
                     ~color=themeObj.colorIconCardCvcError,
+                    ~cvcIcon=options.cvcIcon,
                   )}
                   type_="tel"
                   className={`tracking-widest w-full ${compressedLayoutStyleForCvcError}`}

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -1,3 +1,4 @@
+type cvcIconStyle = Default | Hidden
 type showTerms = Auto | Always | Never
 type paymentMethodsArrangementForTabs = Default | Grid
 type showType = Auto | Never
@@ -279,6 +280,7 @@ type options = {
   hideExpiredPaymentMethods: bool,
   displayDefaultSavedPaymentIcon: bool,
   hideCardNicknameField: bool,
+  cvcIcon: cvcIconStyle,
   displayBillingDetails: bool,
   customMessageForCardTerms: string,
   showShortSurchargeMessage: bool,
@@ -474,6 +476,7 @@ let defaultOptions = {
   hideExpiredPaymentMethods: false,
   displayDefaultSavedPaymentIcon: true,
   hideCardNicknameField: false,
+  cvcIcon: Default,
   displayBillingDetails: false,
   customMessageForCardTerms: "",
   showShortSurchargeMessage: false,
@@ -1572,6 +1575,7 @@ let allowedPaymentElementOptions = [
   "branding",
   "displayDefaultSavedPaymentIcon",
   "hideCardNicknameField",
+  "cvcIcon",
   "displayBillingDetails",
   "customMessageForCardTerms",
   "showShortSurchargeMessage",
@@ -1614,6 +1618,17 @@ let sanitizePreloadSdkParms = dict => {
   ->JSON.Encode.object
   ->(Utils.maskStringValuesInJson(~value=_, ~currentPath="", ~depth=0, ~shouldMaskField=_ => true))
   ->getDictFromJson
+}
+
+let getCvcIconStyle = (str): cvcIconStyle => {
+  switch str {
+  | "hidden" => Hidden
+  | "" | "default" => Default
+  | str => {
+      str->unknownPropValueWarning(["hidden", "default"], "options.cvcIcon")
+      Default
+    }
+  }
 }
 
 let itemToObjMapper = (dict, logger: HyperLoggerTypes.loggerMake) => {
@@ -1668,6 +1683,7 @@ let itemToObjMapper = (dict, logger: HyperLoggerTypes.loggerMake) => {
     hideExpiredPaymentMethods: getBool(dict, "hideExpiredPaymentMethods", false),
     displayDefaultSavedPaymentIcon: getBool(dict, "displayDefaultSavedPaymentIcon", true),
     hideCardNicknameField: getBool(dict, "hideCardNicknameField", false),
+    cvcIcon: getWarningString(dict, "cvcIcon", "", ~logger)->getCvcIconStyle,
     displayBillingDetails: getBool(dict, "displayBillingDetails", false),
     customMessageForCardTerms: getString(dict, "customMessageForCardTerms", ""),
     showShortSurchargeMessage: getBool(dict, "showShortSurchargeMessage", false),


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Adds a new merchant-facing `cvcIcon` option to the Payment Element that allows hiding the CVC/CVV icon inside the CVC input field.
### Usage
```js
elements.create("payment", {
  cvcIcon: "hidden"   // hides the CVC icon
  // cvcIcon: "default" or omit — shows the icon (default behaviour)
})
```
### Changes
src/Types/PaymentType.res
- Defined a new cvcIconStyle variant type: DefaultCvcIcon | HiddenCvcIcon
- Added cvcIcon: cvcIconStyle to the options record
- Added cvcIcon: DefaultCvcIcon to defaultOptions
- Added "cvcIcon" to allowedPaymentElementOptions
- Added getCvcIconStyle parser with unknownPropValueWarning for invalid values
- Used getWarningString (consistent with redirectionInfo, branding patterns) in itemToObjMapper
src/CardUtils.res
- Added optional ~cvcIcon: PaymentType.cvcIconStyle=DefaultCvcIcon parameter to setRightIconForCvc
- Returns React.null when cvcIcon is HiddenCvcIcon
src/Payments/CardPayment.res
- Passes ~cvcIcon=options.cvcIcon to setRightIconForCvc
src/Components/DynamicFields.res
- Destructures cvcIcon from optionAtom
- Passes ~cvcIcon to both setRightIconForCvc call sites (CardCvc and CardExpiryAndCvc branches)

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

### cvcIcon: "default"

<img width="488" height="326" alt="Screenshot 2026-05-25 at 3 49 59 PM" src="https://github.com/user-attachments/assets/f315ab51-2c56-4a7f-9497-8ba8e257649a" />

### cvcIcon: "hidden"
<img width="485" height="440" alt="Screenshot 2026-05-25 at 3 50 41 PM" src="https://github.com/user-attachments/assets/8d5747ba-f63f-4cd7-88eb-0c8e7b73a6fb" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
