### PR TITLE
fix: malformed redirect url when return_url has query params

### DIFF
--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -3,6 +3,7 @@ open ErrorUtils
 open Identity
 open Utils
 open EventListenerManager
+open URLModule
 
 type trustPayFunctions = {
   finishApplePaymentV2: (string, ApplePayTypes.paymentRequestData, string) => promise<JSON.t>,
@@ -811,7 +812,10 @@ let make = (
             let dict = json->getDictFromJson
             let status = dict->getString("status", "")
             let returnUrl = dict->getString("return_url", "")
-            let redirectUrl = `${returnUrl}?payment_intent_client_secret=${clientSecretRef.contents}&status=${status}`
+            let url = makeUrl(returnUrl)
+            url.searchParams.set("payment_intent_client_secret", clientSecretRef.contents)
+            url.searchParams.set("status", status)
+            let redirectUrl = url.href
             if redirect.contents === "always" {
               Utils.replaceRootHref(redirectUrl, redirectionFlags)
               resolve(JSON.Encode.null)


### PR DESCRIPTION
Fixes #1598

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes malformed post-poll-status redirect URLs in Elements when `return_url` already contains query parameters.

## Problem

In `handleRetrievePaymentResponse` (`Elements.res`), the redirect URL was built with string concatenation:

```rescript
`${returnUrl}?payment_intent_client_secret=...&status=...`