### PR TITLE
fix: user gesture fix for trustpay applepay

### DIFF
--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -286,17 +286,15 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
           if isInvokeSDKFlow {
             if isApplePayDelayedSessionFlow {
               setShowApplePayLoader(_ => true)
-              let bodyDict = PaymentBody.applePayThirdPartySdkBody(~connectors)
-              ApplePayHelpers.processPayment(
-                ~bodyArr=bodyDict,
-                ~isThirdPartyFlow=true,
-                ~isGuestCustomer,
-                ~paymentMethodListValue,
-                ~intent,
-                ~options,
-                ~publishableKey,
-                ~isManualRetryEnabled,
-              )
+              // New flow: send the initial session token directly to Elements (parent).
+              // Do NOT call /confirm here — the ApplePayInterceptor will trigger the
+              // confirm call from inside the iframe during onvalidatemerchant.
+              let sessionData = sessionObj->getOptionsDict->JSON.Encode.object
+              messageParentWindow([
+                ("applePayButtonClicked", true->JSON.Encode.bool),
+                ("applePayPresent", sessionData),
+                ("componentName", componentName->JSON.Encode.string),
+              ])
             } else {
               ApplePayHelpers.handleApplePayButtonClicked(
                 ~sessionObj,

--- a/src/Payments/PaymentMethodsRecord.res
+++ b/src/Payments/PaymentMethodsRecord.res
@@ -1228,7 +1228,9 @@ let itemToObjMapper = dict => {
     isGuestCustomer: getOptionBool(dict, "is_guest_customer"),
     intent_data: dict->getIntentData,
     sdk_next_action: dict->getDictFromDict("sdk_next_action")->getOptionString("next_action"),
-    should_block_confirm: dict->getDictFromDict("sdk_next_action")->getBool("should_block_confirm", false),
+    should_block_confirm: dict
+    ->getDictFromDict("sdk_next_action")
+    ->getBool("should_block_confirm", false),
   }
 }
 

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -12,6 +12,7 @@ let processPayment = (
   ~options: PaymentType.options,
   ~publishableKey,
   ~isManualRetryEnabled,
+  ~isTrustpayInterceptorConfirm=false,
 ) => {
   let requestBody = PaymentUtils.appendedCustomerAcceptance(
     ~isGuestCustomer,
@@ -29,6 +30,7 @@ let processPayment = (
     ~handleUserError=true,
     ~isThirdPartyFlow,
     ~manualRetry=isManualRetryEnabled,
+    ~isTrustpayInterceptorConfirm,
   )
 }
 
@@ -276,6 +278,29 @@ let useHandleApplePayResponse = (
           processPayment(
             ~bodyArr=PaymentBody.applePayThirdPartySdkBody(~connectors, ~token),
             ~isThirdPartyFlow=true,
+            ~isGuestCustomer,
+            ~paymentMethodListValue,
+            ~intent,
+            ~options,
+            ~publishableKey,
+            ~isManualRetryEnabled,
+          )
+        } else if dict->Dict.get("applePayConfirmRequest")->Option.isSome {
+          // The interceptor in the parent window is asking us to call /confirm and
+          // return the TrustPay secrets so it can swap them into TrustPay's
+          // merchant-validation FormData. Reuse processPayment so the confirm goes
+          // through PaymentHelpers; intentCall posts "applePayConfirmSecrets" back to
+          // the parent for the interceptor flow (~isTrustpayInterceptorConfirm=true).
+          logger.setLogInfo(
+            ~value="[ApplePayInterceptor] applePayConfirmRequest received — calling /confirm",
+            ~eventName=APPLE_PAY_FLOW,
+            ~paymentMethod="APPLE_PAY",
+          )
+
+          processPayment(
+            ~bodyArr=PaymentBody.applePayThirdPartySdkBody(~connectors),
+            ~isThirdPartyFlow=true,
+            ~isTrustpayInterceptorConfirm=true,
             ~isGuestCustomer,
             ~paymentMethodListValue,
             ~intent,

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -353,6 +353,7 @@ let rec intentCall = (
   ~redirectionFlags,
   ~sdkAuthorization=None,
   ~mode: CardThemeType.mode=NONE,
+  ~isTrustpayInterceptorConfirm=false,
 ) => {
   open Promise
   let isConfirm = uri->String.includes("/confirm")
@@ -820,11 +821,21 @@ let rec intentCall = (
                 let walletName = session_token->getString("wallet_name", "")
 
                 let message = switch walletName {
-                | "apple_pay" => [
-                    ("applePayButtonClicked", true->JSON.Encode.bool),
-                    ("applePayPresent", session_token->anyTypeToJson),
-                    ("componentName", componentName->JSON.Encode.string),
-                  ]
+                | "apple_pay" =>
+                  if isTrustpayInterceptorConfirm {
+                    let secrets =
+                      session_token
+                      ->getDictFromDict("session_token_data")
+                      ->Dict.get("secrets")
+                      ->Option.getOr(JSON.Encode.null)
+                    [("applePayConfirmSecrets", secrets)]
+                  } else {
+                    [
+                      ("applePayButtonClicked", true->JSON.Encode.bool),
+                      ("applePayPresent", session_token->anyTypeToJson),
+                      ("componentName", componentName->JSON.Encode.string),
+                    ]
+                  }
                 | "google_pay" => [("googlePayThirdPartyFlow", session_token->anyTypeToJson)]
                 | "open_banking" => {
                     let metaData = [
@@ -907,10 +918,20 @@ let rec intentCall = (
                 }
                 let walletName = session_token->getString("wallet_name", "")
                 let message = switch walletName {
-                | "apple_pay" => [
-                    ("applePayButtonClicked", true->JSON.Encode.bool),
-                    ("applePayPresent", session_token->anyTypeToJson),
-                  ]
+                | "apple_pay" =>
+                  if isTrustpayInterceptorConfirm {
+                    let secrets =
+                      session_token
+                      ->getDictFromDict("session_token_data")
+                      ->Dict.get("secrets")
+                      ->Option.getOr(JSON.Encode.null)
+                    [("applePayConfirmSecrets", secrets)]
+                  } else {
+                    [
+                      ("applePayButtonClicked", true->JSON.Encode.bool),
+                      ("applePayPresent", session_token->anyTypeToJson),
+                    ]
+                  }
                 | "google_pay" => [("googlePayThirdPartyFlow", session_token->anyTypeToJson)]
                 | _ => []
                 }
@@ -1308,6 +1329,7 @@ let usePaymentIntent = (optLogger, paymentType) => {
     ~isThirdPartyFlow=false,
     ~intentCallback=_ => (),
     ~manualRetry=false,
+    ~isTrustpayInterceptorConfirm=false,
   ) => {
     switch keys.clientSecret {
     | Some(clientSecret) =>
@@ -1412,6 +1434,7 @@ let usePaymentIntent = (optLogger, paymentType) => {
             ~componentName,
             ~redirectionFlags,
             ~sdkAuthorization=keys.sdkAuthorization->Utils.getNonEmptyOption,
+            ~isTrustpayInterceptorConfirm,
           )
           ->then(val => {
             intentCallback(val)
@@ -2041,6 +2064,7 @@ let usePostSessionTokens = (
     ~isThirdPartyFlow=false,
     ~intentCallback=_ => (),
     ~manualRetry as _=false,
+    ~isTrustpayInterceptorConfirm as _=false,
   ) => {
     switch keys.clientSecret {
     | Some(clientSecret) =>

--- a/src/Utilities/PaymentHelpersTypes.res
+++ b/src/Utilities/PaymentHelpersTypes.res
@@ -18,6 +18,7 @@ type paymentIntent = (
   ~isThirdPartyFlow: bool=?,
   ~intentCallback: Core__JSON.t => unit=?,
   ~manualRetry: bool=?,
+  ~isTrustpayInterceptorConfirm: bool=?,
 ) => unit
 
 type completeAuthorize = (

--- a/src/hyper-loader/ApplePayInterceptor.res
+++ b/src/hyper-loader/ApplePayInterceptor.res
@@ -1,0 +1,316 @@
+open Utils
+open Identity
+
+// Stores a callback that posts a message dict to the payment iframe.
+// Set by Elements.res when it handles the TrustPay delayed-session message, so the
+// interceptor can send "applePayConfirmRequest" back to the correct iframe during
+// onvalidatemerchant.
+//
+// WHY a callback instead of the DOM source window:
+//   The `source` field of a message event is a cross-origin WindowProxy.
+//   Wrapping it in `Some(...)` compiles to `Caml_option.some(x)` which reads
+//   `x.BS_PRIVATE_NESTED_SOME_NONE` — any property access on a cross-origin
+//   WindowProxy throws a SecurityError in browsers.  Storing a pre-bound closure
+//   that uses `mountedIframeRef->Window.iframePostMessage(...)` is the safe alternative.
+let postToIframeRef: ref<option<Dict.t<JSON.t> => unit>> = ref(None)
+
+let setPostToIframe = (fn: Dict.t<JSON.t> => unit) => {
+  postToIframeRef := Some(fn)
+}
+
+// Clears the stored iframe-post callback.
+// MUST be called from Elements.res in all three branches (.then / .catch / catch)
+// after finishApplePaymentV2 completes.  Without this, isInterceptModeActive()
+// permanently returns true after the first TrustPay session, causing every
+// subsequent Braintree Apple Pay session on the same page to be incorrectly
+// intercepted, have the confirm request time out (8 s), and abort.
+let clearPostToIframe = () => {
+  postToIframeRef := None
+}
+
+// Guards against two concurrent waitForConfirmResponse() invocations.
+// Fires if the user double-clicks the Apple Pay button before the first session
+// settles.  Without this, two window "message" listeners and two 8-second timers
+// would accumulate; both would resolve/reject on the same iframe reply, causing
+// the second proxy session to run enableFetchInterception and originalHandler
+// on a session that was already handled (or aborted) by the first.
+let waitingForConfirmRef: ref<bool> = ref(false)
+
+// Sends "applePayConfirmRequest" to the stored iframe and returns a Promise that
+// resolves with the secrets JSON once the iframe replies with "applePayConfirmSecrets".
+//
+// Fixes applied here:
+//   H-5 — times out after 8 seconds and cleans up the listener
+//
+// NOTE: postToIframeRef is intentionally NOT cleared inside cleanup().
+//   In the timeout / reject path, cleanup() runs first, then the proxy calls
+//   onInterceptFailure() → sendShowApplePayButtonToIframe().  If postToIframeRef
+//   were cleared in cleanup(), the reset message could not be delivered (H-6).
+//   sendShowApplePayButtonToIframe() clears it afterwards.  clearPostToIframe()
+//   in Elements.res is a safe no-op double-clear on normal completion.
+// Implementation injected by AppleHacks.js
+let waitForConfirmResponse = (): promise<JSON.t> => {
+  open Promise
+  make((resolve, reject) => {
+    if waitingForConfirmRef.contents {
+      reject(
+        Exn.anyToExnInternal(
+          "[ApplePayInterceptor] Already waiting for applePayConfirmSecrets — ignoring concurrent call",
+        ),
+      )
+    } else {
+      waitingForConfirmRef := true
+
+      let handlerRef: ref<option<Types.event => unit>> = ref(None)
+      let timerIdRef = ref(None)
+
+      let cleanup = () => {
+        waitingForConfirmRef := false
+        switch handlerRef.contents {
+        | Some(h) => Window.removeEventListener("message", h)
+        | None => ()
+        }
+        switch timerIdRef.contents {
+        | Some(id) => clearTimeout(id)
+        | None => ()
+        }
+      }
+
+      let handler = (ev: Types.event) => {
+        let dict = ev.data->anyTypeToJson->getDictFromJson
+        switch dict->Dict.get("applePayConfirmSecrets") {
+        | Some(secrets) =>
+          cleanup()
+          if secrets == JSON.Encode.null {
+            reject(Exn.anyToExnInternal("[ApplePayInterceptor] Confirm call returned null secrets"))
+          } else {
+            resolve(secrets)
+          }
+        | None => ()
+        }
+      }
+      handlerRef := Some(handler)
+      Window.addEventListener("message", handler)
+
+      let timerId = setTimeout(() => {
+        cleanup()
+        reject(
+          Exn.anyToExnInternal(
+            "[ApplePayInterceptor] Timed out (8 s) waiting for applePayConfirmSecrets",
+          ),
+        )
+      }, 8000)
+      timerIdRef := Some(timerId)
+
+      switch postToIframeRef.contents {
+      | Some(postFn) => postFn([("applePayConfirmRequest", true->JSON.Encode.bool)]->Dict.fromArray)
+      | None =>
+        cleanup()
+        reject(
+          Exn.anyToExnInternal(
+            "[ApplePayInterceptor] No iframe post function stored — cannot request confirm",
+          ),
+        )
+      }
+    }
+  })
+}
+
+// Temporarily patches window.fetch to swap TrustPay's Secret.* fields in the
+// merchant-validation FormData with the new secrets received from /confirm.
+// Self-destructs after the first matching intercept.
+//
+// H-7 fix: also strips the plain "Secret" key (without a dot suffix).
+// Implementation injected by AppleHacks.js
+let enableFetchInterception: JSON.t => unit = %raw(`
+function enableFetchInterception(newSecret) {
+  var origFetch = window.fetch;
+  var fetchPatched = false;
+
+  window.fetch = function(url, options) {
+    if (
+      !fetchPatched &&
+      newSecret &&
+      options &&
+      options.method === "POST" &&
+      options.body instanceof FormData
+    ) {
+      var keys = Array.from(options.body.keys());
+      var hasSecretKey = keys.some(function(k) {
+        return k === "Secret" || k.startsWith("Secret.");
+      });
+
+      if (hasSecretKey && keys.includes("ValidationUrl")) {
+        fetchPatched = true;
+        window.fetch = origFetch; // self-destruct
+
+        var newBody = new FormData();
+        for (var _i = 0, _entries = options.body.entries(); ; ) {
+          var _ref = _entries.next();
+          if (_ref.done) break;
+          var entry = _ref.value;
+          if (entry[0] !== "Secret" && !entry[0].startsWith("Secret.")) {
+            newBody.append(entry[0], entry[1]);
+          }
+        }
+
+        if (typeof newSecret === "object" && newSecret !== null) {
+          for (var subKey in newSecret) {
+            if (Object.prototype.hasOwnProperty.call(newSecret, subKey)) {
+              newBody.append("Secret." + subKey, newSecret[subKey]);
+            }
+          }
+        } else {
+          newBody.append("Secret", String(newSecret));
+        }
+
+        return origFetch.call(this, url, Object.assign({}, options, { body: newBody }));
+      }
+    }
+    return origFetch.apply(this, arguments);
+  };
+}
+`)
+
+// The raw function receives the ReScript-compiled callbacks plus two guards:
+//   isInterceptModeActive — returns true only when postToIframeRef is set
+//                           (i.e., a TrustPay session is in progress).
+//                           Used to pass through non-TrustPay sessions (e.g. Braintree)
+//                           without intercepting (B-1 fix).
+//   onInterceptFailure    — called when the intercept fails so the iframe can
+//                           reset its button/loader (H-6 fix).
+// Implementation injected by AppleHacks.js
+let initApplePaySessionProxy: (
+  unit => promise<JSON.t>,
+  JSON.t => unit,
+  unit => bool,
+  unit => unit,
+) => unit = %raw(`
+function initApplePaySessionProxy(waitForConfirmResponse, enableFetchInterception, isInterceptModeActive, onInterceptFailure) {
+  if (typeof window === "undefined" || !window.ApplePaySession) {
+    console.warn("[ApplePayInterceptor] ApplePaySession not available, skipping proxy.");
+    return;
+  }
+  if (window.__applePayProxyInstalled) {
+    return;
+  }
+
+  var OrigSession = window.ApplePaySession;
+
+  function ProxyApplePaySession(version, paymentRequest) {
+    var target = new OrigSession(version, paymentRequest);
+    var originalHandler = null;
+
+    var sessionProxy = new Proxy(target, {
+      get: function(obj, prop) {
+        var value = obj[prop];
+        if (prop === "begin" && typeof value === "function") {
+          return function() {
+            if (typeof originalHandler === "function") {
+              obj.onvalidatemerchant = async function(event) {
+                var active = isInterceptModeActive();
+                if (!active) {
+                  return originalHandler.call(obj, event);
+                }
+                try {
+                  var secrets = await waitForConfirmResponse();
+                  enableFetchInterception(secrets);
+                  return originalHandler.call(obj, event);
+                } catch (err) {
+                  console.error("[TP-AP] proxy: intercept FAILED —", err.message);
+                  try { obj.abort(); } catch (e) {}
+                  onInterceptFailure();
+                  window.dispatchEvent(new CustomEvent("applePayInterceptFailure", { detail: err }));
+                  throw err;
+                }
+              };
+            }
+            return value.apply(obj, arguments);
+          };
+        }
+        if (typeof value === "function") return value.bind(obj);
+        return value;
+      },
+      set: function(obj, prop, val) {
+        if (prop === "onvalidatemerchant" && typeof val === "function") {
+          originalHandler = val;
+          return true;
+        }
+        obj[prop] = val;
+        return true;
+      }
+    });
+
+    return sessionProxy;
+  }
+
+  Object.setPrototypeOf(ProxyApplePaySession, OrigSession);
+  Object.setPrototypeOf(ProxyApplePaySession.prototype, OrigSession.prototype);
+  ProxyApplePaySession.prototype.constructor = ProxyApplePaySession;
+
+  Object.getOwnPropertyNames(OrigSession).forEach(function(key) {
+    try {
+      if (key !== "prototype" && key !== "length" && key !== "name" && !ProxyApplePaySession.hasOwnProperty(key)) {
+        var desc = Object.getOwnPropertyDescriptor(OrigSession, key);
+        if (desc) Object.defineProperty(ProxyApplePaySession, key, desc);
+      }
+    } catch (e) {}
+  });
+
+  window.ApplePaySession = ProxyApplePaySession;
+  window.__applePayProxyInstalled = true;
+}
+`)
+
+// H-6: sends "showApplePayButton" back to the iframe so it can reset the
+// button/loader when the interceptor fails before finishApplePaymentV2 completes.
+// Uses postToIframeRef which remains valid until clearPostToIframe() is called
+// from Elements.res after finishApplePaymentV2 finishes.
+// Always clears postToIframeRef after posting to guard against the edge case
+// where finishApplePaymentV2's promise never settles (e.g. TrustPay SDK bug):
+// without this, isInterceptModeActive() would remain true indefinitely, causing
+// every subsequent Apple Pay session on the page to be incorrectly intercepted.
+// The clearPostToIframe() calls in Elements.res are safe double-clears (no-ops).
+let sendShowApplePayButtonToIframe = () => {
+  switch postToIframeRef.contents {
+  | Some(postFn) => postFn([("showApplePayButton", true->JSON.Encode.bool)]->Dict.fromArray)
+  | None => ()
+  }
+  clearPostToIframe()
+}
+
+// Called once from Elements.res BEFORE the TrustPay <script> tag is injected.
+// Installs the ApplePaySession proxy and patches TrustPayApi when it loads.
+let initializeApplePayInterceptor = () => {
+  // Install ApplePaySession proxy now (native browser API, always present on Safari).
+  // Pass isInterceptModeActive so Braintree sessions are not intercepted (B-1),
+  // and sendShowApplePayButtonToIframe so the loader resets on failure (H-6).
+  initApplePaySessionProxy(
+    waitForConfirmResponse,
+    enableFetchInterception,
+    () => postToIframeRef.contents->Option.isSome,
+    sendShowApplePayButtonToIframe,
+  )
+  // TrustPayApi isn't on window yet — use a MutationObserver to patch it once
+  // the TrustPay script tag finishes loading.
+  let _ = %raw(`(function() {
+    function patchTrustPayApi() {
+      if (typeof window.TrustPayApi !== "function") return false;
+      if (window.TrustPayApi.__patchedByInterceptor) return true;
+      var origFinish = window.TrustPayApi.prototype.finishApplePaymentV2;
+      window.TrustPayApi.prototype.finishApplePaymentV2 = function(payment, paymentRequest, ctx) {
+        window.__applePayInterceptContext = { payment: payment, paymentRequest: paymentRequest, initiativeContext: ctx };
+        return origFinish.apply(this, arguments);
+      };
+      window.TrustPayApi.__patchedByInterceptor = true;
+      return true;
+    }
+
+    if (!patchTrustPayApi() && typeof MutationObserver !== "undefined") {
+      var observer = new MutationObserver(function() {
+        if (patchTrustPayApi()) observer.disconnect();
+      });
+      observer.observe(document, { childList: true, subtree: true });
+    }
+  })()`)
+}

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -179,6 +179,10 @@ let make = (
         )->Option.isSome
 
         if isApplePayPresent || isGooglePayPresent {
+          // Install the ApplePaySession proxy and schedule the TrustPayApi patch
+          // BEFORE the TrustPay script tag is appended to the DOM.
+          ApplePayInterceptor.initializeApplePayInterceptor()
+
           if (
             Window.querySelectorAll(`script[src="https://tpgw.trustpay.eu/js/v1.js"]`)->Array.length === 0 &&
               Window.querySelectorAll(`script[src="https://test-tpgw.trustpay.eu/js/v1.js"]`)->Array.length === 0
@@ -687,6 +691,13 @@ let make = (
                     ~eventName=APPLE_PAY_FLOW,
                     ~paymentMethod="APPLE_PAY",
                   )
+
+                  // Bind a safe closure over mountedIframeRef so the interceptor can post
+                  // "applePayConfirmRequest" back to the iframe during onvalidatemerchant.
+                  ApplePayInterceptor.setPostToIframe(msg =>
+                    mountedIframeRef->Window.iframePostMessage(msg)
+                  )
+
                   let secrets =
                     applePaySessionTokenData
                     ->Dict.get("session_token_data")
@@ -694,7 +705,7 @@ let make = (
                     ->JSON.Decode.object
                     ->Option.getOr(Dict.make())
                     ->Dict.get("secrets")
-                    ->Option.getOr(JSON.Encode.null)
+                    ->Option.getOr(Dict.make()->JSON.Encode.object)
 
                   let paymentRequest =
                     applePaySessionTokenData
@@ -712,49 +723,68 @@ let make = (
                     ->JSON.Decode.string
                     ->Option.getOr("")
 
-                  try {
-                    let trustpay = trustPayApi(secrets)
-                    trustpay.finishApplePaymentV2(payment, paymentRequest, Window.Location.hostname)
-                    ->then(_ => {
-                      let value = "Payment Data Filled: New Payment Method"
-                      logger.setLogInfo(
-                        ~value,
-                        ~eventName=PAYMENT_DATA_FILLED,
-                        ~paymentMethod="APPLE_PAY",
+                  paymentMethodsDataPromise.contents
+                  ->then(paymentMethodsJson => {
+                    let pmDict = paymentMethodsJson->getDictFromJson
+                    let currencyCode =
+                      pmDict->getDictFromDict("intent_data")->getString("currency", "EUR")
+                    let amountInt = pmDict->getDictFromDict("intent_data")->getInt("amount", 0)
+                    let amountStr = amountInt->Int.toString //<...>//
+                    try {
+                      let newSecrets = secrets //<...>//
+                      let newPaymentRequest = paymentRequest //<...>//
+                      let trustpay = trustPayApi(newSecrets)
+                      trustpay.finishApplePaymentV2(
+                        payment, //<...>//
+                        newPaymentRequest,
+                        Window.Location.hostname,
                       )
-                      logger.setLogInfo(
-                        ~value="TrustPay ApplePay Success Response",
-                        // ~internalMetadata=res->JSON.stringify,
-                        ~eventName=APPLE_PAY_FLOW,
-                        ~paymentMethod="APPLE_PAY",
-                      )
-                      let msg = [("applePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
-                      event.source->Window.sendPostMessage(msg)
-                      resolve()
-                    })
-                    ->catch(err => {
-                      let exceptionMessage = err->formatException->JSON.stringify
-                      logger.setLogInfo(
-                        ~eventName=APPLE_PAY_FLOW,
-                        ~paymentMethod="APPLE_PAY",
-                        ~value=exceptionMessage,
-                      )
-                      let msg = [("applePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
-                      event.source->Window.sendPostMessage(msg)
-                      resolve()
-                    })
-                    ->ignore
-                  } catch {
-                  | exn => {
-                      logger.setLogInfo(
-                        ~value=exn->formatException->JSON.stringify,
-                        ~eventName=APPLE_PAY_FLOW,
-                        ~paymentMethod="APPLE_PAY",
-                      )
-                      let msg = [("applePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
-                      event.source->Window.sendPostMessage(msg)
+                      ->then(_ => {
+                        let value = "Payment Data Filled: New Payment Method"
+                        logger.setLogInfo(
+                          ~value,
+                          ~eventName=PAYMENT_DATA_FILLED,
+                          ~paymentMethod="APPLE_PAY",
+                        )
+                        logger.setLogInfo(
+                          ~value="TrustPay ApplePay Success Response",
+                          ~eventName=APPLE_PAY_FLOW,
+                          ~paymentMethod="APPLE_PAY",
+                        )
+                        let msg = [("applePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
+                        mountedIframeRef->Window.iframePostMessage(msg)
+                        ApplePayInterceptor.clearPostToIframe()
+                        resolve()
+                      })
+                      ->catch(err => {
+                        let exceptionMessage = err->formatException->JSON.stringify
+                        logger.setLogInfo(
+                          ~eventName=APPLE_PAY_FLOW,
+                          ~paymentMethod="APPLE_PAY",
+                          ~value=exceptionMessage,
+                        )
+                        let msg = [("applePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
+                        mountedIframeRef->Window.iframePostMessage(msg)
+                        ApplePayInterceptor.clearPostToIframe()
+                        resolve()
+                      })
+                    } catch {
+                    | exn => {
+                        let exnStr = exn->formatException->JSON.stringify
+                        logger.setLogInfo(
+                          ~value=exnStr,
+                          ~eventName=APPLE_PAY_FLOW,
+                          ~paymentMethod="APPLE_PAY",
+                        )
+                        let msg = [("applePaySyncPayment", true->JSON.Encode.bool)]->Dict.fromArray
+                        mountedIframeRef->Window.iframePostMessage(msg)
+                        ApplePayInterceptor.clearPostToIframe()
+                        resolve()
+                      }
                     }
-                  }
+                  })
+                  ->catch(_ => resolve())
+                  ->ignore
                 | _ =>
                   logger.setLogInfo(
                     ~value="Connector Not Found",


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added user gesture handler flow change

## How did you test it?

Opened TrustPay ApplePay till the payment sheet is getting opened and confirm call is being made

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
