### PR TITLE
fix: renamed hide default to hide generic

### DIFF
--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -665,7 +665,7 @@ let getCardBrandIconVisibility = (
   switch cardBrandIconSetting {
   | Standard | Animated => true // Animated is reserved for future use; behaves like Standard for now
   | Hidden => false
-  | HideDefault => cardType != NOTFOUND
+  | HideGeneric => cardType != NOTFOUND
   }
 }
 

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -1,5 +1,5 @@
 type cvcIconStyle = Default | Hidden
-type cardBrandIconStyle = Standard | Hidden | Animated | HideDefault
+type cardBrandIconStyle = Standard | Hidden | Animated | HideGeneric
 type showTerms = Auto | Always | Never
 type paymentMethodsArrangementForTabs = Default | Grid
 type showType = Auto | Never
@@ -601,11 +601,11 @@ let getCardBrandIconStyle = (str): cardBrandIconStyle => {
   switch str {
   | "hidden" => Hidden
   | "animated" => Animated
-  | "hideDefault" => HideDefault
+  | "hideGeneric" => HideGeneric
   | "" | "standard" => Standard
   | str => {
       str->unknownPropValueWarning(
-        ["standard", "hidden", "animated", "hideDefault"],
+        ["standard", "hidden", "animated", "hideGeneric"],
         "options.layout.cardBrandIcon",
       )
       Standard


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

## Description
Renames the `cardBrandIcon` prop value from `"hideDefault"` to `"hideGeneric"` for better clarity and API consistency.
`"hideDefault"` was misleading — "default" implies the default behaviour or mode, not the generic placeholder icon. `"hideGeneric"` precisely describes what is being hidden: the generic/placeholder card silhouette shown before any card brand is detected.
## Change
```js
// Before
cardBrandIcon: "hideDefault"
// After
cardBrandIcon: "hideGeneric"
```
## Full Prop Reference
```js
const paymentElementOptions = {
  layout: {
    cardBrandIcon: "standard", // "standard" | "hidden" | "animated" | "hideGeneric"
  }
}
```

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

https://github.com/user-attachments/assets/c4accdf1-942f-4654-8ceb-0fd6007245ee


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
