### PR TITLE
feat: added card brand icon and changed location of cvc icon

### DIFF
--- a/src/CardSchemeComponent.res
+++ b/src/CardSchemeComponent.res
@@ -53,8 +53,12 @@ let make = (
   let marginLeft = isCardCoBadged ? "-ml-2" : ""
 
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
+  let {layout} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let cardBrandIconSetting = CardUtils.getLayoutClass(layout).cardBrandIcon
   let shouldShowCoBadgeCardSchemeDropDown =
     isCardCoBadged && cardNumber->CardValidations.clearSpaces->String.length >= 16
+
+  let showCardBrandIcon = CardUtils.getCardBrandIconVisibility(cardBrandIconSetting, cardType)
 
   React.useEffect1(() => {
     if shouldShowCoBadgeCardSchemeDropDown && !isCoBadgedCardDetectedOnce.current {
@@ -65,7 +69,7 @@ let make = (
   }, [shouldShowCoBadgeCardSchemeDropDown])
 
   <div className={`${animate} flex items-center ${marginLeft} hellow-rodl`}>
-    cardBrandIcon
+    <RenderIf condition={showCardBrandIcon}> cardBrandIcon </RenderIf>
     <RenderIf condition={shouldShowCoBadgeCardSchemeDropDown}>
       <CoBadgeCardSchemeDropDown eligibleCardSchemes setCardBrand />
     </RenderIf>

--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -658,6 +658,17 @@ let getLayoutClass = layout => {
   }
 }
 
+let getCardBrandIconVisibility = (
+  cardBrandIconSetting: PaymentType.cardBrandIconStyle,
+  cardType,
+) => {
+  switch cardBrandIconSetting {
+  | Standard | Animated => true // Animated is reserved for future use; behaves like Standard for now
+  | Hidden => false
+  | HideDefault => cardType != NOTFOUND
+  }
+}
+
 let getAllBanknames = obj => {
   obj->Array.reduce([], (acc, item) => {
     item->Array.map(val => acc->Array.push(val))->ignore

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -46,7 +46,9 @@ let make = (
     None
   }, [paymentMethodType])
 
-  let {billingAddress, redirectionInfo, cvcIcon} = Recoil.useRecoilValueFromAtom(optionAtom)
+  let {billingAddress, redirectionInfo, layout} = Recoil.useRecoilValueFromAtom(optionAtom)
+  let layoutClass = CardUtils.getLayoutClass(layout)
+  let cvcIcon = layoutClass.cvcIcon
 
   //<...>//
   let paymentMethodTypes = PaymentUtils.usePaymentMethodTypeFromList(

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -546,7 +546,7 @@ let make = (
                     ~cardEmpty,
                     ~cardInvalid,
                     ~color=themeObj.colorIconCardCvcError,
-                    ~cvcIcon=options.cvcIcon,
+                    ~cvcIcon=layoutClass.cvcIcon,
                   )}
                   type_="tel"
                   className={`tracking-widest w-full ${compressedLayoutStyleForCvcError}`}

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -1,4 +1,5 @@
 type cvcIconStyle = Default | Hidden
+type cardBrandIconStyle = Standard | Hidden | Animated | HideDefault
 type showTerms = Auto | Always | Never
 type paymentMethodsArrangementForTabs = Default | Grid
 type showType = Auto | Never
@@ -169,6 +170,8 @@ type layoutConfig = {
   displayOneClickPaymentMethodsOnTop: bool,
   showCheckedIconForSelection: bool,
   separatorText: option<string>,
+  cvcIcon: cvcIconStyle,
+  cardBrandIcon: cardBrandIconStyle,
 }
 
 type layoutType =
@@ -280,7 +283,6 @@ type options = {
   hideExpiredPaymentMethods: bool,
   displayDefaultSavedPaymentIcon: bool,
   hideCardNicknameField: bool,
-  cvcIcon: cvcIconStyle,
   displayBillingDetails: bool,
   customMessageForCardTerms: string,
   showShortSurchargeMessage: bool,
@@ -358,6 +360,8 @@ let defaultLayout = {
   displayOneClickPaymentMethodsOnTop: true,
   showCheckedIconForSelection: false,
   separatorText: None,
+  cvcIcon: Default,
+  cardBrandIcon: Standard,
 }
 
 let defaultAddress: address = {
@@ -476,7 +480,6 @@ let defaultOptions = {
   hideExpiredPaymentMethods: false,
   displayDefaultSavedPaymentIcon: true,
   hideCardNicknameField: false,
-  cvcIcon: Default,
   displayBillingDetails: false,
   customMessageForCardTerms: "",
   showShortSurchargeMessage: false,
@@ -579,6 +582,33 @@ let getPaymentMethodsArrangementForTabs = str => {
   | str => {
       str->unknownPropValueWarning(["grid", "default"], "options.paymentMethodsArrangementForTabs")
       Default
+    }
+  }
+}
+
+let getCvcIconStyle = (str): cvcIconStyle => {
+  switch str {
+  | "hidden" => Hidden
+  | "" | "default" => Default
+  | str => {
+      str->unknownPropValueWarning(["hidden", "default"], "options.layout.cvcIcon")
+      Default
+    }
+  }
+}
+
+let getCardBrandIconStyle = (str): cardBrandIconStyle => {
+  switch str {
+  | "hidden" => Hidden
+  | "animated" => Animated
+  | "hideDefault" => HideDefault
+  | "" | "standard" => Standard
+  | str => {
+      str->unknownPropValueWarning(
+        ["standard", "hidden", "animated", "hideDefault"],
+        "options.layout.cardBrandIcon",
+      )
+      Standard
     }
   }
 }
@@ -957,6 +987,8 @@ let getLayoutValues = (val, logger) => {
           "displayOneClickPaymentMethodsOnTop",
           "showCheckedIconForSelection",
           "separatorText",
+          "cvcIcon",
+          "cardBrandIcon",
         ],
         json,
         "options.layout",
@@ -986,6 +1018,13 @@ let getLayoutValues = (val, logger) => {
           ~logger,
         ),
         separatorText: getOptionString(json, "separatorText"),
+        cvcIcon: getWarningString(json, "cvcIcon", "", ~logger)->getCvcIconStyle,
+        cardBrandIcon: getWarningString(
+          json,
+          "cardBrandIcon",
+          "standard",
+          ~logger,
+        )->getCardBrandIconStyle,
       }
     })
   | _ => StringLayout(Tabs)
@@ -1575,7 +1614,6 @@ let allowedPaymentElementOptions = [
   "branding",
   "displayDefaultSavedPaymentIcon",
   "hideCardNicknameField",
-  "cvcIcon",
   "displayBillingDetails",
   "customMessageForCardTerms",
   "showShortSurchargeMessage",
@@ -1618,17 +1656,6 @@ let sanitizePreloadSdkParms = dict => {
   ->JSON.Encode.object
   ->(Utils.maskStringValuesInJson(~value=_, ~currentPath="", ~depth=0, ~shouldMaskField=_ => true))
   ->getDictFromJson
-}
-
-let getCvcIconStyle = (str): cvcIconStyle => {
-  switch str {
-  | "hidden" => Hidden
-  | "" | "default" => Default
-  | str => {
-      str->unknownPropValueWarning(["hidden", "default"], "options.cvcIcon")
-      Default
-    }
-  }
 }
 
 let itemToObjMapper = (dict, logger: HyperLoggerTypes.loggerMake) => {
@@ -1683,7 +1710,6 @@ let itemToObjMapper = (dict, logger: HyperLoggerTypes.loggerMake) => {
     hideExpiredPaymentMethods: getBool(dict, "hideExpiredPaymentMethods", false),
     displayDefaultSavedPaymentIcon: getBool(dict, "displayDefaultSavedPaymentIcon", true),
     hideCardNicknameField: getBool(dict, "hideCardNicknameField", false),
-    cvcIcon: getWarningString(dict, "cvcIcon", "", ~logger)->getCvcIconStyle,
     displayBillingDetails: getBool(dict, "displayBillingDetails", false),
     customMessageForCardTerms: getString(dict, "customMessageForCardTerms", ""),
     showShortSurchargeMessage: getBool(dict, "showShortSurchargeMessage", false),


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a new `cardBrandIcon` prop inside the `layout` configuration to give merchants control over card brand icon visibility in the card number input. Also moves `cvcIcon` from the top-level `options` object into `layout` for a more cohesive icon configuration API.
## Prop Structure
```js
const paymentElementOptions = {
  layout: {
    cvcIcon: "default",        // "default" | "hidden"
    cardBrandIcon: "standard", // "standard" | "hidden" | "animated" | "hideDefault"
  }
}
```
## `cardBrandIcon` Values
| Value | Behaviour |
|---|---|
| `"standard"` | *(Default)* Always shows the card brand icon; shows placeholder when no brand is detected |
| `"hidden"` | Hides all card brand icons at all times |
| `"animated"` | Reserved for future use; currently behaves identically to `"standard"` |
| `"hideDefault"` | Hides the placeholder icon when no brand is detected; shows the icon once a brand is identified |
## Changes
- **`src/Types/PaymentType.res`** — Added `type cardBrandIconStyle = Standard | Hidden | Animated | HideDefault`; added `cvcIcon` and `cardBrandIcon` fields to `layoutConfig` and `defaultLayout`; removed both from top-level `options`; added parsers with correct warning paths (`options.layout.cvcIcon`, `options.layout.cardBrandIcon`)
- **`src/CardUtils.res`** — Added `getCardBrandIconVisibility(cardBrandIconSetting, cardType)` helper function
- **`src/CardSchemeComponent.res`** — Reads `cardBrandIcon` from layout via `getLayoutClass`; uses `getCardBrandIconVisibility` to conditionally render the icon; co-badge dropdown is unaffected
- **`src/Payments/CardPayment.res`** — Sources `cvcIcon` from `getLayoutClass(options.layout).cvcIcon`
- **`src/Components/DynamicFields.res`** — Sources `cvcIcon` from `getLayoutClass(layout).cvcIcon`

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

https://github.com/user-attachments/assets/a138f607-f0da-4b3e-a885-886e226e681f


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
