### PR TITLE
feat: superposition dynamic fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.2.0",
         "react-datepicker": "^8.4.0",
         "react-dom": "^18.2.0",
+        "react-final-form": "^7.0.0",
         "recoil": "^0.7.7",
         "webpack-merge": "^6.0.1"
       },
@@ -1603,6 +1604,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -5366,6 +5376,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/final-form": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-5.0.1.tgz",
+      "integrity": "sha512-Ohygw2lDgc2HNynfUu82Jp5U45+OLLeBQcwWbrex1IAbQw0uNaFMUbm5dhYCF6y7jcORgl5tg19/1zYxlJtLmg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/final-form"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -8488,6 +8515,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-final-form": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-7.0.1.tgz",
+      "integrity": "sha512-8K1ITLecBI7F+jCxiMA/JI1amHT/+klQB+nhl5YFZu3R1sQftbiQk/UfwRDvE7ZxIqIvCf8nYLDQRrfwaDT3kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/final-form"
+      },
+      "peerDependencies": {
+        "final-form": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^18.2.0",
     "react-datepicker": "^8.4.0",
     "react-dom": "^18.2.0",
+    "react-final-form": "^7.0.0",
     "recoil": "^0.7.7",
     "webpack-merge": "^6.0.1"
   },

--- a/src/Components/CryptoCurrencyNetworks.res
+++ b/src/Components/CryptoCurrencyNetworks.res
@@ -1,40 +1,52 @@
+open SuperpositionTypes
+
 @react.component
-let make = () => {
-  open DropdownField
-  let currencyVal = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCurrency)
+let make = (
+  ~networkField: fieldConfig,
+  ~currencyField: fieldConfig,
+) => {
+  let networkPath = networkField.confirmRequestWritePath
+  let currencyFieldPath = currencyField.confirmRequestWritePath
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let (cryptoCurrencyNetworks, setCryptoCurrencyNetworks) = Recoil.useRecoilState(
-    RecoilAtoms.cryptoCurrencyNetworks,
-  )
+  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=networkField, ~localeObject=localeString)
+  let validate =
+    DynamicFieldsUtils.resolveValidator(~field=networkField, ~localeObject=localeString)
+
+  let currencyFieldProps = ReactFinalForm.useField(currencyFieldPath)
+  let currencyVal = currencyFieldProps.input.value->Option.getOr("")
 
   let dropdownOptions =
     Utils.currencyNetworksDict
     ->Dict.get(currencyVal)
     ->Option.getOr([])
-    ->Array.map(item => {
-      label: Utils.toSpacedUpperCase(~str=item, ~delimiter="_"),
-      value: item,
+    ->Array.map((item): DropdownField.optionType => {
+      {
+        label: Utils.toSpacedUpperCase(~str=item, ~delimiter="_"),
+        value: item,
+      }
     })
 
-  let initialValue = (
-    dropdownOptions
-    ->Array.get(0)
-    ->Option.getOr({
-      label: "",
-      value: "",
-    })
-  ).value
+  let initialNetwork = dropdownOptions->Array.get(0)->Option.map(opt => opt.value)->Option.getOr("")
+
+  let field = ReactFinalForm.useField(
+    networkPath,
+    ~config={validate, initialValue: Some(initialNetwork)},
+  )
 
   React.useEffect(() => {
-    setCryptoCurrencyNetworks(_ => initialValue)
+    if initialNetwork !== "" {
+      field.input.onChange(initialNetwork)
+    }
     None
-  }, [initialValue])
+  }, [initialNetwork])
+
+  let value = field.input.value->Option.getOr(initialNetwork)
 
   <DropdownField
     appearance=config.appearance
-    fieldName=localeString.currencyNetwork
-    value=cryptoCurrencyNetworks
-    setValue=setCryptoCurrencyNetworks
+    fieldName={label}
+    value
+    setValue={setter => field.input.onChange(setter(value))}
     disabled=false
     options=dropdownOptions
   />

--- a/src/Components/CryptoCurrencyNetworks.res
+++ b/src/Components/CryptoCurrencyNetworks.res
@@ -1,16 +1,18 @@
 open SuperpositionTypes
 
 @react.component
-let make = (
-  ~networkField: fieldConfig,
-  ~currencyField: fieldConfig,
-) => {
+let make = (~networkField: fieldConfig, ~currencyField: fieldConfig) => {
   let networkPath = networkField.confirmRequestWritePath
   let currencyFieldPath = currencyField.confirmRequestWritePath
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=networkField, ~localeObject=localeString)
-  let validate =
-    DynamicFieldsUtils.resolveValidator(~field=networkField, ~localeObject=localeString)
+  let {label} = DynamicFieldsUtils.resolveFieldTexts(
+    ~field=networkField,
+    ~localeObject=localeString,
+  )
+  let validate = DynamicFieldsUtils.resolveValidator(
+    ~field=networkField,
+    ~localeObject=localeString,
+  )
 
   let currencyFieldProps = ReactFinalForm.useField(currencyFieldPath)
   let currencyVal = currencyFieldProps.input.value->Option.getOr("")

--- a/src/Components/DynamicFieldInput.res
+++ b/src/Components/DynamicFieldInput.res
@@ -59,9 +59,16 @@ let renderSingleField = (
           {(fieldProps: ReactFinalForm.Field.fieldProps) => {
             let {input, meta} = fieldProps
             let value = input.value->Option.getOr("")
-            let isValid = if meta.touched {Some(meta.valid)} else {None}
-            let errorString =
-              if meta.touched && meta.invalid {meta.error->Option.getOr("")} else {""}
+            let isValid = if meta.touched {
+              Some(meta.valid)
+            } else {
+              None
+            }
+            let errorString = if meta.touched && meta.invalid {
+              meta.error->Option.getOr("")
+            } else {
+              ""
+            }
             <PaymentInputField
               fieldName={label}
               value
@@ -91,12 +98,14 @@ let renderSingleField = (
       <EmailField fieldConfig=field paths=allEmailPaths />
     }
 
-  | Date =>
-    <DateOfBirth fieldConfig=field />
+  | Date => <DateOfBirth fieldConfig=field />
 
   | Generic =>
     let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-    let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field, ~localeObject=localeString)
+    let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+      ~field,
+      ~localeObject=localeString,
+    )
     let autocomplete = field.htmlAutocompleteAttribute->Option.getOr("on")
     let validate = DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
 
@@ -131,8 +140,7 @@ let renderSingleField = (
 
   | Dropdown =>
     if field.confirmRequestWritePath->String.endsWith(".state") {
-      let countryFieldPath =
-        field.confirmRequestWritePath->String.replace(".state", ".country")
+      let countryFieldPath = field.confirmRequestWritePath->String.replace(".state", ".country")
       <StateDropdownField field countryFieldPath />
     } else if field.confirmRequestWritePath->String.endsWith(".country") {
       let isoCodes = field.dropdownOptions->Option.getOr([])
@@ -154,8 +162,7 @@ let renderSingleField = (
         )
       switch currencyField {
       | None => React.null
-      | Some(currencyField) =>
-        <CryptoCurrencyNetworks networkField=field currencyField />
+      | Some(currencyField) => <CryptoCurrencyNetworks networkField=field currencyField />
       }
     } else {
       let options =
@@ -168,8 +175,7 @@ let renderSingleField = (
       }
     }
 
-  | Phone =>
-    <PhoneField fieldConfig=field />
+  | Phone => <PhoneField fieldConfig=field />
   }
 }
 
@@ -187,13 +193,7 @@ let makeRow = (
   | 1 =>
     switch fields->Array.get(0) {
     | None => React.null
-    | Some(field) =>
-      renderSingleField(
-        field,
-        ~allFields,
-        ~fieldRef,
-        ~globalEmailPaths?,
-      )
+    | Some(field) => renderSingleField(field, ~allFields, ~fieldRef, ~globalEmailPaths?)
     }
   | _ =>
     <div className="flex gap-4 w-full">
@@ -203,12 +203,7 @@ let makeRow = (
         <div
           key={field.confirmRequestWritePath ++ "-" ++ i->Int.toString}
           style={flexGrow: flex->Float.toString, flexShrink: "1", flexBasis: "0%"}>
-          {renderSingleField(
-            field,
-            ~allFields,
-            ~fieldRef,
-            ~globalEmailPaths?,
-          )}
+          {renderSingleField(field, ~allFields, ~fieldRef, ~globalEmailPaths?)}
         </div>
       })
       ->React.array}

--- a/src/Components/DynamicFieldInput.res
+++ b/src/Components/DynamicFieldInput.res
@@ -1,19 +1,59 @@
 open SuperpositionTypes
 
-// Groups an array of fieldConfig by layoutRowId.
-// Fields with no layoutRowId each form their own singleton row.
-let groupFieldsByRow = (fields: array<fieldConfig>): array<array<fieldConfig>> => {
-  let rows: array<array<fieldConfig>> = []
-  let rowMap: Dict.t<array<fieldConfig>> = Dict.make()
+type fieldItem =
+  | SingleField(fieldConfig)
+  | CombinedName(fieldConfig, fieldConfig)
 
-  fields->Array.forEach(field => {
-    switch field.layoutRowId {
-    | None => rows->Array.push([field])
+let toFieldItems = (fields: array<fieldConfig>): array<fieldItem> => {
+  let firstNameField = fields->Array.find(f => f.fieldRenderType === FirstName)
+  let lastNameField = fields->Array.find(f => f.fieldRenderType === LastName)
+  switch (firstNameField, lastNameField) {
+  | (Some(first), Some(last)) =>
+    fields->Array.filterMap(field =>
+      if field === first {
+        Some(CombinedName(first, last))
+      } else if field === last {
+        None
+      } else {
+        Some(SingleField(field))
+      }
+    )
+  | _ => fields->Array.map(field => SingleField(field))
+  }
+}
+
+let itemLayoutRowId = (item: fieldItem): option<string> =>
+  switch item {
+  | SingleField(field) => field.layoutRowId
+  | CombinedName(firstNameField, _) => firstNameField.layoutRowId
+  }
+
+let itemKey = (item: fieldItem): string =>
+  switch item {
+  | SingleField(field) => field.confirmRequestWritePath
+  | CombinedName(firstNameField, _) => firstNameField.confirmRequestWritePath
+  }
+
+let itemWidthRatio = (item: fieldItem): float =>
+  switch item {
+  | SingleField(field) => field.layoutWidthRatio->Option.getOr(1.0)
+  | CombinedName(firstNameField, _) => firstNameField.layoutWidthRatio->Option.getOr(1.0)
+  }
+
+// Groups items by layoutRowId.
+// Items with no layoutRowId each form their own singleton row.
+let groupItemsByRow = (items: array<fieldItem>): array<array<fieldItem>> => {
+  let rows: array<array<fieldItem>> = []
+  let rowMap: Dict.t<array<fieldItem>> = Dict.make()
+
+  items->Array.forEach(item => {
+    switch itemLayoutRowId(item) {
+    | None => rows->Array.push([item])
     | Some(rowId) =>
       switch rowMap->Dict.get(rowId) {
-      | Some(row) => row->Array.push(field)
+      | Some(row) => row->Array.push(item)
       | None =>
-        let row = [field]
+        let row = [item]
         rowMap->Dict.set(rowId, row)
         rows->Array.push(row)
       }
@@ -27,64 +67,14 @@ let groupFieldsByRow = (fields: array<fieldConfig>): array<array<fieldConfig>> =
 let renderSingleField = (
   field: fieldConfig,
   ~allFields: array<fieldConfig>,
-  ~fieldRef: React.ref<Nullable.t<'a>>,
   ~globalEmailPaths: option<array<string>>=?,
 ) => {
   switch field.fieldRenderType {
   | CardNumber
-  | Cvc => React.null
-
-  | CardHolderName =>
-    // last_name is rendered as part of the first_name field — skip it here
-    if field.confirmRequestWritePath->String.endsWith(".last_name") {
-      React.null
-    } else {
-      let lastNameField =
-        allFields->Array.find(f =>
-          f.fieldRenderType === CardHolderName &&
-            f.confirmRequestWritePath->String.endsWith(".last_name")
-        )
-      switch lastNameField {
-      | Some(lastNameField) => <CardHolderNameField firstNameField=field lastNameField />
-      | None =>
-        // No separate last_name field — render as a plain Generic input
-        let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-        let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
-          ~field,
-          ~localeObject=localeString,
-        )
-        let autocomplete = field.htmlAutocompleteAttribute->Option.getOr("cc-name")
-        let validate = DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
-        <ReactFinalForm.Field name={field.confirmRequestWritePath} validate={Some(validate)}>
-          {(fieldProps: ReactFinalForm.Field.fieldProps) => {
-            let {input, meta} = fieldProps
-            let value = input.value->Option.getOr("")
-            let isValid = if meta.touched {
-              Some(meta.valid)
-            } else {
-              None
-            }
-            let errorString = if meta.touched && meta.invalid {
-              meta.error->Option.getOr("")
-            } else {
-              ""
-            }
-            <PaymentInputField
-              fieldName={label}
-              value
-              onChange={ev => input.onChange(ReactEvent.Form.target(ev)["value"])}
-              onBlur={_ev => input.onBlur()}
-              isValid
-              errorString
-              placeholder
-              inputRef={fieldRef}
-              autocomplete
-              maxLength=?{field.maxInputLength}
-            />
-          }}
-        </ReactFinalForm.Field>
-      }
-    }
+  | Cvc
+  | CardExpiryMonth
+  | CardExpiryYear
+  | CardNetwork => React.null
 
   | Email =>
     let allEmailPaths = switch globalEmailPaths {
@@ -92,118 +82,88 @@ let renderSingleField = (
     | None => []
     }
     let firstEmailPath = allEmailPaths->Array.get(0)
-    if firstEmailPath !== Some(field.confirmRequestWritePath) {
-      React.null
-    } else {
+    <RenderIf condition={firstEmailPath === Some(field.confirmRequestWritePath)}>
       <EmailField fieldConfig=field paths=allEmailPaths />
-    }
+    </RenderIf>
 
-  | Date => <DateOfBirth fieldConfig=field />
-
-  | Generic =>
-    let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-    let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
-      ~field,
-      ~localeObject=localeString,
-    )
-    let autocomplete = field.htmlAutocompleteAttribute->Option.getOr("on")
-    let validate = DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
-
-    <ReactFinalForm.Field name={field.confirmRequestWritePath} validate={Some(validate)}>
-      {(fieldProps: ReactFinalForm.Field.fieldProps) => {
-        let {input, meta} = fieldProps
-        let value = input.value->Option.getOr("")
-        let isValid = if meta.touched {
-          Some(meta.valid)
-        } else {
-          None
-        }
-        let errorString = if meta.touched && meta.invalid {
-          meta.error->Option.getOr("")
-        } else {
-          ""
-        }
-        <PaymentInputField
-          fieldName={label}
-          value
-          onChange={ev => input.onChange(ReactEvent.Form.target(ev)["value"])}
-          onBlur={_ev => input.onBlur()}
-          isValid
-          errorString
-          placeholder
-          inputRef={fieldRef}
-          autocomplete
-          maxLength=?{field.maxInputLength}
-        />
-      }}
-    </ReactFinalForm.Field>
-
-  | Dropdown =>
-    if field.confirmRequestWritePath->String.endsWith(".state") {
-      let countryFieldPath = field.confirmRequestWritePath->String.replace(".state", ".country")
-      <StateDropdownField field countryFieldPath />
-    } else if field.confirmRequestWritePath->String.endsWith(".country") {
-      let isoCodes = field.dropdownOptions->Option.getOr([])
-      let options =
-        isoCodes
-        ->Utils.isoOptionsToCountryNames
-        ->DropdownField.updateArrayOfStringToOptionsTypeArray
-      if options->Array.length === 0 {
-        React.null
-      } else {
-        <CountryDropdownField fieldConfig=field options />
-      }
-    } else if field.confirmRequestWritePath->String.endsWith(".country_code") {
-      <PhoneCountryCodeDropdownField fieldConfig=field />
-    } else if field.confirmRequestWritePath->String.endsWith("crypto.network") {
-      let currencyField =
-        allFields->Array.find(f =>
-          f.confirmRequestWritePath->String.endsWith("crypto.pay_currency")
-        )
-      switch currencyField {
-      | None => React.null
-      | Some(currencyField) => <CryptoCurrencyNetworks networkField=field currencyField />
-      }
-    } else {
-      let options =
-        field.dropdownOptions->Option.getOr([])->DropdownField.updateArrayOfStringToOptionsTypeArray
-      if options->Array.length === 0 {
-        React.null
-      } else {
-        let initialValue = options->Array.get(0)->Option.map(o => o.value)->Option.getOr("")
-        <GenericDropdownField fieldConfig=field options initialValue />
-      }
-    }
+  | Date
+  | DateOfBirth =>
+    <DateOfBirth fieldConfig=field />
 
   | Phone => <PhoneField fieldConfig=field />
+
+  | PhoneCountryCode => <PhoneCountryCodeDropdownField fieldConfig=field />
+
+  | State => <StateDropdownField fieldConfig=field />
+
+  | Country =>
+    let isoCodes = field.dropdownOptions->Option.getOr([])
+    let options =
+      isoCodes
+      ->Utils.isoOptionsToCountryNames
+      ->DropdownField.updateArrayOfStringToOptionsTypeArray
+    <RenderIf condition={options->Array.length > 0}>
+      <CountryDropdownField fieldConfig=field options />
+    </RenderIf>
+
+  | CryptoNetwork =>
+    switch DynamicFieldsUtils.findCryptoCurrencyField(~allFields) {
+    | None => React.null
+    | Some(currencyField) => <CryptoCurrencyNetworks networkField=field currencyField />
+    }
+
+  | CryptoCurrency
+  | Dropdown =>
+    let options =
+      field.dropdownOptions->Option.getOr([])->DropdownField.updateArrayOfStringToOptionsTypeArray
+    <RenderIf condition={options->Array.length > 0}>
+      <GenericDropdownField fieldConfig=field options />
+    </RenderIf>
+
+  | CardHolderName
+  | FirstName
+  | LastName
+  | Generic =>
+    <GenericInputField fieldConfig=field />
   }
 }
 
-// Renders a row of fields side-by-side using flex layout.
-@react.component
-let makeRow = (
-  ~fields: array<fieldConfig>,
+// Renders a single derived item: a combined full-name input, or a plain single field.
+let renderItem = (
+  item: fieldItem,
   ~allFields: array<fieldConfig>,
   ~globalEmailPaths: option<array<string>>=?,
 ) => {
-  let fieldRef = React.useRef(Nullable.null)
+  switch item {
+  | CombinedName(firstNameField, lastNameField) =>
+    <CardHolderNameField firstNameField lastNameField />
+  | SingleField(field) => renderSingleField(field, ~allFields, ~globalEmailPaths?)
+  }
+}
 
-  switch fields->Array.length {
+// Renders a row of items side-by-side using flex layout.
+@react.component
+let makeRow = (
+  ~items: array<fieldItem>,
+  ~allFields: array<fieldConfig>,
+  ~globalEmailPaths: option<array<string>>=?,
+) => {
+  switch items->Array.length {
   | 0 => React.null
   | 1 =>
-    switch fields->Array.get(0) {
+    switch items->Array.get(0) {
     | None => React.null
-    | Some(field) => renderSingleField(field, ~allFields, ~fieldRef, ~globalEmailPaths?)
+    | Some(item) => renderItem(item, ~allFields, ~globalEmailPaths?)
     }
   | _ =>
     <div className="flex gap-4 w-full">
-      {fields
-      ->Array.mapWithIndex((field, i) => {
-        let flex = field.layoutWidthRatio->Option.getOr(1.0)
+      {items
+      ->Array.mapWithIndex((item, i) => {
+        let flex = itemWidthRatio(item)
         <div
-          key={field.confirmRequestWritePath ++ "-" ++ i->Int.toString}
+          key={itemKey(item) ++ "-" ++ i->Int.toString}
           style={flexGrow: flex->Float.toString, flexShrink: "1", flexBasis: "0%"}>
-          {renderSingleField(field, ~allFields, ~fieldRef, ~globalEmailPaths?)}
+          {renderItem(item, ~allFields, ~globalEmailPaths?)}
         </div>
       })
       ->React.array}

--- a/src/Components/DynamicFieldInput.res
+++ b/src/Components/DynamicFieldInput.res
@@ -1,0 +1,217 @@
+open SuperpositionTypes
+
+// Groups an array of fieldConfig by layoutRowId.
+// Fields with no layoutRowId each form their own singleton row.
+let groupFieldsByRow = (fields: array<fieldConfig>): array<array<fieldConfig>> => {
+  let rows: array<array<fieldConfig>> = []
+  let rowMap: Dict.t<array<fieldConfig>> = Dict.make()
+
+  fields->Array.forEach(field => {
+    switch field.layoutRowId {
+    | None => rows->Array.push([field])
+    | Some(rowId) =>
+      switch rowMap->Dict.get(rowId) {
+      | Some(row) => row->Array.push(field)
+      | None =>
+        let row = [field]
+        rowMap->Dict.set(rowId, row)
+        rows->Array.push(row)
+      }
+    }
+  })
+
+  rows
+}
+
+// Renders a single fieldConfig entry as a RFF-connected input.
+let renderSingleField = (
+  field: fieldConfig,
+  ~allFields: array<fieldConfig>,
+  ~fieldRef: React.ref<Nullable.t<'a>>,
+  ~globalEmailPaths: option<array<string>>=?,
+) => {
+  switch field.fieldRenderType {
+  | CardNumber
+  | Cvc => React.null
+
+  | CardHolderName =>
+    // last_name is rendered as part of the first_name field — skip it here
+    if field.confirmRequestWritePath->String.endsWith(".last_name") {
+      React.null
+    } else {
+      let lastNameField =
+        allFields->Array.find(f =>
+          f.fieldRenderType === CardHolderName &&
+            f.confirmRequestWritePath->String.endsWith(".last_name")
+        )
+      switch lastNameField {
+      | Some(lastNameField) => <CardHolderNameField firstNameField=field lastNameField />
+      | None =>
+        // No separate last_name field — render as a plain Generic input
+        let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+        let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+          ~field,
+          ~localeObject=localeString,
+        )
+        let autocomplete = field.htmlAutocompleteAttribute->Option.getOr("cc-name")
+        let validate = DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
+        <ReactFinalForm.Field name={field.confirmRequestWritePath} validate={Some(validate)}>
+          {(fieldProps: ReactFinalForm.Field.fieldProps) => {
+            let {input, meta} = fieldProps
+            let value = input.value->Option.getOr("")
+            let isValid = if meta.touched {Some(meta.valid)} else {None}
+            let errorString =
+              if meta.touched && meta.invalid {meta.error->Option.getOr("")} else {""}
+            <PaymentInputField
+              fieldName={label}
+              value
+              onChange={ev => input.onChange(ReactEvent.Form.target(ev)["value"])}
+              onBlur={_ev => input.onBlur()}
+              isValid
+              errorString
+              placeholder
+              inputRef={fieldRef}
+              autocomplete
+              maxLength=?{field.maxInputLength}
+            />
+          }}
+        </ReactFinalForm.Field>
+      }
+    }
+
+  | Email =>
+    let allEmailPaths = switch globalEmailPaths {
+    | Some(paths) => paths
+    | None => []
+    }
+    let firstEmailPath = allEmailPaths->Array.get(0)
+    if firstEmailPath !== Some(field.confirmRequestWritePath) {
+      React.null
+    } else {
+      <EmailField fieldConfig=field paths=allEmailPaths />
+    }
+
+  | Date =>
+    <DateOfBirth fieldConfig=field />
+
+  | Generic =>
+    let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+    let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field, ~localeObject=localeString)
+    let autocomplete = field.htmlAutocompleteAttribute->Option.getOr("on")
+    let validate = DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
+
+    <ReactFinalForm.Field name={field.confirmRequestWritePath} validate={Some(validate)}>
+      {(fieldProps: ReactFinalForm.Field.fieldProps) => {
+        let {input, meta} = fieldProps
+        let value = input.value->Option.getOr("")
+        let isValid = if meta.touched {
+          Some(meta.valid)
+        } else {
+          None
+        }
+        let errorString = if meta.touched && meta.invalid {
+          meta.error->Option.getOr("")
+        } else {
+          ""
+        }
+        <PaymentInputField
+          fieldName={label}
+          value
+          onChange={ev => input.onChange(ReactEvent.Form.target(ev)["value"])}
+          onBlur={_ev => input.onBlur()}
+          isValid
+          errorString
+          placeholder
+          inputRef={fieldRef}
+          autocomplete
+          maxLength=?{field.maxInputLength}
+        />
+      }}
+    </ReactFinalForm.Field>
+
+  | Dropdown =>
+    if field.confirmRequestWritePath->String.endsWith(".state") {
+      let countryFieldPath =
+        field.confirmRequestWritePath->String.replace(".state", ".country")
+      <StateDropdownField field countryFieldPath />
+    } else if field.confirmRequestWritePath->String.endsWith(".country") {
+      let isoCodes = field.dropdownOptions->Option.getOr([])
+      let options =
+        isoCodes
+        ->Utils.isoOptionsToCountryNames
+        ->DropdownField.updateArrayOfStringToOptionsTypeArray
+      if options->Array.length === 0 {
+        React.null
+      } else {
+        <CountryDropdownField fieldConfig=field options />
+      }
+    } else if field.confirmRequestWritePath->String.endsWith(".country_code") {
+      <PhoneCountryCodeDropdownField fieldConfig=field />
+    } else if field.confirmRequestWritePath->String.endsWith("crypto.network") {
+      let currencyField =
+        allFields->Array.find(f =>
+          f.confirmRequestWritePath->String.endsWith("crypto.pay_currency")
+        )
+      switch currencyField {
+      | None => React.null
+      | Some(currencyField) =>
+        <CryptoCurrencyNetworks networkField=field currencyField />
+      }
+    } else {
+      let options =
+        field.dropdownOptions->Option.getOr([])->DropdownField.updateArrayOfStringToOptionsTypeArray
+      if options->Array.length === 0 {
+        React.null
+      } else {
+        let initialValue = options->Array.get(0)->Option.map(o => o.value)->Option.getOr("")
+        <GenericDropdownField fieldConfig=field options initialValue />
+      }
+    }
+
+  | Phone =>
+    <PhoneField fieldConfig=field />
+  }
+}
+
+// Renders a row of fields side-by-side using flex layout.
+@react.component
+let makeRow = (
+  ~fields: array<fieldConfig>,
+  ~allFields: array<fieldConfig>,
+  ~globalEmailPaths: option<array<string>>=?,
+) => {
+  let fieldRef = React.useRef(Nullable.null)
+
+  switch fields->Array.length {
+  | 0 => React.null
+  | 1 =>
+    switch fields->Array.get(0) {
+    | None => React.null
+    | Some(field) =>
+      renderSingleField(
+        field,
+        ~allFields,
+        ~fieldRef,
+        ~globalEmailPaths?,
+      )
+    }
+  | _ =>
+    <div className="flex gap-4 w-full">
+      {fields
+      ->Array.mapWithIndex((field, i) => {
+        let flex = field.layoutWidthRatio->Option.getOr(1.0)
+        <div
+          key={field.confirmRequestWritePath ++ "-" ++ i->Int.toString}
+          style={flexGrow: flex->Float.toString, flexShrink: "1", flexBasis: "0%"}>
+          {renderSingleField(
+            field,
+            ~allFields,
+            ~fieldRef,
+            ~globalEmailPaths?,
+          )}
+        </div>
+      })
+      ->React.array}
+    </div>
+  }
+}

--- a/src/Components/DynamicFieldInput.res
+++ b/src/Components/DynamicFieldInput.res
@@ -1,59 +1,19 @@
 open SuperpositionTypes
 
-type fieldItem =
-  | SingleField(fieldConfig)
-  | CombinedName(fieldConfig, fieldConfig)
+// Groups fields by layoutRowId.
+// Fields with no layoutRowId each form their own singleton row.
+let groupFieldsByRow = (fields: array<fieldConfig>): array<array<fieldConfig>> => {
+  let rows: array<array<fieldConfig>> = []
+  let rowMap: Dict.t<array<fieldConfig>> = Dict.make()
 
-let toFieldItems = (fields: array<fieldConfig>): array<fieldItem> => {
-  let firstNameField = fields->Array.find(f => f.fieldRenderType === FirstName)
-  let lastNameField = fields->Array.find(f => f.fieldRenderType === LastName)
-  switch (firstNameField, lastNameField) {
-  | (Some(first), Some(last)) =>
-    fields->Array.filterMap(field =>
-      if field === first {
-        Some(CombinedName(first, last))
-      } else if field === last {
-        None
-      } else {
-        Some(SingleField(field))
-      }
-    )
-  | _ => fields->Array.map(field => SingleField(field))
-  }
-}
-
-let itemLayoutRowId = (item: fieldItem): option<string> =>
-  switch item {
-  | SingleField(field) => field.layoutRowId
-  | CombinedName(firstNameField, _) => firstNameField.layoutRowId
-  }
-
-let itemKey = (item: fieldItem): string =>
-  switch item {
-  | SingleField(field) => field.confirmRequestWritePath
-  | CombinedName(firstNameField, _) => firstNameField.confirmRequestWritePath
-  }
-
-let itemWidthRatio = (item: fieldItem): float =>
-  switch item {
-  | SingleField(field) => field.layoutWidthRatio->Option.getOr(1.0)
-  | CombinedName(firstNameField, _) => firstNameField.layoutWidthRatio->Option.getOr(1.0)
-  }
-
-// Groups items by layoutRowId.
-// Items with no layoutRowId each form their own singleton row.
-let groupItemsByRow = (items: array<fieldItem>): array<array<fieldItem>> => {
-  let rows: array<array<fieldItem>> = []
-  let rowMap: Dict.t<array<fieldItem>> = Dict.make()
-
-  items->Array.forEach(item => {
-    switch itemLayoutRowId(item) {
-    | None => rows->Array.push([item])
+  fields->Array.forEach(field => {
+    switch field.layoutRowId {
+    | None => rows->Array.push([field])
     | Some(rowId) =>
       switch rowMap->Dict.get(rowId) {
-      | Some(row) => row->Array.push(item)
+      | Some(row) => row->Array.push(field)
       | None =>
-        let row = [item]
+        let row = [field]
         rowMap->Dict.set(rowId, row)
         rows->Array.push(row)
       }
@@ -67,7 +27,8 @@ let groupItemsByRow = (items: array<fieldItem>): array<array<fieldItem>> => {
 let renderSingleField = (
   field: fieldConfig,
   ~allFields: array<fieldConfig>,
-  ~globalEmailPaths: option<array<string>>=?,
+  ~globalEmailFields: option<array<fieldConfig>>=?,
+  ~globalCardHolderNameFields: option<array<fieldConfig>>=?,
 ) => {
   switch field.fieldRenderType {
   | CardNumber
@@ -77,13 +38,21 @@ let renderSingleField = (
   | CardNetwork => React.null
 
   | Email =>
-    let allEmailPaths = switch globalEmailPaths {
-    | Some(paths) => paths
+    let allEmailFields = globalEmailFields->Option.getOr([])
+    let firstEmailPath = allEmailFields->Array.get(0)->Option.map(f => f.confirmRequestWritePath)
+    <RenderIf condition={firstEmailPath === Some(field.confirmRequestWritePath)}>
+      <EmailField fields=allEmailFields />
+    </RenderIf>
+
+  | CardHolderName =>
+    let allCardHolderNameFields = switch globalCardHolderNameFields {
+    | Some(nameFields) => nameFields
     | None => []
     }
-    let firstEmailPath = allEmailPaths->Array.get(0)
-    <RenderIf condition={firstEmailPath === Some(field.confirmRequestWritePath)}>
-      <EmailField fieldConfig=field paths=allEmailPaths />
+    let firstCardHolderNamePath =
+      allCardHolderNameFields->Array.get(0)->Option.map(field => field.confirmRequestWritePath)
+    <RenderIf condition={firstCardHolderNamePath === Some(field.confirmRequestWritePath)}>
+      <CardHolderNameField fields=allCardHolderNameFields />
     </RenderIf>
 
   | Date
@@ -120,7 +89,6 @@ let renderSingleField = (
       <GenericDropdownField fieldConfig=field options />
     </RenderIf>
 
-  | CardHolderName
   | FirstName
   | LastName
   | Generic =>
@@ -128,42 +96,31 @@ let renderSingleField = (
   }
 }
 
-// Renders a single derived item: a combined full-name input, or a plain single field.
-let renderItem = (
-  item: fieldItem,
-  ~allFields: array<fieldConfig>,
-  ~globalEmailPaths: option<array<string>>=?,
-) => {
-  switch item {
-  | CombinedName(firstNameField, lastNameField) =>
-    <CardHolderNameField firstNameField lastNameField />
-  | SingleField(field) => renderSingleField(field, ~allFields, ~globalEmailPaths?)
-  }
-}
-
-// Renders a row of items side-by-side using flex layout.
+// Renders a row of fields side-by-side using flex layout.
 @react.component
 let makeRow = (
-  ~items: array<fieldItem>,
+  ~items: array<fieldConfig>,
   ~allFields: array<fieldConfig>,
-  ~globalEmailPaths: option<array<string>>=?,
+  ~globalEmailFields: option<array<fieldConfig>>=?,
+  ~globalCardHolderNameFields: option<array<fieldConfig>>=?,
 ) => {
   switch items->Array.length {
   | 0 => React.null
   | 1 =>
     switch items->Array.get(0) {
     | None => React.null
-    | Some(item) => renderItem(item, ~allFields, ~globalEmailPaths?)
+    | Some(field) =>
+      renderSingleField(field, ~allFields, ~globalEmailFields?, ~globalCardHolderNameFields?)
     }
   | _ =>
     <div className="flex gap-4 w-full">
       {items
-      ->Array.mapWithIndex((item, i) => {
-        let flex = itemWidthRatio(item)
+      ->Array.mapWithIndex((field, i) => {
+        let flex = field.layoutWidthRatio->Option.getOr(1.0)
         <div
-          key={itemKey(item) ++ "-" ++ i->Int.toString}
+          key={field.confirmRequestWritePath ++ "-" ++ i->Int.toString}
           style={flexGrow: flex->Float.toString, flexShrink: "1", flexBasis: "0%"}>
-          {renderItem(item, ~allFields, ~globalEmailPaths?)}
+          {renderSingleField(field, ~allFields, ~globalEmailFields?, ~globalCardHolderNameFields?)}
         </div>
       })
       ->React.array}

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -40,7 +40,7 @@ let make = (
   let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {billingAddress, redirectionInfo} = Recoil.useRecoilValueFromAtom(optionAtom)
   let country = Recoil.useRecoilValueFromAtom(userCountry)
-  let sdkConfigs = Recoil.useRecoilValueFromAtom(sdkConfigs)
+  let sdkConfigsValue = Recoil.useRecoilValueFromAtom(PaymentUtils.sdkConfigsValue)
 
   React.useEffect(() => {
     setRequiredFieldsBody(_ => Dict.make())
@@ -53,24 +53,21 @@ let make = (
     ~paymentMethodType,
   )
 
-  let rawConfigs = React.useMemo(() => {
-    switch sdkConfigs {
-    | Loaded(json) => json->getDictFromJson->Dict.get("raw_configs")
-    | _ => None
-    }
-  }, [sdkConfigs])
+  let rawConfigs = sdkConfigsValue.raw_configs
 
-  let getSuperpositionFinalFields = ConfigurationService.useConfigurationService(
-    ~rawConfigs
-  )
+  let getSuperpositionFinalFields = ConfigurationService.useConfigurationService(~rawConfigs)
 
   let requiredFieldsFromPMLFlat = React.useMemo(() => {
     extractValuesFromPMLRequiredFields(paymentMethodTypes.required_fields)
   }, [paymentMethodTypes.required_fields])
 
   let eligibleConnectors = React.useMemo(() => {
-    getEligibleConnectors(paymentMethodTypes, paymentMethod)
-  }, (paymentMethodTypes, paymentMethod))
+    SdkConfigParser.getEligibleConnectorsFromPaymentMethods(
+      sdkConfigsValue.payment_methods,
+      paymentMethod,
+      paymentMethodType,
+    )->Array.map(item => item->JSON.Encode.string)
+  }, (sdkConfigsValue.payment_methods, paymentMethod, paymentMethodType))
 
   let superpositionBaseContext = React.useMemo(() => {
     buildSuperpositionBaseContext(

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -78,7 +78,7 @@ let make = (
     )
   }, (paymentMethod, paymentMethodType, country, paymentMethodListValue))
 
-  let (_requiredFields, missingRequiredFields, initialValues) = React.useMemo(() => {
+  let (_requiredFields, missingRequiredFields, superpositionInitialValues) = React.useMemo(() => {
     getSuperpositionFinalFields(
       eligibleConnectors,
       superpositionBaseContext,
@@ -90,6 +90,7 @@ let make = (
     superpositionBaseContext,
     requiredFieldsFromPMLFlat,
   ))
+  let initialValues = React.useMemo(() => superpositionInitialValues, [requiredFieldsFromPMLFlat])
 
   let missingRequiredFieldsFiltered = React.useMemo(() => {
     let afterBillingFilter = removeBillingDetailsIfUseBillingAddress(
@@ -125,8 +126,6 @@ let make = (
       }
     })
   }, (missingRequiredFields, billingAddress.isUseBillingAddress))
-
-  let billingPrefix = "payment_method_data.billing."
 
   let dynamicFieldsOutsideBilling = React.useMemo(() => {
     missingRequiredFieldsFiltered->Array.filter(field =>
@@ -190,7 +189,7 @@ let make = (
 
           ReactFinalForm.useFormStateHandler(
             ~onFormChange=values => {
-              // Flatten the nested form values so keys align correctly during merge using `mergeAndFlattenToTuples`.
+              // RFF stores values as nested objects; flatten to dot-notation keys so they align with the confirm-payload merge.
               let flatValues = values->JSON.Encode.object->Utils.flattenObject(false)
               setRequiredFieldsBody(_ => flatValues)
             },

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -178,6 +178,15 @@ let make = (
   let spacedStylesForBillingDetails = isSpacedInnerLayout ? "p-2" : "my-2"
   let hasAnyField = missingRequiredFieldsFiltered->Array.length > 0
   let setAreRequiredFieldsValid = Recoil.useSetRecoilState(areRequiredFieldsValid)
+  let setAreRequiredFieldsEmpty = Recoil.useSetRecoilState(areRequiredFieldsEmpty)
+
+  React.useEffect(() => {
+    if isSavedCardFlow || !hasAnyField {
+      setAreRequiredFieldsValid(_ => true)
+      setAreRequiredFieldsEmpty(_ => false)
+    }
+    None
+  }, (isSavedCardFlow, hasAnyField))
 
   <>
     <RenderIf condition={!isSavedCardFlow && hasAnyField}>
@@ -192,6 +201,15 @@ let make = (
               // RFF stores values as nested objects; flatten to dot-notation keys so they align with the confirm-payload merge.
               let flatValues = values->JSON.Encode.object->Utils.flattenObject(false)
               setRequiredFieldsBody(_ => flatValues)
+
+              let isEmpty = missingRequiredFieldsFiltered->Array.some(field => {
+                switch flatValues->Dict.get(field.confirmRequestWritePath) {
+                | None | Some(JSON.Null) => true
+                | Some(JSON.String(str)) => str->String.trim === ""
+                | Some(_) => false
+                }
+              })
+              setAreRequiredFieldsEmpty(_ => isEmpty)
             },
             ~onValidationChange=isValid => {
               setAreRequiredFieldsValid(_ => isValid)

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -125,14 +125,14 @@ let make = (
   let dynamicFieldsOutsideBilling = React.useMemo(() => {
     missingRequiredFieldsFiltered->Array.filter(field =>
       !(field.confirmRequestWritePath->String.startsWith(billingPrefix)) ||
-      field.fieldRenderType === CardHolderName
+      (paymentMethod == "card" && (field.fieldRenderType === FirstName || field.fieldRenderType === LastName))
     )
   }, [missingRequiredFieldsFiltered])
 
   let dynamicFieldsInsideBilling = React.useMemo(() => {
     missingRequiredFieldsFiltered->Array.filter(field =>
       field.confirmRequestWritePath->String.startsWith(billingPrefix) &&
-        field.fieldRenderType !== CardHolderName
+        !(paymentMethod == "card" && (field.fieldRenderType === FirstName || field.fieldRenderType === LastName))
     )
   }, [missingRequiredFieldsFiltered])
 

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -105,21 +105,17 @@ let make = (
       ->Option.map(fieldConfig => fieldConfig.confirmRequestWritePath)
 
     // remove fields that would render as React.null:
-    //   - CardNumber and Cvc (rendered separately via cardProps/cvcProps)
     //   - Any card-data fields (card_exp_month, card_exp_year, card_network, etc.)
-    //     that live under payment_method_data.card.* — handled by card iframe widgets
     //   - Duplicate Email fields (only the first path is rendered)
-    //   - CardHolderName last_name (rendered inside the first_name field)
     //   - Dropdown fields with no options (would render React.null anyway)
     afterBillingFilter->Array.filter(field => {
       switch field.fieldRenderType {
-      | CardNumber | Cvc => false
+      | CardNumber | Cvc | CardExpiryMonth | CardExpiryYear | CardNetwork => false
       | Dropdown =>
         let options = field.dropdownOptions->Option.getOr([])
         options->Array.length > 0
       | Email => firstEmailPath === Some(field.confirmRequestWritePath)
-      | CardHolderName => !(field.confirmRequestWritePath->String.endsWith(".last_name"))
-      | _ => !(field.confirmRequestWritePath->String.startsWith("payment_method_data.card."))
+      | _ => true
       }
     })
   }, (missingRequiredFields, billingAddress.isUseBillingAddress))
@@ -198,12 +194,14 @@ let make = (
           )
 
           <>
-            {DynamicFieldInput.groupFieldsByRow(dynamicFieldsOutsideBilling)
+            {dynamicFieldsOutsideBilling
+            ->DynamicFieldInput.toFieldItems
+            ->DynamicFieldInput.groupItemsByRow
             ->Array.mapWithIndex((row, rowIdx) => {
               <DynamicFieldsToRenderWrapper
                 key={`outside-row-${rowIdx->Int.toString}`} index={rowIdx} isInside={false}>
                 <DynamicFieldInput.makeRow
-                  fields={row}
+                  items={row}
                   allFields={dynamicFieldsOutsideBilling}
                   globalEmailPaths={allEmailPaths}
                 />
@@ -231,12 +229,14 @@ let make = (
                   style={
                     gap: isSpacedInnerLayout ? themeObj.spacingGridRow : "",
                   }>
-                  {DynamicFieldInput.groupFieldsByRow(dynamicFieldsInsideBilling)
+                  {dynamicFieldsInsideBilling
+                  ->DynamicFieldInput.toFieldItems
+                  ->DynamicFieldInput.groupItemsByRow
                   ->Array.mapWithIndex((row, rowIdx) => {
                     <DynamicFieldsToRenderWrapper
                       key={`inside-row-${rowIdx->Int.toString}`} index={rowIdx}>
                       <DynamicFieldInput.makeRow
-                        fields={row}
+                        items={row}
                         allFields={dynamicFieldsInsideBilling}
                         globalEmailPaths={allEmailPaths}
                       />

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -32,834 +32,234 @@ let make = (
   ~isSplitPaymentsEnabled=false,
 ) => {
   open DynamicFieldsUtils
-  open PaymentTypeContext
   open Utils
   open RecoilAtoms
+  open SuperpositionTypes
+
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
-  let paymentManagementListValue = Recoil.useRecoilValueFromAtom(
-    PaymentUtils.paymentManagementListValue,
-  )
   let {config, themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-  let contextPaymentType = usePaymentType()
+  let {billingAddress, redirectionInfo} = Recoil.useRecoilValueFromAtom(optionAtom)
+  let country = Recoil.useRecoilValueFromAtom(userCountry)
+  let sdkConfigs = Recoil.useRecoilValueFromAtom(sdkConfigs)
+
   React.useEffect(() => {
     setRequiredFieldsBody(_ => Dict.make())
     None
   }, [paymentMethodType])
 
-  let {billingAddress, redirectionInfo, layout} = Recoil.useRecoilValueFromAtom(optionAtom)
-  let layoutClass = CardUtils.getLayoutClass(layout)
-  let cvcIcon = layoutClass.cvcIcon
-
-  //<...>//
   let paymentMethodTypes = PaymentUtils.usePaymentMethodTypeFromList(
     ~paymentMethodListValue,
     ~paymentMethod,
     ~paymentMethodType,
   )
 
-  let paymentMethodTypesV2 = PaymentUtilsV2.usePaymentMethodTypeFromListV2(
-    ~paymentsListValueV2=paymentManagementListValue,
-    ~paymentMethod,
-    ~paymentMethodType,
-  )
-
-  let creditPaymentMethodTypes = PaymentUtils.usePaymentMethodTypeFromList(
-    ~paymentMethodListValue,
-    ~paymentMethod,
-    ~paymentMethodType="credit",
-  )
-
-  let creditPaymentMethodTypesV2 = PaymentUtilsV2.usePaymentMethodTypeFromListV2(
-    ~paymentsListValueV2=paymentManagementListValue,
-    ~paymentMethod,
-    ~paymentMethodType="credit",
-  )
-
-  let requiredFieldsWithBillingDetails = React.useMemo(() => {
-    if paymentMethod === "card" {
-      switch contextPaymentType {
-      | PaymentMethodsManagement =>
-        let creditRequiredFields =
-          paymentManagementListValue.paymentMethodsEnabled
-          ->Array.filter(item => {
-            item.paymentMethodSubtype === "credit" && item.paymentMethodType === "card"
-          })
-          ->Array.get(0)
-          ->Option.getOr(UnifiedHelpersV2.defaultPaymentMethods)
-
-        let finalCreditRequiredFields = creditRequiredFields.requiredFields
-        [
-          ...paymentMethodTypes.required_fields,
-          ...finalCreditRequiredFields,
-        ]->removeRequiredFieldsDuplicates
-
-      | _ =>
-        let creditRequiredFields = creditPaymentMethodTypes.required_fields
-
-        [
-          ...paymentMethodTypes.required_fields,
-          ...creditRequiredFields,
-        ]->removeRequiredFieldsDuplicates
-      }
-    } else if dynamicFieldsEnabledPaymentMethods->Array.includes(paymentMethodType) {
-      switch contextPaymentType {
-      | PaymentMethodsManagement => paymentMethodTypesV2.requiredFields
-      | _ => paymentMethodTypes.required_fields
-      }
-    } else {
-      []
+  let rawConfigs = React.useMemo(() => {
+    switch sdkConfigs {
+    | Loaded(json) => json->getDictFromJson->Dict.get("raw_configs")
+    | _ => None
     }
+  }, [sdkConfigs])
+
+  let getSuperpositionFinalFields = ConfigurationService.useConfigurationService(
+    ~rawConfigs
+  )
+
+  let requiredFieldsFromPMLFlat = React.useMemo(() => {
+    extractValuesFromPMLRequiredFields(paymentMethodTypes.required_fields)
+  }, [paymentMethodTypes.required_fields])
+
+  let eligibleConnectors = React.useMemo(() => {
+    getEligibleConnectors(paymentMethodTypes, paymentMethod)
+  }, (paymentMethodTypes, paymentMethod))
+
+  let superpositionBaseContext = React.useMemo(() => {
+    buildSuperpositionBaseContext(
+      ~paymentMethod,
+      ~paymentMethodType,
+      ~country,
+      ~paymentMethodListValue,
+    )
+  }, (paymentMethod, paymentMethodType, country, paymentMethodListValue))
+
+  let (_requiredFields, missingRequiredFields, initialValues) = React.useMemo(() => {
+    getSuperpositionFinalFields(
+      eligibleConnectors,
+      superpositionBaseContext,
+      requiredFieldsFromPMLFlat,
+    )
   }, (
-    paymentMethod,
-    paymentMethodTypes.required_fields,
-    paymentMethodTypesV2.requiredFields,
-    paymentMethodType,
-    creditPaymentMethodTypes.required_fields,
-    creditPaymentMethodTypesV2.requiredFields,
+    getSuperpositionFinalFields,
+    eligibleConnectors,
+    superpositionBaseContext,
+    requiredFieldsFromPMLFlat,
   ))
 
-  let requiredFields = React.useMemo(() => {
-    requiredFieldsWithBillingDetails
-    ->removeBillingDetailsIfUseBillingAddress(billingAddress)
-    ->removeClickToPayFieldsIfSaveDetailsWithClickToPay(isSaveDetailsWithClickToPay)
-  }, (requiredFieldsWithBillingDetails, isSaveDetailsWithClickToPay))
-
-  let isAllStoredCardsHaveName = React.useMemo(() => {
-    PaymentType.getIsStoredPaymentMethodHasName(savedMethod)
-  }, [savedMethod])
-
-  //<...>//
-
-  let clickToPayConfig = Recoil.useRecoilValueFromAtom(RecoilAtoms.clickToPayConfig)
-
-  let fieldsArr = React.useMemo(() => {
-    PaymentMethodsRecord.getPaymentMethodFields(
-      paymentMethodType,
-      requiredFields,
-      ~isSavedCardFlow,
-      ~isAllStoredCardsHaveName,
-      ~localeString,
+  let missingRequiredFieldsFiltered = React.useMemo(() => {
+    let afterBillingFilter = removeBillingDetailsIfUseBillingAddress(
+      missingRequiredFields,
+      billingAddress,
     )
-    ->updateDynamicFields(billingAddress, isSaveDetailsWithClickToPay, clickToPayConfig)
-    ->Belt.SortArray.stableSortBy(PaymentMethodsRecord.sortPaymentMethodFields)
-    //<...>//
-  }, (requiredFields, isAllStoredCardsHaveName, isSavedCardFlow, isSaveDetailsWithClickToPay))
 
-  let isSpacedInnerLayout = config.appearance.innerLayout === Spaced
+    let firstEmailPath =
+      afterBillingFilter
+      ->Array.filter(fieldConfig => fieldConfig.fieldRenderType === Email)
+      ->Array.toSorted((a, b) => (a.fieldDisplayOrder - b.fieldDisplayOrder)->Int.toFloat)
+      ->Array.get(0)
+      ->Option.map(fieldConfig => fieldConfig.confirmRequestWritePath)
 
-  let (line1, setLine1) = Recoil.useRecoilState(userAddressline1)
-  let (line2, setLine2) = Recoil.useRecoilState(userAddressline2)
-  let (city, setCity) = Recoil.useRecoilState(userAddressCity)
-  let (state, setState) = Recoil.useRecoilState(userAddressState)
-  let (postalCode, setPostalCode) = Recoil.useRecoilState(userAddressPincode)
+    // remove fields that would render as React.null:
+    //   - CardNumber and Cvc (rendered separately via cardProps/cvcProps)
+    //   - Any card-data fields (card_exp_month, card_exp_year, card_network, etc.)
+    //     that live under payment_method_data.card.* — handled by card iframe widgets
+    //   - Duplicate Email fields (only the first path is rendered)
+    //   - CardHolderName last_name (rendered inside the first_name field)
+    //   - Dropdown fields with no options (would render React.null anyway)
+    afterBillingFilter->Array.filter(field => {
+      switch field.fieldRenderType {
+      | CardNumber | Cvc => false
+      | Dropdown =>
+        let options = field.dropdownOptions->Option.getOr([])
+        options->Array.length > 0
+      | Email => firstEmailPath === Some(field.confirmRequestWritePath)
+      | CardHolderName => !(field.confirmRequestWritePath->String.endsWith(".last_name"))
+      | _ => !(field.confirmRequestWritePath->String.startsWith("payment_method_data.card."))
+      }
+    })
+  }, (missingRequiredFields, billingAddress.isUseBillingAddress))
 
-  let (currency, setCurrency) = Recoil.useRecoilState(userCurrency)
-  let line1Ref = React.useRef(Nullable.null)
-  let line2Ref = React.useRef(Nullable.null)
-  let cityRef = React.useRef(Nullable.null)
-  let bankAccountNumberRef = React.useRef(Nullable.null)
-  let sourceBankAccountIdRef = React.useRef(Nullable.null)
-  let postalRef = React.useRef(Nullable.null)
-  let (selectedBank, setSelectedBank) = Recoil.useRecoilState(userBank)
-  let (country, setCountry) = Recoil.useRecoilState(userCountry)
+  let billingPrefix = "payment_method_data.billing."
 
-  let (bankAccountNumber, setBankAccountNumber) = Recoil.useRecoilState(userBankAccountNumber)
-  let (sourceBankAccountId, setSourceBankAccountId) = Recoil.useRecoilState(sourceBankAccountId)
-  let countryList = CountryStateDataRefs.countryDataRef.contents
-  let stateNames = getStateNames({
-    value: country,
-    isValid: None,
-    errorString: "",
-  })
+  let dynamicFieldsOutsideBilling = React.useMemo(() => {
+    missingRequiredFieldsFiltered->Array.filter(field =>
+      !(field.confirmRequestWritePath->String.startsWith(billingPrefix)) ||
+      field.fieldRenderType === CardHolderName
+    )
+  }, [missingRequiredFieldsFiltered])
 
-  let bankNames = Bank.getBanks(paymentMethodType)->getBankNames(paymentMethodTypes.bank_names)
+  let dynamicFieldsInsideBilling = React.useMemo(() => {
+    missingRequiredFieldsFiltered->Array.filter(field =>
+      field.confirmRequestWritePath->String.startsWith(billingPrefix) &&
+        field.fieldRenderType !== CardHolderName
+    )
+  }, [missingRequiredFieldsFiltered])
 
-  let countryNames = getCountryNames(Country.getCountry(paymentMethodType, countryList))
+  // Collect all Email-type paths globally (sorted by fieldDisplayOrder) so that
+  // a single Email widget writes to all output paths.
+  // Sourced from missingRequiredFields (before dedup filtering) to preserve all write targets.
+  let allEmailPaths = React.useMemo(() => {
+    missingRequiredFields
+    ->Array.filter(fieldConfig => fieldConfig.fieldRenderType === Email)
+    ->Array.map(fieldConfig => fieldConfig.confirmRequestWritePath)
+  }, [missingRequiredFields])
 
-  let setCurrency = val => {
-    setCurrency(val)
-  }
-  let setSelectedBank = val => {
-    setSelectedBank(val)
-  }
-  let setCountry = val => {
-    setCountry(val)
-  }
+  let formRef: React.ref<option<ReactFinalForm.Form.formMethods>> = React.useRef(None)
 
-  let defaultCardProps = CardUtils.useDefaultCardProps()
-  let defaultExpiryProps = CardUtils.useDefaultExpiryProps()
-  let defaultCvcProps = CardUtils.useDefaultCvcProps()
-
-  let cardProps = switch cardProps {
-  | Some(props) => props
-  | None => defaultCardProps
-  }
-
-  let expiryProps = switch expiryProps {
-  | Some(props) => props
-  | None => defaultExpiryProps
-  }
-
-  let cvcProps = switch cvcProps {
-  | Some(props) => props
-  | None => defaultCvcProps
-  }
-
-  let {
-    isCardValid,
-    setIsCardValid,
-    cardNumber,
-    changeCardNumber,
-    handleCardBlur,
-    cardRef,
-    icon,
-    cardError,
-    maxCardLength,
-  } = cardProps
-
-  let {
-    isExpiryValid,
-    setIsExpiryValid,
-    cardExpiry,
-    changeCardExpiry,
-    handleExpiryBlur,
-    expiryRef,
-    expiryError,
-  } = expiryProps
-
-  let {
-    isCVCValid,
-    setIsCVCValid,
-    cvcNumber,
-    changeCVCNumber,
-    handleCVCBlur,
-    cvcRef,
-    cvcError,
-  } = cvcProps
-
-  let isCvcValidValue = CardUtils.getBoolOptionVal(isCVCValid)
-  let (cardEmpty, cardComplete, cardInvalid) = CardUtils.useCardDetails(
-    ~cvcNumber,
-    ~isCVCValid,
-    ~isCvcValidValue,
-  )
-
-  React.useEffect0(() => {
-    let bank = bankNames->Array.get(0)->Option.getOr("")
-    setSelectedBank(_ => bank)
-    None
-  })
-
-  let onPostalChange = ev => {
-    let val = ReactEvent.Form.target(ev)["value"]
-
-    if val !== "" {
-      setPostalCode(_ => {
-        isValid: Some(true),
-        value: val,
-        errorString: "",
-      })
-    } else {
-      setPostalCode(_ => {
-        isValid: Some(false),
-        value: val,
-        errorString: "",
-      })
+  let submitCallback = React.useCallback((ev: Window.event) => {
+    let json = ev.data->safeParse
+    let confirm = json->getDictFromJson->ConfirmType.itemToObjMapper
+    if confirm.doSubmit {
+      formRef.current->Option.forEach(form => form.submit())
     }
-  }
+  }, [formRef])
 
-  useRequiredFieldsEmptyAndValid(
-    ~requiredFields,
-    ~fieldsArr,
-    ~countryNames,
-    ~bankNames,
-    ~isCardValid,
-    ~isExpiryValid,
-    ~isCVCValid,
-    ~cardNumber,
-    ~cardExpiry,
-    ~cvcNumber,
-    ~isSavedCardFlow,
-  )
-
-  useSetInitialRequiredFields(
-    ~requiredFields={
-      billingAddress.usePrefilledValues === Auto ? requiredFieldsWithBillingDetails : requiredFields
-    },
-    ~paymentMethodType,
-  )
-
-  useRequiredFieldsBody(
-    ~requiredFields,
-    ~paymentMethodType,
-    ~cardNumber,
-    ~cardExpiry,
-    ~cvcNumber,
-    ~isSavedCardFlow,
-    ~isAllStoredCardsHaveName,
-    ~setRequiredFieldsBody,
-  )
-
-  let submitCallback = useSubmitCallback()
   useSubmitPaymentData(submitCallback)
 
   let bottomElement = <InfoElement />
-
-  let getCustomFieldName = (item: PaymentMethodsRecord.paymentMethodsFields) => {
-    if (
-      requiredFields
-      ->Array.filter(requiredFieldType =>
-        requiredFieldType.field_type === item &&
-          requiredFieldType.display_name === "card_holder_name"
-      )
-      ->Array.length > 0
-    ) {
-      Some(localeString.cardHolderName)
-    } else {
-      None
-    }
-  }
-
-  let dynamicFieldsToRenderOutsideBilling = React.useMemo(() => {
-    fieldsArr->Array.filter(isFieldTypeToRenderOutsideBilling)
-  }, [fieldsArr])
-
-  let dynamicFieldsToRenderInsideBilling = React.useMemo(() => {
-    fieldsArr->Array.filter(field => !(field->isFieldTypeToRenderOutsideBilling))
-  }, [fieldsArr])
-
-  let isInfoElementPresent = dynamicFieldsToRenderOutsideBilling->Array.includes(InfoElement)
+  let isSpacedInnerLayout = config.appearance.innerLayout === Spaced
+  let isRenderDynamicFieldsInsideBilling = dynamicFieldsInsideBilling->Array.length > 0
+  let isInfoElementPresent = React.useMemo(() => {
+    PaymentMethodsRecord.getPaymentMethodsFields(~localeString)
+    ->Array.find(pm => pm.paymentMethodName === paymentMethodType)
+    ->Option.map(pm => pm.fields->Array.includes(PaymentMethodsRecord.InfoElement))
+    ->Option.getOr(false)
+  }, [paymentMethodType])
   let isRenderInfoElement =
     isInfoElementPresent && !isDisableInfoElement && redirectionInfo === ShowRedirectionInfo
 
-  let isRenderDynamicFieldsInsideBilling = dynamicFieldsToRenderInsideBilling->Array.length > 0
+  let spacedStylesForBillingDetails = isSpacedInnerLayout ? "p-2" : "my-2"
+  let hasAnyField = missingRequiredFieldsFiltered->Array.length > 0
+  let setAreRequiredFieldsValid = Recoil.useSetRecoilState(areRequiredFieldsValid)
 
-  let spacedStylesForBiilingDetails = isSpacedInnerLayout ? "p-2" : "my-2"
+  <>
+    <RenderIf condition={!isSavedCardFlow && hasAnyField}>
+      <ReactFinalForm.Form
+        initialValues={Some(initialValues)}
+        onSubmit={_values => ()}
+        render={formProps => {
+          formRef.current = Some(formProps.form)
 
-  <RenderIf condition={!isSavedCardFlow && fieldsArr->Array.length > 0}>
-    {<>
-      {dynamicFieldsToRenderOutsideBilling
-      ->Array.mapWithIndex((item, index) => {
-        <DynamicFieldsToRenderWrapper key={index->Int.toString} index={index} isInside={false}>
-          {switch item {
-          | CardNumber =>
-            <PaymentInputField
-              fieldName=localeString.cardNumberLabel
-              isValid=isCardValid
-              setIsValid=setIsCardValid
-              value=cardNumber
-              onChange=changeCardNumber
-              onBlur=handleCardBlur
-              rightIcon={icon}
-              errorString=cardError
-              type_="tel"
-              maxLength=maxCardLength
-              inputRef=cardRef
-              placeholder="1234 1234 1234 1234"
-              autocomplete="cc-number"
-            />
-          | GiftCardNumber => <GiftCardNumberInput />
-          | CardExpiryMonth
-          | CardExpiryYear
-          | CardExpiryMonthAndYear =>
-            <PaymentInputField
-              fieldName=localeString.validThruText
-              isValid=isExpiryValid
-              setIsValid=setIsExpiryValid
-              value=cardExpiry
-              onChange=changeCardExpiry
-              onBlur=handleExpiryBlur
-              errorString=expiryError
-              type_="tel"
-              maxLength=7
-              inputRef=expiryRef
-              placeholder=localeString.expiryPlaceholder
-              autocomplete="cc-exp"
-            />
-          | CardCvc =>
-            <PaymentInputField
-              fieldName=localeString.cvcTextLabel
-              isValid=isCVCValid
-              setIsValid=setIsCVCValid
-              value=cvcNumber
-              onChange=changeCVCNumber
-              onBlur=handleCVCBlur
-              errorString=cvcError
-              rightIcon={CardUtils.setRightIconForCvc(
-                ~cardEmpty,
-                ~cardInvalid,
-                ~color=themeObj.colorIconCardCvcError,
-                ~cardComplete,
-                ~cvcIcon,
-              )}
-              type_="tel"
-              className="tracking-widest w-full"
-              maxLength=4
-              inputRef=cvcRef
-              placeholder="123"
-              autocomplete="cc-csc"
-            />
-          | GiftCardPin => <GiftCardPinInput />
+          ReactFinalForm.useFormStateHandler(
+            ~onFormChange=values => {
+              // Flatten the nested form values so keys align correctly during merge using `mergeAndFlattenToTuples`.
+              let flatValues = values->JSON.Encode.object->Utils.flattenObject(false)
+              setRequiredFieldsBody(_ => flatValues)
+            },
+            ~onValidationChange=isValid => {
+              setAreRequiredFieldsValid(_ => isValid)
+            },
+            ~formProps,
+          )
 
-          | CardExpiryAndCvc =>
-            <div className="flex gap-10">
-              <PaymentInputField
-                fieldName=localeString.validThruText
-                isValid=isExpiryValid
-                setIsValid=setIsExpiryValid
-                value=cardExpiry
-                onChange=changeCardExpiry
-                onBlur=handleExpiryBlur
-                errorString=expiryError
-                type_="tel"
-                maxLength=7
-                inputRef=expiryRef
-                placeholder=localeString.expiryPlaceholder
-                autocomplete="cc-exp"
-              />
-              <PaymentInputField
-                fieldName=localeString.cvcTextLabel
-                isValid=isCVCValid
-                setIsValid=setIsCVCValid
-                value=cvcNumber
-                onChange=changeCVCNumber
-                onBlur=handleCVCBlur
-                errorString=cvcError
-                rightIcon={CardUtils.setRightIconForCvc(
-                  ~cardEmpty,
-                  ~cardInvalid,
-                  ~color=themeObj.colorIconCardCvcError,
-                  ~cardComplete,
-                  ~cvcIcon,
-                )}
-                type_="tel"
-                className="tracking-widest w-full"
-                maxLength=4
-                inputRef=cvcRef
-                placeholder="123"
-                autocomplete="cc-csc"
-              />
-            </div>
-          | Currency(currencyArr) =>
-            let updatedCurrencyArray =
-              currencyArr->DropdownField.updateArrayOfStringToOptionsTypeArray
-            <DropdownField
-              appearance=config.appearance
-              fieldName=localeString.currencyLabel
-              value=currency
-              setValue=setCurrency
-              disabled=false
-              options=updatedCurrencyArray
-            />
-          | DocumentType(opt) => {
-              let updatedDocumentTypeArray =
-                opt->DropdownField.updateArrayOfStringToOptionsTypeArrayWithUpperCaseLabel
-              <DocumentNumberInput options={updatedDocumentTypeArray} />
-            }
-          | FullName =>
-            <>
-              <RenderIf condition={!isSpacedInnerLayout}>
+          <>
+            {DynamicFieldInput.groupFieldsByRow(dynamicFieldsOutsideBilling)
+            ->Array.mapWithIndex((row, rowIdx) => {
+              <DynamicFieldsToRenderWrapper
+                key={`outside-row-${rowIdx->Int.toString}`} index={rowIdx} isInside={false}>
+                <DynamicFieldInput.makeRow
+                  fields={row}
+                  allFields={dynamicFieldsOutsideBilling}
+                  globalEmailPaths={allEmailPaths}
+                />
+              </DynamicFieldsToRenderWrapper>
+            })
+            ->React.array}
+            <RenderIf condition={isRenderDynamicFieldsInsideBilling}>
+              <div
+                className={`billing-section ${spacedStylesForBillingDetails} w-full text-left`}
+                style={
+                  border: {isSpacedInnerLayout ? `1px solid ${themeObj.borderColor}` : ""},
+                  borderRadius: {isSpacedInnerLayout ? themeObj.borderRadius : ""},
+                }>
                 <div
+                  className="billing-details-text"
                   style={
                     marginBottom: "5px",
                     fontSize: themeObj.fontSizeLg,
                     opacity: "0.6",
                   }>
-                  {item->getCustomFieldName->Option.getOr("")->React.string}
+                  {React.string(localeString.billingDetailsText)}
                 </div>
-              </RenderIf>
-              <FullNamePaymentInput
-                customFieldName={item->getCustomFieldName}
-                optionalRequiredFields={Some(requiredFields)}
-              />
-            </>
-          | CryptoCurrencyNetworks => <CryptoCurrencyNetworks />
-          | DateOfBirth => <DateOfBirth />
-          | VpaId => <VpaIdPaymentInput />
-          | PixKey => <PixPaymentInput fieldType="pixKey" />
-          | PixCPF => <PixPaymentInput fieldType="pixCPF" />
-          | PixCNPJ => <PixPaymentInput fieldType="pixCNPJ" />
-          | BankAccountNumber | IBAN =>
-            <PaymentField
-              fieldName="IBAN"
-              setValue={setBankAccountNumber}
-              value=bankAccountNumber
-              onChange={ev => {
-                let value = ReactEvent.Form.target(ev)["value"]
-                setBankAccountNumber(_ => {
-                  isValid: Some(value !== ""),
-                  value,
-                  errorString: value !== "" ? "" : localeString.ibanEmptyText,
-                })
-              }}
-              onBlur={ev => {
-                let value = ReactEvent.Focus.target(ev)["value"]
-                setBankAccountNumber(prev => {
-                  ...prev,
-                  errorString: value !== "" ? "" : localeString.ibanEmptyText,
-                  isValid: Some(value !== ""),
-                })
-              }}
-              type_="text"
-              name="bankAccountNumber"
-              maxLength=42
-              inputRef=bankAccountNumberRef
-              placeholder="DE00 0000 0000 0000 0000 00"
-            />
-          | SourceBankAccountId =>
-            <PaymentField
-              fieldName="Source Bank Account ID"
-              setValue={setSourceBankAccountId}
-              value=sourceBankAccountId
-              onChange={ev => {
-                let value = ReactEvent.Form.target(ev)["value"]
-                setSourceBankAccountId(_ => {
-                  isValid: Some(value !== ""),
-                  value,
-                  errorString: value !== "" ? "" : localeString.sourceBankAccountIdEmptyText,
-                })
-              }}
-              onBlur={ev => {
-                let value = ReactEvent.Focus.target(ev)["value"]
-                setSourceBankAccountId(prev => {
-                  ...prev,
-                  isValid: Some(value !== ""),
-                })
-              }}
-              type_="text"
-              name="sourceBankAccountId"
-              maxLength=42
-              inputRef=sourceBankAccountIdRef
-              placeholder="DE00 0000 0000 0000 0000 00"
-            />
-          | DocumentNumber
-          | Email
-          | InfoElement
-          | Country
-          | Bank
-          | None
-          | BillingName
-          | PhoneNumber
-          | AddressLine1
-          | AddressLine2
-          | AddressCity
-          | StateAndCity
-          | AddressPincode
-          | AddressState
-          | BlikCode
-          | SpecialField(_)
-          | CountryAndPincode(_)
-          | AddressCountry(_)
-          | ShippingName // Shipping Details are currently supported by only one click widgets
-          | ShippingAddressLine1
-          | ShippingAddressLine2
-          | ShippingAddressCity
-          | ShippingAddressPincode
-          | ShippingAddressState
-          | PhoneCountryCode
-          | PhoneNumberAndCountryCode
-          | LanguagePreference(_)
-          | ShippingAddressCountry(_)
-          | BankList(_) => React.null
-          }}
-        </DynamicFieldsToRenderWrapper>
-      })
-      ->React.array}
-      <RenderIf condition={isRenderDynamicFieldsInsideBilling}>
-        <div
-          className={`billing-section ${spacedStylesForBiilingDetails} w-full text-left`}
-          style={
-            border: {isSpacedInnerLayout ? `1px solid ${themeObj.borderColor}` : ""},
-            borderRadius: {isSpacedInnerLayout ? themeObj.borderRadius : ""},
-          }>
-          <div
-            className="billing-details-text"
-            style={
-              marginBottom: "5px",
-              fontSize: themeObj.fontSizeLg,
-              opacity: "0.6",
-            }>
-            {React.string(localeString.billingDetailsText)}
-          </div>
-          <div
-            className={`flex flex-col`}
-            style={
-              gap: isSpacedInnerLayout ? themeObj.spacingGridRow : "",
-            }>
-            {dynamicFieldsToRenderInsideBilling
-            ->Array.mapWithIndex((item, index) => {
-              <DynamicFieldsToRenderWrapper key={index->Int.toString} index={index}>
-                {switch item {
-                | BillingName => <BillingNamePaymentInput requiredFields />
-                | Email => <EmailPaymentInput />
-                | PhoneNumberAndCountryCode => <PhoneNumberPaymentInput />
-                | StateAndCity =>
-                  <div className={`flex ${isSpacedInnerLayout ? "gap-4" : ""} overflow-hidden`}>
-                    <PaymentField
-                      fieldName=localeString.cityLabel
-                      setValue={setCity}
-                      value=city
-                      onChange={ev => {
-                        let value = ReactEvent.Form.target(ev)["value"]
-                        setCity(prev => {
-                          isValid: Some(value !== ""),
-                          value,
-                          errorString: value !== "" ? "" : prev.errorString,
-                        })
-                      }}
-                      onBlur={ev => {
-                        let value = ReactEvent.Focus.target(ev)["value"]
-                        setCity(prev => {
-                          ...prev,
-                          isValid: Some(value !== ""),
-                        })
-                      }}
-                      type_="text"
-                      name="city"
-                      inputRef=cityRef
-                      placeholder=localeString.cityLabel
-                      className={isSpacedInnerLayout ? "" : "!border-r-0"}
-                    />
-                    <RenderIf condition={stateNames->Array.length > 0}>
-                      <PaymentDropDownField
-                        fieldName=localeString.stateLabel
-                        value=state
-                        setValue=setState
-                        options={stateNames}
+                <div
+                  className="flex flex-col"
+                  style={
+                    gap: isSpacedInnerLayout ? themeObj.spacingGridRow : "",
+                  }>
+                  {DynamicFieldInput.groupFieldsByRow(dynamicFieldsInsideBilling)
+                  ->Array.mapWithIndex((row, rowIdx) => {
+                    <DynamicFieldsToRenderWrapper
+                      key={`inside-row-${rowIdx->Int.toString}`} index={rowIdx}>
+                      <DynamicFieldInput.makeRow
+                        fields={row}
+                        allFields={dynamicFieldsInsideBilling}
+                        globalEmailPaths={allEmailPaths}
                       />
-                    </RenderIf>
-                  </div>
-                | CountryAndPincode(countryArr) =>
-                  let updatedCountryArray =
-                    countryArr->DropdownField.updateArrayOfStringToOptionsTypeArray
-                  <div className={`flex ${isSpacedInnerLayout ? "gap-4" : ""}`}>
-                    <DropdownField
-                      appearance=config.appearance
-                      fieldName=localeString.countryLabel
-                      value=country
-                      setValue=setCountry
-                      disabled=false
-                      options=updatedCountryArray
-                      className={isSpacedInnerLayout ? "" : "!border-t-0 !border-r-0"}
-                    />
-                    <PaymentField
-                      fieldName=localeString.postalCodeLabel
-                      setValue={setPostalCode}
-                      value=postalCode
-                      onBlur={ev => {
-                        let value = ReactEvent.Focus.target(ev)["value"]
-                        setPostalCode(prev => {
-                          ...prev,
-                          isValid: Some(value !== ""),
-                        })
-                      }}
-                      onChange=onPostalChange
-                      name="postal"
-                      inputRef=postalRef
-                      placeholder=localeString.postalCodeLabel
-                      className={isSpacedInnerLayout ? "" : "!border-t-0"}
-                    />
-                  </div>
-                | AddressLine1 =>
-                  <PaymentField
-                    fieldName=localeString.line1Label
-                    setValue={setLine1}
-                    value=line1
-                    onChange={ev => {
-                      let value = ReactEvent.Form.target(ev)["value"]
-                      setLine1(prev => {
-                        isValid: Some(value !== ""),
-                        value,
-                        errorString: value !== "" ? "" : prev.errorString,
-                      })
-                    }}
-                    onBlur={ev => {
-                      let value = ReactEvent.Focus.target(ev)["value"]
-                      setLine1(prev => {
-                        ...prev,
-                        isValid: Some(value !== ""),
-                      })
-                    }}
-                    type_="text"
-                    name="line1"
-                    inputRef=line1Ref
-                    placeholder=localeString.line1Placeholder
-                    className={isSpacedInnerLayout ? "" : "!border-b-0"}
-                  />
-                | AddressLine2 =>
-                  <PaymentField
-                    fieldName=localeString.line2Label
-                    setValue={setLine2}
-                    value=line2
-                    onChange={ev => {
-                      let value = ReactEvent.Form.target(ev)["value"]
-                      setLine2(prev => {
-                        isValid: Some(value !== ""),
-                        value,
-                        errorString: value !== "" ? "" : prev.errorString,
-                      })
-                    }}
-                    onBlur={ev => {
-                      let value = ReactEvent.Focus.target(ev)["value"]
-                      setLine2(prev => {
-                        ...prev,
-                        isValid: Some(value !== ""),
-                      })
-                    }}
-                    type_="text"
-                    name="line2"
-                    inputRef=line2Ref
-                    placeholder=localeString.line2Placeholder
-                  />
-                | AddressCity =>
-                  <PaymentField
-                    fieldName=localeString.cityLabel
-                    setValue={setCity}
-                    value=city
-                    onChange={ev => {
-                      let value = ReactEvent.Form.target(ev)["value"]
-                      setCity(prev => {
-                        isValid: Some(value !== ""),
-                        value,
-                        errorString: value !== "" ? "" : prev.errorString,
-                      })
-                    }}
-                    onBlur={ev => {
-                      let value = ReactEvent.Focus.target(ev)["value"]
-                      setCity(prev => {
-                        ...prev,
-                        isValid: Some(value !== ""),
-                      })
-                    }}
-                    type_="text"
-                    name="city"
-                    inputRef=cityRef
-                    placeholder=localeString.cityLabel
-                  />
-                | AddressState =>
-                  <RenderIf condition={stateNames->Array.length > 0}>
-                    <PaymentDropDownField
-                      fieldName=localeString.stateLabel
-                      value=state
-                      setValue=setState
-                      options={stateNames}
-                    />
-                  </RenderIf>
-                | AddressPincode =>
-                  <PaymentField
-                    fieldName=localeString.postalCodeLabel
-                    setValue=setPostalCode
-                    value=postalCode
-                    onBlur={ev => {
-                      let value = ReactEvent.Focus.target(ev)["value"]
-                      setPostalCode(prev => {
-                        ...prev,
-                        isValid: Some(value !== ""),
-                      })
-                    }}
-                    onChange=onPostalChange
-                    name="postal"
-                    inputRef=postalRef
-                    placeholder=localeString.postalCodeLabel
-                  />
-                | BlikCode => <BlikCodePaymentInput />
-                | Country =>
-                  let updatedCountryNames =
-                    countryNames->DropdownField.updateArrayOfStringToOptionsTypeArray
-                  <DropdownField
-                    appearance=config.appearance
-                    fieldName=localeString.countryLabel
-                    value=country
-                    setValue=setCountry
-                    disabled=false
-                    options=updatedCountryNames
-                  />
-                | AddressCountry(countryArr) =>
-                  let updatedCountryArr =
-                    countryArr->DropdownField.updateArrayOfStringToOptionsTypeArray
-                  <DropdownField
-                    appearance=config.appearance
-                    fieldName=localeString.countryLabel
-                    value=country
-                    setValue=setCountry
-                    disabled=false
-                    options=updatedCountryArr
-                  />
-                | BankList(bankArr) =>
-                  let updatedBankNames =
-                    Bank.getBanks(paymentMethodType)
-                    ->getBankNames(bankArr)
-                    ->DropdownField.updateArrayOfStringToOptionsTypeArray
-                  <DropdownField
-                    appearance=config.appearance
-                    fieldName=localeString.bankLabel
-                    value=selectedBank
-                    setValue=setSelectedBank
-                    disabled=false
-                    options=updatedBankNames
-                  />
-                | Bank =>
-                  let updatedBankNames =
-                    bankNames->DropdownField.updateArrayOfStringToOptionsTypeArray
-                  <DropdownField
-                    appearance=config.appearance
-                    fieldName=localeString.bankLabel
-                    value=selectedBank
-                    setValue=setSelectedBank
-                    disabled=false
-                    options=updatedBankNames
-                  />
-                | SpecialField(element) => element
-                | InfoElement
-                | PixKey
-                | PixCPF
-                | PixCNPJ
-                | DocumentType(_)
-                | DocumentNumber
-                | CardNumber
-                | CardExpiryMonth
-                | CardExpiryYear
-                | CardExpiryMonthAndYear
-                | CardCvc
-                | CardExpiryAndCvc
-                | Currency(_)
-                | FullName
-                | GiftCardNumber
-                | GiftCardPin
-                | ShippingName // Shipping Details are currently supported by only one click widgets
-                | ShippingAddressLine1
-                | ShippingAddressLine2
-                | ShippingAddressCity
-                | ShippingAddressPincode
-                | ShippingAddressState
-                | ShippingAddressCountry(_)
-                | CryptoCurrencyNetworks
-                | DateOfBirth
-                | PhoneNumber
-                | PhoneCountryCode
-                | VpaId
-                | LanguagePreference(_)
-                | BankAccountNumber
-                | IBAN
-                | SourceBankAccountId
-                | None => React.null
-                }}
-              </DynamicFieldsToRenderWrapper>
-            })
-            ->React.array}
-          </div>
-        </div>
-      </RenderIf>
-      <Surcharge paymentMethod paymentMethodType />
-      <RenderIf condition={isRenderInfoElement}>
-        {<>
-          {if fieldsArr->Array.length > 1 {
-            bottomElement
-          } else {
-            <Block bottomElement />
-          }}
-        </>}
-      </RenderIf>
-    </>}
-  </RenderIf>
+                    </DynamicFieldsToRenderWrapper>
+                  })
+                  ->React.array}
+                </div>
+              </div>
+            </RenderIf>
+            <Surcharge paymentMethod paymentMethodType />
+          </>
+        }}
+      />
+    </RenderIf>
+    <RenderIf condition={isRenderInfoElement}>
+      {if missingRequiredFieldsFiltered->Array.length >= 1 {
+        bottomElement
+      } else {
+        <Block bottomElement />
+      }}
+    </RenderIf>
+  </>
 }

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -100,13 +100,18 @@ let make = (
     let firstEmailPath =
       afterBillingFilter
       ->Array.filter(fieldConfig => fieldConfig.fieldRenderType === Email)
-      ->Array.toSorted((a, b) => (a.fieldDisplayOrder - b.fieldDisplayOrder)->Int.toFloat)
+      ->Array.get(0)
+      ->Option.map(fieldConfig => fieldConfig.confirmRequestWritePath)
+
+    let firstCardHolderNamePath =
+      afterBillingFilter
+      ->Array.filter(fieldConfig => fieldConfig.fieldRenderType === CardHolderName)
       ->Array.get(0)
       ->Option.map(fieldConfig => fieldConfig.confirmRequestWritePath)
 
     // remove fields that would render as React.null:
     //   - Any card-data fields (card_exp_month, card_exp_year, card_network, etc.)
-    //   - Duplicate Email fields (only the first path is rendered)
+    //   - Duplicate Email / CardHolderName fields (only the first path is rendered)
     //   - Dropdown fields with no options (would render React.null anyway)
     afterBillingFilter->Array.filter(field => {
       switch field.fieldRenderType {
@@ -115,6 +120,7 @@ let make = (
         let options = field.dropdownOptions->Option.getOr([])
         options->Array.length > 0
       | Email => firstEmailPath === Some(field.confirmRequestWritePath)
+      | CardHolderName => firstCardHolderNamePath === Some(field.confirmRequestWritePath)
       | _ => true
       }
     })
@@ -125,24 +131,25 @@ let make = (
   let dynamicFieldsOutsideBilling = React.useMemo(() => {
     missingRequiredFieldsFiltered->Array.filter(field =>
       !(field.confirmRequestWritePath->String.startsWith(billingPrefix)) ||
-      (paymentMethod == "card" && (field.fieldRenderType === FirstName || field.fieldRenderType === LastName))
+      (paymentMethod == "card" && field.fieldRenderType === CardHolderName)
     )
   }, [missingRequiredFieldsFiltered])
 
   let dynamicFieldsInsideBilling = React.useMemo(() => {
     missingRequiredFieldsFiltered->Array.filter(field =>
       field.confirmRequestWritePath->String.startsWith(billingPrefix) &&
-        !(paymentMethod == "card" && (field.fieldRenderType === FirstName || field.fieldRenderType === LastName))
+        !(paymentMethod == "card" && field.fieldRenderType === CardHolderName)
     )
   }, [missingRequiredFieldsFiltered])
 
-  // Collect all Email-type paths globally (sorted by fieldDisplayOrder) so that
-  // a single Email widget writes to all output paths.
-  // Sourced from missingRequiredFields (before dedup filtering) to preserve all write targets.
-  let allEmailPaths = React.useMemo(() => {
-    missingRequiredFields
-    ->Array.filter(fieldConfig => fieldConfig.fieldRenderType === Email)
-    ->Array.map(fieldConfig => fieldConfig.confirmRequestWritePath)
+  let allEmailFields = React.useMemo(() => {
+    missingRequiredFields->Array.filter(fieldConfig => fieldConfig.fieldRenderType === Email)
+  }, [missingRequiredFields])
+
+  let allCardHolderNameFields = React.useMemo(() => {
+    missingRequiredFields->Array.filter(fieldConfig =>
+      fieldConfig.fieldRenderType === CardHolderName
+    )
   }, [missingRequiredFields])
 
   let formRef: React.ref<option<ReactFinalForm.Form.formMethods>> = React.useRef(None)
@@ -195,15 +202,15 @@ let make = (
 
           <>
             {dynamicFieldsOutsideBilling
-            ->DynamicFieldInput.toFieldItems
-            ->DynamicFieldInput.groupItemsByRow
+            ->DynamicFieldInput.groupFieldsByRow
             ->Array.mapWithIndex((row, rowIdx) => {
               <DynamicFieldsToRenderWrapper
                 key={`outside-row-${rowIdx->Int.toString}`} index={rowIdx} isInside={false}>
                 <DynamicFieldInput.makeRow
                   items={row}
                   allFields={dynamicFieldsOutsideBilling}
-                  globalEmailPaths={allEmailPaths}
+                  globalEmailFields={allEmailFields}
+                  globalCardHolderNameFields={allCardHolderNameFields}
                 />
               </DynamicFieldsToRenderWrapper>
             })
@@ -230,15 +237,15 @@ let make = (
                     gap: isSpacedInnerLayout ? themeObj.spacingGridRow : "",
                   }>
                   {dynamicFieldsInsideBilling
-                  ->DynamicFieldInput.toFieldItems
-                  ->DynamicFieldInput.groupItemsByRow
+                  ->DynamicFieldInput.groupFieldsByRow
                   ->Array.mapWithIndex((row, rowIdx) => {
                     <DynamicFieldsToRenderWrapper
                       key={`inside-row-${rowIdx->Int.toString}`} index={rowIdx}>
                       <DynamicFieldInput.makeRow
                         items={row}
                         allFields={dynamicFieldsInsideBilling}
-                        globalEmailPaths={allEmailPaths}
+                        globalEmailFields={allEmailFields}
+                        globalCardHolderNameFields={allCardHolderNameFields}
                       />
                     </DynamicFieldsToRenderWrapper>
                   })

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -6,10 +6,16 @@ let make = (~firstNameField: fieldConfig, ~lastNameField: fieldConfig) => {
   let firstNamePath = firstNameField.confirmRequestWritePath
   let lastNamePath = lastNameField.confirmRequestWritePath
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
-    ~field=firstNameField,
-    ~localeObject=localeString,
-  )
+
+  let label = switch firstNameField.merchantProvidedDisplayName {
+  | Some(name) => name
+  | None => localeString.fullNameLabel
+  }
+  let placeholder = switch firstNameField.merchantProvidedPlaceholderText {
+  | Some(text) => text
+  | None => localeString.fullNamePlaceholder
+  }
+  let autocomplete = firstNameField.htmlAutocompleteAttribute
 
   let firstValidator = DynamicFieldsUtils.resolveValidator(
     ~field=firstNameField,
@@ -23,7 +29,11 @@ let make = (~firstNameField: fieldConfig, ~lastNameField: fieldConfig) => {
   let firstField = ReactFinalForm.useField(firstNamePath, ~config={validate: firstValidator})
   let lastField = ReactFinalForm.useField(lastNamePath, ~config={validate: lastValidator})
 
-  let (inputValue, setInputValue) = React.useState(_ => "")
+  let (inputValue, setInputValue) = React.useState(() => {
+    let first = firstField.input.value->Option.getOr("")
+    let last = lastField.input.value->Option.getOr("")
+    [first, last]->Array.filter(part => part !== "")->Array.join(" ")
+  })
 
   let handleChange = ev => {
     let value: string = ReactEvent.Form.target(ev)["value"]
@@ -69,6 +79,6 @@ let make = (~firstNameField: fieldConfig, ~lastNameField: fieldConfig) => {
     errorString
     placeholder
     inputRef={fieldRef}
-    autocomplete="cc-name"
+    ?autocomplete
   />
 }

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -1,80 +1,97 @@
 open SuperpositionTypes
 
+// "John Doe" -> ("John", "Doe")   "John" -> ("John", "")
+let splitName = (value: string): (string, string) =>
+  switch value->String.indexOf(" ") {
+  | -1 => (value, "")
+  | i => (value->String.substring(~start=0, ~end=i), value->String.substringToEnd(~start=i + 1))
+  }
+
+module FullNameFieldInput = {
+  @react.component
+  let make = (~firstNameFieldConfig: fieldConfig, ~lastNameFieldConfig: fieldConfig) => {
+    let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+
+    let firstValidator = DynamicFieldsUtils.resolveValidator(
+      ~field=firstNameFieldConfig,
+      ~localeObject=localeString,
+    )
+    let lastValidator = DynamicFieldsUtils.resolveValidator(
+      ~field=lastNameFieldConfig,
+      ~localeObject=localeString,
+    )
+
+    let firstProps = ReactFinalForm.useField(
+      firstNameFieldConfig.confirmRequestWritePath,
+      ~config={validate: firstValidator},
+    )
+    let lastProps = ReactFinalForm.useField(
+      lastNameFieldConfig.confirmRequestWritePath,
+      ~config={validate: lastValidator},
+    )
+
+    let inputRef = React.useRef(Nullable.null)
+    let (name, setName) = React.useState(() => {
+      let first = firstProps.input.value->Option.getOr("")
+      let last = lastProps.input.value->Option.getOr("")
+      [first, last]->Array.filter(val => val !== "")->Array.join(" ")
+    })
+
+    let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+      ~field=firstNameFieldConfig,
+      ~localeObject=localeString,
+    )
+    let autocomplete = firstNameFieldConfig.htmlAutocompleteAttribute
+
+    let handleChange = event => {
+      let value: string = ReactEvent.Form.target(event)["value"]
+      setName(_ => value)
+      let (firstName, lastName) = splitName(value)
+      firstProps.input.onChange(firstName)
+      lastProps.input.onChange(lastName)
+    }
+
+    let handleBlur = _event => {
+      firstProps.input.onBlur()
+      lastProps.input.onBlur()
+    }
+
+    let showError =
+      firstProps.meta.touched ||
+      firstProps.meta.submitFailed ||
+      lastProps.meta.touched ||
+      lastProps.meta.submitFailed
+    let allValid = firstProps.meta.valid && lastProps.meta.valid
+    let isValid = showError ? Some(allValid) : None
+    let errorString =
+      showError && !allValid
+        ? firstProps.meta.error->Option.getOr(lastProps.meta.error->Option.getOr(""))
+        : ""
+
+    <PaymentInputField
+      fieldName={label}
+      value={name}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      isValid
+      errorString
+      placeholder
+      inputRef
+      ?autocomplete
+    />
+  }
+}
+
 @react.component
-let make = (~firstNameField: fieldConfig, ~lastNameField: fieldConfig) => {
-  let fieldRef = React.useRef(Nullable.null)
-  let firstNamePath = firstNameField.confirmRequestWritePath
-  let lastNamePath = lastNameField.confirmRequestWritePath
-  let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+let make = (~fields: array<fieldConfig>) => {
+  let firstNameField = fields->Array.get(0)
+  let lastNameField = fields->Array.get(1)
 
-  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
-    ~field=firstNameField,
-    ~localeObject=localeString,
-  )
-  let autocomplete = firstNameField.htmlAutocompleteAttribute
-
-  let firstValidator = DynamicFieldsUtils.resolveValidator(
-    ~field=firstNameField,
-    ~localeObject=localeString,
-  )
-  let lastValidator = DynamicFieldsUtils.resolveValidator(
-    ~field=lastNameField,
-    ~localeObject=localeString,
-  )
-
-  let firstField = ReactFinalForm.useField(firstNamePath, ~config={validate: firstValidator})
-  let lastField = ReactFinalForm.useField(lastNamePath, ~config={validate: lastValidator})
-
-  let (inputValue, setInputValue) = React.useState(() => {
-    let first = firstField.input.value->Option.getOr("")
-    let last = lastField.input.value->Option.getOr("")
-    [first, last]->Array.filter(part => part !== "")->Array.join(" ")
-  })
-
-  let handleChange = ev => {
-    let value: string = ReactEvent.Form.target(ev)["value"]
-    setInputValue(_ => value)
-    let spaceIndex = value->String.indexOf(" ")
-    if spaceIndex === -1 {
-      firstField.input.onChange(value)
-      lastField.input.onChange("")
-    } else {
-      let firstName = value->String.substring(~start=0, ~end=spaceIndex)
-      let lastName = value->String.substringToEnd(~start=spaceIndex + 1)
-      firstField.input.onChange(firstName)
-      lastField.input.onChange(lastName)
-    }
+  switch (firstNameField, lastNameField) {
+  | (Some(firstNameFieldConfig), None) => <GenericInputField fieldConfig=firstNameFieldConfig />
+  | (None, Some(lastNameFieldConfig)) => <GenericInputField fieldConfig=lastNameFieldConfig />
+  | (Some(firstNameFieldConfig), Some(lastNameFieldConfig)) =>
+    <FullNameFieldInput firstNameFieldConfig lastNameFieldConfig />
+  | (_, _) => React.null
   }
-
-  let errorString = if (
-    (firstField.meta.touched && !firstField.meta.active) ||
-      (lastField.meta.touched && !lastField.meta.active)
-  ) {
-    switch (firstField.meta.error, lastField.meta.error) {
-    | (Some(err), _) => err
-    | (_, Some(err)) => err
-    | _ => ""
-    }
-  } else {
-    ""
-  }
-
-  let isValid =
-    firstField.meta.valid &&
-    (lastField.meta.valid || !lastField.meta.touched || lastField.meta.active)
-
-  <PaymentInputField
-    fieldName={label}
-    value={inputValue}
-    onChange={handleChange}
-    onBlur={_ev => {
-      firstField.input.onBlur()
-      lastField.input.onBlur()
-    }}
-    isValid={Some(isValid)}
-    errorString
-    placeholder
-    inputRef={fieldRef}
-    ?autocomplete
-  />
 }

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -1,12 +1,5 @@
 open SuperpositionTypes
 
-// "John Doe" -> ("John", "Doe")   "John" -> ("John", "")
-let splitName = (value: string): (string, string) =>
-  switch value->String.indexOf(" ") {
-  | -1 => (value, "")
-  | i => (value->String.substring(~start=0, ~end=i), value->String.substringToEnd(~start=i + 1))
-  }
-
 module FullNameFieldInput = {
   @react.component
   let make = (~firstNameFieldConfig: fieldConfig, ~lastNameFieldConfig: fieldConfig) => {
@@ -46,7 +39,7 @@ module FullNameFieldInput = {
     let handleChange = event => {
       let value: string = ReactEvent.Form.target(event)["value"]
       setName(_ => value)
-      let (firstName, lastName) = splitName(value)
+      let (firstName, lastName) = Utils.splitFullName(value)
       firstProps.input.onChange(firstName)
       lastProps.input.onChange(lastName)
     }

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -1,0 +1,84 @@
+open SuperpositionTypes
+
+@react.component
+let make = (
+  ~firstNameField: fieldConfig,
+  ~lastNameField: fieldConfig,
+) => {
+  let fieldRef = React.useRef(Nullable.null)
+  let firstNamePath = firstNameField.confirmRequestWritePath
+  let lastNamePath = lastNameField.confirmRequestWritePath
+  let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+    ~field=firstNameField,
+    ~localeObject=localeString,
+  )
+
+  let firstValidator = DynamicFieldsUtils.resolveValidator(
+    ~field=firstNameField,
+    ~localeObject=localeString,
+  )
+  let lastValidator = DynamicFieldsUtils.resolveValidator(
+    ~field=lastNameField,
+    ~localeObject=localeString,
+  )
+
+  let firstField = ReactFinalForm.useField(
+    firstNamePath,
+    ~config={validate: firstValidator},
+  )
+  let lastField = ReactFinalForm.useField(
+    lastNamePath,
+    ~config={validate: lastValidator},
+  )
+
+  let (inputValue, setInputValue) = React.useState(_ => "")
+
+  let handleChange = ev => {
+    let value: string = ReactEvent.Form.target(ev)["value"]
+    setInputValue(_ => value)
+    let spaceIndex = value->String.indexOf(" ")
+    if spaceIndex === -1 {
+      firstField.input.onChange(value)
+      lastField.input.onChange("")
+    } else {
+      let firstName = value->String.substring(~start=0, ~end=spaceIndex)
+      let lastName = value->String.substringToEnd(~start=spaceIndex + 1)
+      firstField.input.onChange(firstName)
+      lastField.input.onChange(lastName)
+    }
+  }
+
+  let errorString =
+    if (
+      (firstField.meta.touched && !firstField.meta.active) ||
+        (lastField.meta.touched && !lastField.meta.active)
+    ) {
+      switch (firstField.meta.error, lastField.meta.error) {
+      | (Some(err), _) => err
+      | (_, Some(err)) => err
+      | _ => ""
+      }
+    } else {
+      ""
+    }
+
+  let isValid =
+    firstField.meta.valid &&
+    (lastField.meta.valid || !lastField.meta.touched || lastField.meta.active)
+
+  <PaymentInputField
+    fieldName={label}
+    value={inputValue}
+    onChange={handleChange}
+    onBlur={_ev => {
+      firstField.input.onBlur()
+      lastField.input.onBlur()
+    }}
+    isValid={Some(isValid)}
+    errorString
+    placeholder
+    inputRef={fieldRef}
+    autocomplete="cc-name"
+  />
+}

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -7,14 +7,10 @@ let make = (~firstNameField: fieldConfig, ~lastNameField: fieldConfig) => {
   let lastNamePath = lastNameField.confirmRequestWritePath
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
 
-  let label = switch firstNameField.merchantProvidedDisplayName {
-  | Some(name) => name
-  | None => localeString.fullNameLabel
-  }
-  let placeholder = switch firstNameField.merchantProvidedPlaceholderText {
-  | Some(text) => text
-  | None => localeString.fullNamePlaceholder
-  }
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+    ~field=firstNameField,
+    ~localeObject=localeString,
+  )
   let autocomplete = firstNameField.htmlAutocompleteAttribute
 
   let firstValidator = DynamicFieldsUtils.resolveValidator(

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -1,10 +1,7 @@
 open SuperpositionTypes
 
 @react.component
-let make = (
-  ~firstNameField: fieldConfig,
-  ~lastNameField: fieldConfig,
-) => {
+let make = (~firstNameField: fieldConfig, ~lastNameField: fieldConfig) => {
   let fieldRef = React.useRef(Nullable.null)
   let firstNamePath = firstNameField.confirmRequestWritePath
   let lastNamePath = lastNameField.confirmRequestWritePath
@@ -23,14 +20,8 @@ let make = (
     ~localeObject=localeString,
   )
 
-  let firstField = ReactFinalForm.useField(
-    firstNamePath,
-    ~config={validate: firstValidator},
-  )
-  let lastField = ReactFinalForm.useField(
-    lastNamePath,
-    ~config={validate: lastValidator},
-  )
+  let firstField = ReactFinalForm.useField(firstNamePath, ~config={validate: firstValidator})
+  let lastField = ReactFinalForm.useField(lastNamePath, ~config={validate: lastValidator})
 
   let (inputValue, setInputValue) = React.useState(_ => "")
 
@@ -49,19 +40,18 @@ let make = (
     }
   }
 
-  let errorString =
-    if (
-      (firstField.meta.touched && !firstField.meta.active) ||
-        (lastField.meta.touched && !lastField.meta.active)
-    ) {
-      switch (firstField.meta.error, lastField.meta.error) {
-      | (Some(err), _) => err
-      | (_, Some(err)) => err
-      | _ => ""
-      }
-    } else {
-      ""
+  let errorString = if (
+    (firstField.meta.touched && !firstField.meta.active) ||
+      (lastField.meta.touched && !lastField.meta.active)
+  ) {
+    switch (firstField.meta.error, lastField.meta.error) {
+    | (Some(err), _) => err
+    | (_, Some(err)) => err
+    | _ => ""
     }
+  } else {
+    ""
+  }
 
   let isValid =
     firstField.meta.valid &&

--- a/src/Components/DynamicFields/CountryDropdownField.res
+++ b/src/Components/DynamicFields/CountryDropdownField.res
@@ -10,10 +10,11 @@ let make = (~fieldConfig: fieldConfig, ~options: array<DropdownField.optionType>
   let firstCountryName = options->Array.get(0)->Option.map(opt => opt.value)->Option.getOr("")
   let defaultCountryName = countryName !== "" ? countryName : firstCountryName
   let defaultIso = Utils.getCountryCode(defaultCountryName).isoAlpha2
+  let defaultIsoRef = React.useRef(defaultIso)
 
   let field = ReactFinalForm.useField(
     fieldConfig.confirmRequestWritePath,
-    ~config={validate, defaultValue: Some(defaultIso)},
+    ~config={validate, defaultValue: Some(defaultIsoRef.current)},
   )
 
   let storedIso = field.input.value->Option.getOr("")

--- a/src/Components/DynamicFields/CountryDropdownField.res
+++ b/src/Components/DynamicFields/CountryDropdownField.res
@@ -1,0 +1,37 @@
+open SuperpositionTypes
+
+@react.component
+let make = (
+  ~fieldConfig: fieldConfig,
+  ~options: array<DropdownField.optionType>,
+) => {
+  let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let validate =
+    DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+  let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
+  let firstOption = options->Array.get(0)->Option.map(opt => opt.value)->Option.getOr("")
+  let initialCountry = defaultCountry !== "" ? defaultCountry : firstOption
+  let initialIso = Utils.getCountryCode(initialCountry).isoAlpha2
+
+  let field = ReactFinalForm.useField(
+    fieldConfig.confirmRequestWritePath,
+    ~config={validate, initialValue: Some(initialIso)},
+  )
+
+  let (country, setCountry) = Recoil.useRecoilState(RecoilAtoms.userCountry)
+
+  <DropdownField
+    appearance={config.appearance}
+    fieldName={label}
+    value={country}
+    setValue={setter => {
+      let newVal = setter(field.input.value->Option.getOr(country))
+      setCountry(_ => newVal)
+      let countryIso = Utils.getCountryCode(newVal).isoAlpha2
+      field.input.onChange(countryIso)
+    }}
+    disabled=false
+    options
+  />
+}

--- a/src/Components/DynamicFields/CountryDropdownField.res
+++ b/src/Components/DynamicFields/CountryDropdownField.res
@@ -5,27 +5,37 @@ let make = (~fieldConfig: fieldConfig, ~options: array<DropdownField.optionType>
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
-  let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
-  let firstOption = options->Array.get(0)->Option.map(opt => opt.value)->Option.getOr("")
-  let initialCountry = defaultCountry !== "" ? defaultCountry : firstOption
-  let initialIso = Utils.getCountryCode(initialCountry).isoAlpha2
+  let (countryName, setCountryName) = Recoil.useRecoilState(RecoilAtoms.userCountry)
+
+  let firstCountryName = options->Array.get(0)->Option.map(opt => opt.value)->Option.getOr("")
+  let defaultCountryName = countryName !== "" ? countryName : firstCountryName
+  let defaultIso = Utils.getCountryCode(defaultCountryName).isoAlpha2
 
   let field = ReactFinalForm.useField(
     fieldConfig.confirmRequestWritePath,
-    ~config={validate, initialValue: Some(initialIso)},
+    ~config={validate, defaultValue: Some(defaultIso)},
   )
 
-  let (country, setCountry) = Recoil.useRecoilState(RecoilAtoms.userCountry)
+  let storedIso = field.input.value->Option.getOr("")
+  let effectiveCountryName =
+    storedIso !== "" ? Utils.getCountryNameFromCode(storedIso) : defaultCountryName
+
+  React.useEffect(() => {
+    if effectiveCountryName !== "" && countryName !== effectiveCountryName {
+      setCountryName(_ => effectiveCountryName)
+    }
+    None
+  }, [effectiveCountryName])
 
   <DropdownField
     appearance={config.appearance}
     fieldName={label}
-    value={country}
+    value={effectiveCountryName}
     setValue={setter => {
-      let newVal = setter(field.input.value->Option.getOr(country))
-      setCountry(_ => newVal)
-      let countryIso = Utils.getCountryCode(newVal).isoAlpha2
-      field.input.onChange(countryIso)
+      let selectedCountryName = setter(effectiveCountryName)
+      setCountryName(_ => selectedCountryName)
+      let selectedIso = Utils.getCountryCode(selectedCountryName).isoAlpha2
+      field.input.onChange(selectedIso)
     }}
     disabled=false
     options

--- a/src/Components/DynamicFields/CountryDropdownField.res
+++ b/src/Components/DynamicFields/CountryDropdownField.res
@@ -1,14 +1,10 @@
 open SuperpositionTypes
 
 @react.component
-let make = (
-  ~fieldConfig: fieldConfig,
-  ~options: array<DropdownField.optionType>,
-) => {
+let make = (~fieldConfig: fieldConfig, ~options: array<DropdownField.optionType>) => {
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
-  let validate =
-    DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
   let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let firstOption = options->Array.get(0)->Option.map(opt => opt.value)->Option.getOr("")
   let initialCountry = defaultCountry !== "" ? defaultCountry : firstOption

--- a/src/Components/DynamicFields/EmailField.res
+++ b/src/Components/DynamicFields/EmailField.res
@@ -1,42 +1,41 @@
 open SuperpositionTypes
 
 @react.component
-let make = (~fieldConfig: fieldConfig, ~paths: array<string>) => {
+let make = (~fields: array<fieldConfig>) => {
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
-    ~field=fieldConfig,
-    ~localeObject=localeString,
-  )
-  let autocomplete = fieldConfig.htmlAutocompleteAttribute->Option.getOr("email")
-  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
-  switch paths->Array.get(0) {
+  switch fields->Array.get(0) {
   | None => React.null
-  | Some(primaryPath) =>
+  | Some(primaryFieldConfig) =>
+    let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+      ~field=primaryFieldConfig,
+      ~localeObject=localeString,
+    )
+    let autocomplete = primaryFieldConfig.htmlAutocompleteAttribute->Option.getOr("email")
+    let validate = DynamicFieldsUtils.resolveValidator(
+      ~field=primaryFieldConfig,
+      ~localeObject=localeString,
+    )
+
     let form = ReactFinalForm.useForm()
-    let primaryField = ReactFinalForm.useField(primaryPath, ~config={validate: validate})
+    let primaryField = ReactFinalForm.useField(
+      primaryFieldConfig.confirmRequestWritePath,
+      ~config={validate: validate},
+    )
     let fieldRef = React.useRef(Nullable.null)
 
     let value = primaryField.input.value->Option.getOr("")
     let touched = primaryField.meta.touched
     let invalid = primaryField.meta.invalid
-    let isValid = if touched {
-      Some(!invalid)
-    } else {
-      None
-    }
-    let errorString = if touched && invalid {
-      primaryField.meta.error->Option.getOr("")
-    } else {
-      ""
-    }
+    let isValid = touched ? Some(!invalid) : None
+    let errorString = touched && invalid ? primaryField.meta.error->Option.getOr("") : ""
 
     <PaymentInputField
       fieldName={label}
       value
       onChange={ev => {
         let val = ReactEvent.Form.target(ev)["value"]
-        paths->Array.forEach(path => form.change(path, val))
+        fields->Array.forEach(field => form.change(field.confirmRequestWritePath, val))
       }}
       onBlur={_ev => primaryField.input.onBlur()}
       isValid

--- a/src/Components/DynamicFields/EmailField.res
+++ b/src/Components/DynamicFields/EmailField.res
@@ -1,12 +1,12 @@
 open SuperpositionTypes
 
 @react.component
-let make = (
-  ~fieldConfig: fieldConfig,
-  ~paths: array<string>,
-) => {
+let make = (~fieldConfig: fieldConfig, ~paths: array<string>) => {
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+    ~field=fieldConfig,
+    ~localeObject=localeString,
+  )
   let autocomplete = fieldConfig.htmlAutocompleteAttribute->Option.getOr("email")
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
@@ -20,9 +20,16 @@ let make = (
     let value = primaryField.input.value->Option.getOr("")
     let touched = primaryField.meta.touched
     let invalid = primaryField.meta.invalid
-    let isValid = if touched { Some(!invalid) } else { None }
-    let errorString =
-      if touched && invalid { primaryField.meta.error->Option.getOr("") } else { "" }
+    let isValid = if touched {
+      Some(!invalid)
+    } else {
+      None
+    }
+    let errorString = if touched && invalid {
+      primaryField.meta.error->Option.getOr("")
+    } else {
+      ""
+    }
 
     <PaymentInputField
       fieldName={label}

--- a/src/Components/DynamicFields/EmailField.res
+++ b/src/Components/DynamicFields/EmailField.res
@@ -1,0 +1,42 @@
+open SuperpositionTypes
+
+@react.component
+let make = (
+  ~fieldConfig: fieldConfig,
+  ~paths: array<string>,
+) => {
+  let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let autocomplete = fieldConfig.htmlAutocompleteAttribute->Option.getOr("email")
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+
+  switch paths->Array.get(0) {
+  | None => React.null
+  | Some(primaryPath) =>
+    let form = ReactFinalForm.useForm()
+    let primaryField = ReactFinalForm.useField(primaryPath, ~config={validate: validate})
+    let fieldRef = React.useRef(Nullable.null)
+
+    let value = primaryField.input.value->Option.getOr("")
+    let touched = primaryField.meta.touched
+    let invalid = primaryField.meta.invalid
+    let isValid = if touched { Some(!invalid) } else { None }
+    let errorString =
+      if touched && invalid { primaryField.meta.error->Option.getOr("") } else { "" }
+
+    <PaymentInputField
+      fieldName={label}
+      value
+      onChange={ev => {
+        let val = ReactEvent.Form.target(ev)["value"]
+        paths->Array.forEach(path => form.change(path, val))
+      }}
+      onBlur={_ev => primaryField.input.onBlur()}
+      isValid
+      errorString
+      placeholder
+      inputRef={fieldRef}
+      autocomplete
+    />
+  }
+}

--- a/src/Components/DynamicFields/GenericDropdownField.res
+++ b/src/Components/DynamicFields/GenericDropdownField.res
@@ -1,0 +1,26 @@
+open SuperpositionTypes
+
+@react.component
+let make = (
+  ~fieldConfig: fieldConfig,
+  ~options: array<DropdownField.optionType>,
+  ~initialValue: string,
+) => {
+  let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let validate =
+    DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+  let field = ReactFinalForm.useField(
+    fieldConfig.confirmRequestWritePath,
+    ~config={validate, initialValue: Some(initialValue)},
+  )
+  let value = field.input.value->Option.getOr(initialValue)
+  <DropdownField
+    appearance={config.appearance}
+    fieldName={label}
+    value
+    setValue={fn => field.input.onChange(fn(value))}
+    disabled=false
+    options
+  />
+}

--- a/src/Components/DynamicFields/GenericDropdownField.res
+++ b/src/Components/DynamicFields/GenericDropdownField.res
@@ -8,8 +8,7 @@ let make = (
 ) => {
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
-  let validate =
-    DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
   let field = ReactFinalForm.useField(
     fieldConfig.confirmRequestWritePath,
     ~config={validate, initialValue: Some(initialValue)},

--- a/src/Components/DynamicFields/GenericDropdownField.res
+++ b/src/Components/DynamicFields/GenericDropdownField.res
@@ -1,19 +1,18 @@
 open SuperpositionTypes
 
 @react.component
-let make = (
-  ~fieldConfig: fieldConfig,
-  ~options: array<DropdownField.optionType>,
-  ~initialValue: string,
-) => {
+let make = (~fieldConfig: fieldConfig, ~options: array<DropdownField.optionType>) => {
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+  let initialValue = options->Array.get(0)->Option.map(opt => opt.value)->Option.getOr("")
+
   let field = ReactFinalForm.useField(
     fieldConfig.confirmRequestWritePath,
     ~config={validate, initialValue: Some(initialValue)},
   )
   let value = field.input.value->Option.getOr(initialValue)
+
   <DropdownField
     appearance={config.appearance}
     fieldName={label}

--- a/src/Components/DynamicFields/GenericInputField.res
+++ b/src/Components/DynamicFields/GenericInputField.res
@@ -1,0 +1,35 @@
+open SuperpositionTypes
+
+@react.component
+let make = (~fieldConfig: fieldConfig) => {
+  let fieldRef = React.useRef(Nullable.null)
+  let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+    ~field=fieldConfig,
+    ~localeObject=localeString,
+  )
+  let autocomplete = fieldConfig.htmlAutocompleteAttribute
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+
+  <ReactFinalForm.Field name={fieldConfig.confirmRequestWritePath} validate={Some(validate)}>
+    {(fieldProps: ReactFinalForm.Field.fieldProps) => {
+      let {input, meta} = fieldProps
+      let value = input.value->Option.getOr("")
+      let showError = meta.touched || meta.submitFailed
+      let isValid = showError ? Some(meta.valid) : None
+      let errorString = showError && meta.invalid ? meta.error->Option.getOr("") : ""
+      <PaymentInputField
+        fieldName={label}
+        value
+        onChange={ev => input.onChange(ReactEvent.Form.target(ev)["value"])}
+        onBlur={_ev => input.onBlur()}
+        isValid
+        errorString
+        placeholder
+        inputRef={fieldRef}
+        ?autocomplete
+        maxLength=?{fieldConfig.maxInputLength}
+      />
+    }}
+  </ReactFinalForm.Field>
+}

--- a/src/Components/DynamicFields/GenericInputField.res
+++ b/src/Components/DynamicFields/GenericInputField.res
@@ -11,25 +11,25 @@ let make = (~fieldConfig: fieldConfig) => {
   let autocomplete = fieldConfig.htmlAutocompleteAttribute
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
-  <ReactFinalForm.Field name={fieldConfig.confirmRequestWritePath} validate={Some(validate)}>
-    {(fieldProps: ReactFinalForm.Field.fieldProps) => {
-      let {input, meta} = fieldProps
-      let value = input.value->Option.getOr("")
-      let showError = meta.touched || meta.submitFailed
-      let isValid = showError ? Some(meta.valid) : None
-      let errorString = showError && meta.invalid ? meta.error->Option.getOr("") : ""
-      <PaymentInputField
-        fieldName={label}
-        value
-        onChange={ev => input.onChange(ReactEvent.Form.target(ev)["value"])}
-        onBlur={_ev => input.onBlur()}
-        isValid
-        errorString
-        placeholder
-        inputRef={fieldRef}
-        ?autocomplete
-        maxLength=?{fieldConfig.maxInputLength}
-      />
-    }}
-  </ReactFinalForm.Field>
+  let {input, meta} = ReactFinalForm.useField(
+    fieldConfig.confirmRequestWritePath,
+    ~config={validate: validate},
+  )
+  let value = input.value->Option.getOr("")
+  let showError = meta.touched || meta.submitFailed
+  let isValid = showError ? Some(meta.valid) : None
+  let errorString = showError && meta.invalid ? meta.error->Option.getOr("") : ""
+
+  <PaymentInputField
+    fieldName={label}
+    value
+    onChange={ev => input.onChange(ReactEvent.Form.target(ev)["value"])}
+    onBlur={_ev => input.onBlur()}
+    isValid
+    errorString
+    placeholder
+    inputRef={fieldRef}
+    ?autocomplete
+    maxLength=?{fieldConfig.maxInputLength}
+  />
 }

--- a/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
+++ b/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
@@ -9,15 +9,14 @@ let make = (~fieldConfig: fieldConfig) => {
   let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
-  let countryAndCodeList =
+  let countryAndCodeList = React.useMemo0(() =>
     phoneNumberJson
-    ->JSON.Decode.object
-    ->Option.getOr(Dict.make())
+    ->getDictFromJson
     ->getArray("countries")
+  )
 
-  let phoneNumberCodeOptions: array<DropdownField.optionType> = countryAndCodeList->Array.reduce(
-    [],
-    (acc, countryObj) => {
+  let phoneNumberCodeOptions: array<DropdownField.optionType> = React.useMemo0(() =>
+    countryAndCodeList->Array.reduce([], (acc, countryObj) => {
       let countryDict = countryObj->getDictFromJson
       let flag = countryDict->getString("country_flag", "")
       let code = countryDict->getString("phone_number_code", "")
@@ -29,7 +28,7 @@ let make = (~fieldConfig: fieldConfig) => {
       }
       acc->Array.push(opt)
       acc
-    },
+    })
   )
 
   let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)

--- a/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
+++ b/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
@@ -1,0 +1,89 @@
+open SuperpositionTypes
+
+let getPhoneCode = val => val->String.split("#")->Array.get(1)->Option.getOr("")
+
+@react.component
+let make = (
+  ~fieldConfig: fieldConfig,
+) => {
+  open Utils
+  let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let validate =
+    DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+
+  let countryAndCodeList =
+    phoneNumberJson
+    ->JSON.Decode.object
+    ->Option.getOr(Dict.make())
+    ->getArray("countries")
+
+  let phoneNumberCodeOptions: array<DropdownField.optionType> =
+    countryAndCodeList->Array.reduce([], (acc, countryObj) => {
+      let countryDict = countryObj->getDictFromJson
+      let flag = countryDict->getString("country_flag", "")
+      let code = countryDict->getString("phone_number_code", "")
+      let name = countryDict->getString("country_name", "")
+      let opt: DropdownField.optionType = {
+        label: `${flag} ${name} ${code}`,
+        displayValue: `${flag} ${code}`,
+        value: `${flag}#${code}`,
+      }
+      acc->Array.push(opt)
+      acc
+    })
+
+  let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
+  let firstOptionValue =
+    phoneNumberCodeOptions->Array.get(0)->Option.map(o => o.value)->Option.getOr("")
+  let seedCountry = defaultCountry !== "" ? defaultCountry : firstOptionValue
+  let seedIso = getCountryCode(seedCountry).isoAlpha2
+
+  let defaultDropdownValue =
+    countryAndCodeList
+    ->Array.find(c => c->getDictFromJson->getString("country_code", "") === seedIso)
+    ->Option.map(c => {
+      let countryDict = c->getDictFromJson
+      let flag = countryDict->getString("country_flag", "")
+      let code = countryDict->getString("phone_number_code", "")
+      `${flag}#${code}`
+    })
+    ->Option.getOr(firstOptionValue)
+
+  let defaultCode = defaultDropdownValue->getPhoneCode
+  let field = ReactFinalForm.useField(
+    fieldConfig.confirmRequestWritePath,
+    ~config={validate, initialValue: Some(defaultCode)},
+  )
+
+  let (valueDropDown, setValueDropDown) = React.useState(_ => defaultDropdownValue)
+  let (displayValue, setDisplayValue) = React.useState(_ => "")
+
+  React.useEffect(() => {
+    let found =
+      phoneNumberCodeOptions
+      ->Array.find(ele => ele.value === valueDropDown)
+      ->Option.getOr(DropdownField.defaultValue)
+    setDisplayValue(_ =>
+      found.displayValue->Option.getOr(found.label->Option.getOr(found.value))
+    )
+    None
+  }, [phoneNumberCodeOptions])
+
+  React.useEffect(() => {
+    field.input.onChange(valueDropDown->getPhoneCode)
+    None
+  }, [valueDropDown])
+
+  <DropdownField
+    appearance={config.appearance}
+    fieldName={label}
+    value=valueDropDown
+    setValue={setter => setValueDropDown(prev => setter(prev))}
+    disabled=false
+    options=phoneNumberCodeOptions
+    displayValue
+    setDisplayValue
+    isDisplayValueVisible=true
+  />
+}

--- a/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
+++ b/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
@@ -3,14 +3,11 @@ open SuperpositionTypes
 let getPhoneCode = val => val->String.split("#")->Array.get(1)->Option.getOr("")
 
 @react.component
-let make = (
-  ~fieldConfig: fieldConfig,
-) => {
+let make = (~fieldConfig: fieldConfig) => {
   open Utils
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
-  let validate =
-    DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
   let countryAndCodeList =
     phoneNumberJson
@@ -18,8 +15,9 @@ let make = (
     ->Option.getOr(Dict.make())
     ->getArray("countries")
 
-  let phoneNumberCodeOptions: array<DropdownField.optionType> =
-    countryAndCodeList->Array.reduce([], (acc, countryObj) => {
+  let phoneNumberCodeOptions: array<DropdownField.optionType> = countryAndCodeList->Array.reduce(
+    [],
+    (acc, countryObj) => {
       let countryDict = countryObj->getDictFromJson
       let flag = countryDict->getString("country_flag", "")
       let code = countryDict->getString("phone_number_code", "")
@@ -31,7 +29,8 @@ let make = (
       }
       acc->Array.push(opt)
       acc
-    })
+    },
+  )
 
   let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let firstOptionValue =
@@ -64,9 +63,7 @@ let make = (
       phoneNumberCodeOptions
       ->Array.find(ele => ele.value === valueDropDown)
       ->Option.getOr(DropdownField.defaultValue)
-    setDisplayValue(_ =>
-      found.displayValue->Option.getOr(found.label->Option.getOr(found.value))
-    )
+    setDisplayValue(_ => found.displayValue->Option.getOr(found.label->Option.getOr(found.value)))
     None
   }, [phoneNumberCodeOptions])
 

--- a/src/Components/DynamicFields/PhoneField.res
+++ b/src/Components/DynamicFields/PhoneField.res
@@ -1,0 +1,36 @@
+open SuperpositionTypes
+
+@react.component
+let make = (~fieldConfig: fieldConfig) => {
+  let fieldRef = React.useRef(Nullable.null)
+  let path = fieldConfig.confirmRequestWritePath
+  let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let maxLength = fieldConfig.maxInputLength
+
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+
+  let field = ReactFinalForm.useField(path, ~config={validate: validate})
+
+  let value = field.input.value->Option.getOr("")
+  let touched = field.meta.touched
+  let invalid = field.meta.invalid
+  let isValid = if touched { Some(!invalid) } else { None }
+  let errorString = if touched && invalid { field.meta.error->Option.getOr("") } else { "" }
+
+  <PaymentInputField
+    fieldName={label}
+    value
+    onChange={ev => {
+      let val = ReactEvent.Form.target(ev)["value"]->String.replaceRegExp(%re("/\D|\s/g"), "")
+      field.input.onChange(val)
+    }}
+    onBlur={_ev => field.input.onBlur()}
+    isValid
+    errorString
+    placeholder
+    inputRef={fieldRef}
+    autocomplete="tel-national"
+    ?maxLength
+  />
+}

--- a/src/Components/DynamicFields/PhoneField.res
+++ b/src/Components/DynamicFields/PhoneField.res
@@ -5,7 +5,10 @@ let make = (~fieldConfig: fieldConfig) => {
   let fieldRef = React.useRef(Nullable.null)
   let path = fieldConfig.confirmRequestWritePath
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+    ~field=fieldConfig,
+    ~localeObject=localeString,
+  )
   let maxLength = fieldConfig.maxInputLength
 
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
@@ -15,8 +18,16 @@ let make = (~fieldConfig: fieldConfig) => {
   let value = field.input.value->Option.getOr("")
   let touched = field.meta.touched
   let invalid = field.meta.invalid
-  let isValid = if touched { Some(!invalid) } else { None }
-  let errorString = if touched && invalid { field.meta.error->Option.getOr("") } else { "" }
+  let isValid = if touched {
+    Some(!invalid)
+  } else {
+    None
+  }
+  let errorString = if touched && invalid {
+    field.meta.error->Option.getOr("")
+  } else {
+    ""
+  }
 
   <PaymentInputField
     fieldName={label}

--- a/src/Components/DynamicFields/PhoneField.res
+++ b/src/Components/DynamicFields/PhoneField.res
@@ -10,6 +10,7 @@ let make = (~fieldConfig: fieldConfig) => {
     ~localeObject=localeString,
   )
   let maxLength = fieldConfig.maxInputLength
+  let autocomplete = fieldConfig.htmlAutocompleteAttribute->Option.getOr("tel-national")
 
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
@@ -41,7 +42,7 @@ let make = (~fieldConfig: fieldConfig) => {
     errorString
     placeholder
     inputRef={fieldRef}
-    autocomplete="tel-national"
+    autocomplete
     ?maxLength
   />
 }

--- a/src/Components/DynamicFields/StateDropdownField.res
+++ b/src/Components/DynamicFields/StateDropdownField.res
@@ -1,0 +1,45 @@
+open SuperpositionTypes
+
+@react.component
+let make = (
+  ~field: fieldConfig,
+  ~countryFieldPath: string,
+) => {
+  let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field, ~localeObject=localeString)
+  let validate =
+    DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
+  let defaultCountryIso = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
+  let countryFieldProps = ReactFinalForm.useField(countryFieldPath)
+  let rffCountryIso = countryFieldProps.input.value->Option.getOr("")
+  let countryIso = if rffCountryIso !== "" { rffCountryIso } else { defaultCountryIso }
+  let countryDisplayName = Utils.getCountryNameFromCode(countryIso)
+
+  let stateDisplayNames =
+    Utils.getStateNames({value: countryDisplayName, isValid: None, errorString: ""})
+
+  let stateOptions = stateDisplayNames->DropdownField.updateArrayOfStringToOptionsTypeArray
+  let field = ReactFinalForm.useField(field.confirmRequestWritePath, ~config={validate: validate})
+  let storedCode = field.input.value->Option.getOr("")
+
+  if stateOptions->Array.length === 0 {
+    React.null
+  } else {
+    let displayName = Utils.getStateNameFromCode(storedCode, countryIso)
+    let effectiveDisplayName =
+      displayName !== "" ? displayName : stateDisplayNames->Array.get(0)->Option.getOr("")
+
+    <DropdownField
+      appearance={config.appearance}
+      fieldName={label}
+      value={effectiveDisplayName}
+      setValue={fn => {
+        let selectedDisplayName = fn(effectiveDisplayName)
+        let stateCode = Utils.getStateCodeFromStateName(selectedDisplayName, countryIso)
+        field.input.onChange(stateCode)
+      }}
+      disabled=false
+      options={stateOptions}
+    />
+  }
+}

--- a/src/Components/DynamicFields/StateDropdownField.res
+++ b/src/Components/DynamicFields/StateDropdownField.res
@@ -1,37 +1,40 @@
 open SuperpositionTypes
 
 @react.component
-let make = (~field: fieldConfig, ~countryFieldPath: string) => {
+let make = (~fieldConfig: fieldConfig) => {
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field, ~localeObject=localeString)
-  let validate = DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
-  let defaultCountryIso = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
-  let countryFieldProps = ReactFinalForm.useField(countryFieldPath)
-  let rffCountryIso = countryFieldProps.input.value->Option.getOr("")
-  let countryIso = if rffCountryIso !== "" {
-    rffCountryIso
-  } else {
-    defaultCountryIso
-  }
-  let countryDisplayName = Utils.getCountryNameFromCode(countryIso)
+  let {label} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
+
+  let countryName = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
+  let countryIso = Utils.getCountryCode(countryName).isoAlpha2
 
   let stateDisplayNames = Utils.getStateNames({
-    value: countryDisplayName,
+    value: countryName,
     isValid: None,
     errorString: "",
   })
-
   let stateOptions = stateDisplayNames->DropdownField.updateArrayOfStringToOptionsTypeArray
-  let field = ReactFinalForm.useField(field.confirmRequestWritePath, ~config={validate: validate})
-  let storedCode = field.input.value->Option.getOr("")
+  let hasStates = stateOptions->Array.length > 0
 
-  if stateOptions->Array.length === 0 {
-    React.null
-  } else {
-    let displayName = Utils.getStateNameFromCode(storedCode, countryIso)
-    let effectiveDisplayName =
-      displayName !== "" ? displayName : stateDisplayNames->Array.get(0)->Option.getOr("")
+  let stateField = ReactFinalForm.useField(
+    fieldConfig.confirmRequestWritePath,
+    ~config={validate: validate},
+  )
+  let storedCode = stateField.input.value->Option.getOr("")
+  let storedDisplayName = Utils.getStateNameFromCode(storedCode, countryIso)
+  let firstStateName = stateDisplayNames->Array.get(0)->Option.getOr("")
+  let effectiveDisplayName = storedDisplayName !== "" ? storedDisplayName : firstStateName
+  let effectiveCode = Utils.getStateCodeFromStateName(effectiveDisplayName, countryIso)
 
+  React.useEffect(() => {
+    if hasStates && storedCode !== effectiveCode {
+      stateField.input.onChange(effectiveCode)
+    }
+    None
+  }, [effectiveCode])
+
+  <RenderIf condition={hasStates}>
     <DropdownField
       appearance={config.appearance}
       fieldName={label}
@@ -39,10 +42,10 @@ let make = (~field: fieldConfig, ~countryFieldPath: string) => {
       setValue={fn => {
         let selectedDisplayName = fn(effectiveDisplayName)
         let stateCode = Utils.getStateCodeFromStateName(selectedDisplayName, countryIso)
-        field.input.onChange(stateCode)
+        stateField.input.onChange(stateCode)
       }}
       disabled=false
       options={stateOptions}
     />
-  }
+  </RenderIf>
 }

--- a/src/Components/DynamicFields/StateDropdownField.res
+++ b/src/Components/DynamicFields/StateDropdownField.res
@@ -32,7 +32,7 @@ let make = (~fieldConfig: fieldConfig) => {
       stateField.input.onChange(effectiveCode)
     }
     None
-  }, [effectiveCode])
+  }, (hasStates, storedCode, effectiveCode))
 
   <RenderIf condition={hasStates}>
     <DropdownField

--- a/src/Components/DynamicFields/StateDropdownField.res
+++ b/src/Components/DynamicFields/StateDropdownField.res
@@ -1,22 +1,25 @@
 open SuperpositionTypes
 
 @react.component
-let make = (
-  ~field: fieldConfig,
-  ~countryFieldPath: string,
-) => {
+let make = (~field: fieldConfig, ~countryFieldPath: string) => {
   let {config, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let {label} = DynamicFieldsUtils.resolveFieldTexts(~field, ~localeObject=localeString)
-  let validate =
-    DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
+  let validate = DynamicFieldsUtils.resolveValidator(~field, ~localeObject=localeString)
   let defaultCountryIso = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let countryFieldProps = ReactFinalForm.useField(countryFieldPath)
   let rffCountryIso = countryFieldProps.input.value->Option.getOr("")
-  let countryIso = if rffCountryIso !== "" { rffCountryIso } else { defaultCountryIso }
+  let countryIso = if rffCountryIso !== "" {
+    rffCountryIso
+  } else {
+    defaultCountryIso
+  }
   let countryDisplayName = Utils.getCountryNameFromCode(countryIso)
 
-  let stateDisplayNames =
-    Utils.getStateNames({value: countryDisplayName, isValid: None, errorString: ""})
+  let stateDisplayNames = Utils.getStateNames({
+    value: countryDisplayName,
+    isValid: None,
+    errorString: "",
+  })
 
   let stateOptions = stateDisplayNames->DropdownField.updateArrayOfStringToOptionsTypeArray
   let field = ReactFinalForm.useField(field.confirmRequestWritePath, ~config={validate: validate})

--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -8,6 +8,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
   let (keys, setKeys) = Recoil.useRecoilState(keys)
   let (paymentMethodList, setPaymentMethodList) = Recoil.useRecoilState(paymentMethodList)
   let setSdkConfigs = Recoil.useSetRecoilState(sdkConfigs)
+  let setSdkConfigsValue = Recoil.useSetRecoilState(PaymentUtils.sdkConfigsValue)
   let (_, setSessions) = Recoil.useRecoilState(sessions)
   let (options, setOptions) = Recoil.useRecoilState(elementOptions)
   let (optionsPayment, setOptionsPayment) = Recoil.useRecoilState(optionAtom)
@@ -626,6 +627,9 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
           | _ => ()
           }
           setSdkConfigs(_ => updatedState)
+          if !isSdkConfigsError {
+            setSdkConfigsValue(_ => sdkConfigsJson->SdkConfigParser.itemToObjMapper)
+          }
         }
         if dict->Dict.get("applePayCanMakePayments")->Option.isSome {
           setIsApplePayReady(_ => true)

--- a/src/Payments/DateOfBirth.res
+++ b/src/Payments/DateOfBirth.res
@@ -32,84 +32,82 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
 
   let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
-  <ReactFinalForm.Field name={path} validate={Some(validate)}>
-    {(field: ReactFinalForm.Field.fieldProps) => {
-      let touched = field.meta.touched
-      let invalid = field.meta.invalid
-      <div className="flex flex-col gap-1">
-        <div
-          className={`Label`}
-          style={
-            fontWeight: themeObj.fontWeightNormal,
-            fontSize: themeObj.fontSizeLg,
-            opacity: "0.6",
-          }>
-          {label->React.string}
+  let field = ReactFinalForm.useField(path, ~config={validate: validate})
+  let touched = field.meta.touched
+  let invalid = field.meta.invalid
+
+  <div className="flex flex-col gap-1">
+    <div
+      className={`Label`}
+      style={
+        fontWeight: themeObj.fontWeightNormal,
+        fontSize: themeObj.fontSizeLg,
+        opacity: "0.6",
+      }>
+      {label->React.string}
+    </div>
+    <DatePicker
+      showIcon=true
+      icon={<Icon name="calander" size=13 className="!px-[6px] !py-[10px]" />}
+      className="w-full border border-gray-300 rounded p-2"
+      selected={selectedDate}
+      onChange={date => {
+        setSelectedDate(_ => date)
+        let strVal =
+          date
+          ->Nullable.toOption
+          ->Option.map(d => d->Date.toLocaleDateStringWithLocale("en-CA"))
+          ->Option.getOr("")
+        field.input.onChange(strVal)
+      }}
+      dateFormat
+      wrapperClassName="datepicker"
+      shouldCloseOnSelect=true
+      placeholderText={placeholder}
+      renderCustomHeader={val => {
+        <div className="flex gap-4 items-center justify-center m-2">
+          <select
+            className="p-1"
+            value={val.date->Date.getFullYear->Int.toString}
+            onChange={ev => {
+              let value = {ev->ReactEvent.Form.target}["value"]
+              val.changeYear(value)
+            }}>
+            {years
+            ->Array.map(option =>
+              <option key={option->Int.toString} value={option->Int.toString}>
+                {option->React.int}
+              </option>
+            )
+            ->React.array}
+          </select>
+          <select
+            className="p-1"
+            value={months[val.date->Date.getMonth]->Option.getOr("January")}
+            onChange={ev => {
+              let value = {ev->ReactEvent.Form.target}["value"]
+              val.changeMonth(months->Array.indexOf(value))
+            }}>
+            {months
+            ->Array.map(option =>
+              <option key={option} value={option}> {option->React.string} </option>
+            )
+            ->React.array}
+          </select>
         </div>
-        <DatePicker
-          showIcon=true
-          icon={<Icon name="calander" size=13 className="!px-[6px] !py-[10px]" />}
-          className="w-full border border-gray-300 rounded p-2"
-          selected={selectedDate}
-          onChange={date => {
-            setSelectedDate(_ => date)
-            let strVal =
-              date
-              ->Nullable.toOption
-              ->Option.map(d => d->Date.toLocaleDateStringWithLocale("en-CA"))
-              ->Option.getOr("")
-            field.input.onChange(strVal)
-          }}
-          dateFormat
-          wrapperClassName="datepicker"
-          shouldCloseOnSelect=true
-          placeholderText={placeholder}
-          renderCustomHeader={val => {
-            <div className="flex gap-4 items-center justify-center m-2">
-              <select
-                className="p-1"
-                value={val.date->Date.getFullYear->Int.toString}
-                onChange={ev => {
-                  let value = {ev->ReactEvent.Form.target}["value"]
-                  val.changeYear(value)
-                }}>
-                {years
-                ->Array.map(option =>
-                  <option key={option->Int.toString} value={option->Int.toString}>
-                    {option->React.int}
-                  </option>
-                )
-                ->React.array}
-              </select>
-              <select
-                className="p-1"
-                value={months[val.date->Date.getMonth]->Option.getOr("January")}
-                onChange={ev => {
-                  let value = {ev->ReactEvent.Form.target}["value"]
-                  val.changeMonth(months->Array.indexOf(value))
-                }}>
-                {months
-                ->Array.map(option =>
-                  <option key={option} value={option}> {option->React.string} </option>
-                )
-                ->React.array}
-              </select>
-            </div>
-          }}
-        />
-        <RenderIf condition={touched && invalid}>
-          <div
-            className="Error pt-1"
-            style={
-              color: themeObj.colorDangerText,
-              fontSize: themeObj.fontSizeSm,
-              alignSelf: "start",
-              textAlign: "left",
-            }>
-            {field.meta.error->Option.getOr("")->React.string}
-          </div>
-        </RenderIf>
+      }}
+    />
+    <RenderIf condition={touched && invalid}>
+      <div
+        className="Error pt-1"
+        style={
+          color: themeObj.colorDangerText,
+          fontSize: themeObj.fontSizeSm,
+          alignSelf: "start",
+          textAlign: "left",
+        }>
+        {field.meta.error->Option.getOr("")->React.string}
       </div>
-    }}
-  </ReactFinalForm.Field>
+    </RenderIf>
+  </div>
 }

--- a/src/Payments/DateOfBirth.res
+++ b/src/Payments/DateOfBirth.res
@@ -20,105 +20,93 @@ let currentYear = Date.getFullYear(Date.make())
 let years = Array.fromInitializer(~length=currentYear - startYear, i => currentYear - i)
 
 @react.component
-let make = () => {
-  open Utils
+let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
+  let path = fieldConfig.confirmRequestWritePath
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let (error, setError) = React.useState(_ => false)
-  let (isNotEligible, setIsNotEligible) = React.useState(_ => false)
-  let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
-  let (dateOfBirth, setDateOfBirth) = Recoil.useRecoilState(RecoilAtoms.dateOfBirth)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let dateFormat = fieldConfig.inputFormatPattern->Option.getOr("dd-MM-yyyy")
+  let (selectedDate, setSelectedDate) = React.useState(() => Nullable.null)
 
-  let submitCallback = React.useCallback((ev: Window.event) => {
-    let json = ev.data->safeParse
-    let confirm = json->getDictFromJson->ConfirmType.itemToObjMapper
-    if confirm.doSubmit {
-      switch dateOfBirth->Nullable.toOption {
-      | Some(_) => setError(_ => false)
-      | None => ()
-      }
-    }
-  }, (dateOfBirth, isNotEligible))
+  let validate = DynamicFieldsUtils.resolveValidator(~field=fieldConfig, ~localeObject=localeString)
 
-  useSubmitPaymentData(submitCallback)
-
-  let onChange = date => {
-    let isAbove18 = switch date->Nullable.toOption {
-    | Some(val) => val->checkIs18OrAbove
-    | None => false
-    }
-    LoggerUtils.logInputChangeInfo("dateOfBirth", loggerState)
-    setDateOfBirth(_ => date)
-    setIsNotEligible(_ => !isAbove18)
-  }
-
-  let errorString = error
-    ? localeString.dateofBirthRequiredText
-    : localeString.dateOfBirthInvalidText
-
-  <div className="flex flex-col gap-1">
-    <div
-      className={`Label`}
-      style={
-        fontWeight: themeObj.fontWeightNormal,
-        fontSize: themeObj.fontSizeLg,
-        opacity: "0.6",
-      }>
-      {React.string(localeString.dateOfBirth)}
-    </div>
-    <DatePicker
-      showIcon=true
-      icon={<Icon name="calander" size=13 className="!px-[6px] !py-[10px]" />}
-      className="w-full border border-gray-300 rounded p-2"
-      selected={dateOfBirth}
-      onChange
-      dateFormat="dd-MM-yyyy"
-      wrapperClassName="datepicker"
-      shouldCloseOnSelect=true
-      placeholderText={localeString.dateOfBirthPlaceholderText}
-      renderCustomHeader={val => {
-        <div className="flex gap-4 items-center justify-center m-2">
-          <select
-            className="p-1"
-            value={val.date->Date.getFullYear->Int.toString}
-            onChange={ev => {
-              let value = {ev->ReactEvent.Form.target}["value"]
-              val.changeYear(value)
-            }}>
-            {years
-            ->Array.map(option =>
-              <option key={option->Int.toString} value={option->Int.toString}>
-                {option->React.int}
-              </option>
-            )
-            ->React.array}
-          </select>
-          <select
-            className="p-1"
-            value={months[val.date->Date.getMonth]->Option.getOr("January")}
-            onChange={ev => {
-              let value = {ev->ReactEvent.Form.target}["value"]
-              val.changeMonth(months->Array.indexOf(value))
-            }}>
-            {months
-            ->Array.map(option =>
-              <option key={option} value={option}> {option->React.string} </option>
-            )
-            ->React.array}
-          </select>
+  <ReactFinalForm.Field name={path} validate={Some(validate)}>
+    {(field: ReactFinalForm.Field.fieldProps) => {
+      let touched = field.meta.touched
+      let invalid = field.meta.invalid
+      <div className="flex flex-col gap-1">
+        <div
+          className={`Label`}
+          style={
+            fontWeight: themeObj.fontWeightNormal,
+            fontSize: themeObj.fontSizeLg,
+            opacity: "0.6",
+          }>
+          {label->React.string}
         </div>
-      }}
-    />
-    <RenderIf condition={error || isNotEligible}>
-      <div
-        className="Error pt-1"
-        style={
-          color: themeObj.colorDangerText,
-          fontSize: themeObj.fontSizeSm,
-          alignSelf: "start",
-          textAlign: "left",
-        }>
-        {React.string(errorString)}
+        <DatePicker
+          showIcon=true
+          icon={<Icon name="calander" size=13 className="!px-[6px] !py-[10px]" />}
+          className="w-full border border-gray-300 rounded p-2"
+          selected={selectedDate}
+          onChange={date => {
+            setSelectedDate(_ => date)
+            let strVal =
+              date
+              ->Nullable.toOption
+              ->Option.map(d => d->Date.toLocaleDateStringWithLocale("en-CA"))
+              ->Option.getOr("")
+            field.input.onChange(strVal)
+          }}
+          dateFormat
+          wrapperClassName="datepicker"
+          shouldCloseOnSelect=true
+          placeholderText={placeholder}
+          renderCustomHeader={val => {
+            <div className="flex gap-4 items-center justify-center m-2">
+              <select
+                className="p-1"
+                value={val.date->Date.getFullYear->Int.toString}
+                onChange={ev => {
+                  let value = {ev->ReactEvent.Form.target}["value"]
+                  val.changeYear(value)
+                }}>
+                {years
+                ->Array.map(option =>
+                  <option key={option->Int.toString} value={option->Int.toString}>
+                    {option->React.int}
+                  </option>
+                )
+                ->React.array}
+              </select>
+              <select
+                className="p-1"
+                value={months[val.date->Date.getMonth]->Option.getOr("January")}
+                onChange={ev => {
+                  let value = {ev->ReactEvent.Form.target}["value"]
+                  val.changeMonth(months->Array.indexOf(value))
+                }}>
+                {months
+                ->Array.map(option =>
+                  <option key={option} value={option}> {option->React.string} </option>
+                )
+                ->React.array}
+              </select>
+            </div>
+          }}
+        />
+        <RenderIf condition={touched && invalid}>
+          <div
+            className="Error pt-1"
+            style={
+              color: themeObj.colorDangerText,
+              fontSize: themeObj.fontSizeSm,
+              alignSelf: "start",
+              textAlign: "left",
+            }>
+            {field.meta.error->Option.getOr("")->React.string}
+          </div>
+        </RenderIf>
       </div>
-    </RenderIf>
-  </div>
+    }}
+  </ReactFinalForm.Field>
 }

--- a/src/Payments/DateOfBirth.res
+++ b/src/Payments/DateOfBirth.res
@@ -23,7 +23,10 @@ let years = Array.fromInitializer(~length=currentYear - startYear, i => currentY
 let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
   let path = fieldConfig.confirmRequestWritePath
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
-  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(~field=fieldConfig, ~localeObject=localeString)
+  let {label, placeholder} = DynamicFieldsUtils.resolveFieldTexts(
+    ~field=fieldConfig,
+    ~localeObject=localeString,
+  )
   let dateFormat = fieldConfig.inputFormatPattern->Option.getOr("dd-MM-yyyy")
   let (selectedDate, setSelectedDate) = React.useState(() => Nullable.null)
 

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -3,6 +3,8 @@ type fieldTexts = {
   placeholder: string,
 }
 
+let billingPrefix = "payment_method_data.billing."
+
 let lookupLocaleKey = (key: string, locale: LocaleStringTypes.localeStrings): option<string> =>
   switch key {
   | "cardNumberLabel" => Some(locale.cardNumberLabel)
@@ -259,7 +261,7 @@ let resolveValidator = (
   ~field: SuperpositionTypes.fieldConfig,
   ~localeObject: LocaleStringTypes.localeStrings,
 ) => {
-  let requiredRule = field.isRequired ? [Validation.Required] : []
+  let requiredRule = field.isRequired ? [Validation.Required(None)] : []
 
   let semanticRule = switch field.validationRuleType {
   | Some("phone") => [Validation.Phone]
@@ -281,7 +283,7 @@ let resolveValidator = (
 
   let maxLengthRule = [Validation.MaxLength(field.maxInputLength->Option.getOr(255))]
 
-  let rules = Array.concat(Array.concat(requiredRule, semanticRule), maxLengthRule)
+  let rules = [...requiredRule, ...semanticRule, ...maxLengthRule]
 
   Validation.createFieldValidator(
     rules,
@@ -311,7 +313,7 @@ let removeBillingDetailsIfUseBillingAddress = (
 ) => {
   if billingAddress.isUseBillingAddress {
     missingRequiredFields->Array.filter(requiredField => {
-      !(requiredField.confirmRequestWritePath->String.startsWith("payment_method_data.billing."))
+      !(requiredField.confirmRequestWritePath->String.startsWith(billingPrefix))
     })
   } else {
     missingRequiredFields

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -1,166 +1,365 @@
-open RecoilAtoms
-
-let dynamicFieldsEnabledPaymentMethods = [
-  "crypto_currency",
-  "debit",
-  "credit",
-  "blik",
-  "google_pay",
-  "apple_pay",
-  "bancontact_card",
-  "open_banking_uk",
-  "eps",
-  "ideal",
-  "sofort",
-  "pix_transfer",
-  "pix_emv_transfer",
-  "giropay",
-  "local_bank_transfer_transfer",
-  "afterpay_clearpay",
-  "mifinity",
-  "bluecode",
-  "upi_collect",
-  "upi_intent",
-  "sepa",
-  "sepa_bank_transfer",
-  "instant_bank_transfer",
-  "affirm",
-  "walley",
-  "ach",
-  "bacs",
-  "pay_bright",
-  "multibanco_transfer",
-  "paypal",
-  "instant_bank_transfer_finland",
-  "instant_bank_transfer_poland",
-  "klarna",
-  "skrill",
-  "flexiti",
-  "breadpay",
-  "pay_safe_card",
-  "interac",
-  "open_banking",
-  "trustly",
-  "givex",
-]
-
-let getName = (item: PaymentMethodsRecord.required_fields, field: RecoilAtomTypes.field) => {
-  let fieldNameArr = field.value->String.split(" ")
-  let requiredFieldsArr = item.required_field->String.split(".")
-  switch requiredFieldsArr->Array.get(requiredFieldsArr->Array.length - 1)->Option.getOr("") {
-  | "first_name" => fieldNameArr->Array.get(0)->Option.getOr(field.value)
-  | "last_name" =>
-    fieldNameArr
-    ->Array.sliceToEnd(~start=1)
-    ->Array.reduce("", (acc, item) => acc === "" ? item : `${acc} ${item}`)
-  | _ => field.value
-  }
+type fieldTexts = {
+  label: string,
+  placeholder: string,
 }
 
-let countryList = CountryStateDataRefs.countryDataRef.contents
-let countryNames = Utils.getCountryNames(countryList)
-
-let billingAddressFields: array<PaymentMethodsRecord.paymentMethodsFields> = [
-  BillingName,
-  AddressLine1,
-  AddressLine2,
-  AddressCity,
-  AddressState,
-  AddressCountry(countryNames),
-  AddressPincode,
-]
-
-let isBillingAddressFieldType = (fieldType: PaymentMethodsRecord.paymentMethodsFields) => {
-  switch fieldType {
-  | BillingName
-  | AddressLine1
-  | AddressLine2
-  | AddressCity
-  | AddressState
-  | AddressCountry(_)
-  | AddressPincode => true
-  | _ => false
+let lookupLocaleKey = (key: string, locale: LocaleStringTypes.localeStrings): option<string> =>
+  switch key {
+  | "cardNumberLabel" => Some(locale.cardNumberLabel)
+  | "localeDirection" => Some(locale.localeDirection)
+  | "sortCodeText" => Some(locale.sortCodeText)
+  | "cvcTextLabel" => Some(locale.cvcTextLabel)
+  | "emailLabel" => Some(locale.emailLabel)
+  | "ibanEmptyText" => Some(locale.ibanEmptyText)
+  | "ibanInvalidText" => Some(locale.ibanInvalidText)
+  | "emailEmptyText" => Some(locale.emailEmptyText)
+  | "emailInvalidText" => Some(locale.emailInvalidText)
+  | "accountNumberText" => Some(locale.accountNumberText)
+  | "accountNumberInvalidText" => Some(locale.accountNumberInvalidText)
+  | "sortCodeInvalidText" => Some(locale.sortCodeInvalidText)
+  | "fullNameLabel" => Some(locale.fullNameLabel)
+  | "line1Label" => Some(locale.line1Label)
+  | "line1Placeholder" => Some(locale.line1Placeholder)
+  | "line1EmptyText" => Some(locale.line1EmptyText)
+  | "line2Label" => Some(locale.line2Label)
+  | "line2Placeholder" => Some(locale.line2Placeholder)
+  | "line2EmptyText" => Some(locale.line2EmptyText)
+  | "cityLabel" => Some(locale.cityLabel)
+  | "cityEmptyText" => Some(locale.cityEmptyText)
+  | "postalCodeLabel" => Some(locale.postalCodeLabel)
+  | "postalCodeEmptyText" => Some(locale.postalCodeEmptyText)
+  | "postalCodeInvalidText" => Some(locale.postalCodeInvalidText)
+  | "stateLabel" => Some(locale.stateLabel)
+  | "stateEmptyText" => Some(locale.stateEmptyText)
+  | "fullNamePlaceholder" => Some(locale.fullNamePlaceholder)
+  | "countryLabel" => Some(locale.countryLabel)
+  | "currencyLabel" => Some(locale.currencyLabel)
+  | "bankLabel" => Some(locale.bankLabel)
+  | "documentTypeLabel" => Some(locale.documentTypeLabel)
+  | "redirectText" => Some(locale.redirectText)
+  | "bankDetailsText" => Some(locale.bankDetailsText)
+  | "orPayUsing" => Some(locale.orPayUsing)
+  | "addNewCard" => Some(locale.addNewCard)
+  | "useExisitingSavedCards" => Some(locale.useExisitingSavedCards)
+  | "saveCardDetails" => Some(locale.saveCardDetails)
+  | "addBankAccount" => Some(locale.addBankAccount)
+  | "becsDebitTerms" => Some(locale.becsDebitTerms)
+  | "payNowButton" => Some(locale.payNowButton)
+  | "cardNumberEmptyText" => Some(locale.cardNumberEmptyText)
+  | "cardExpiryDateEmptyText" => Some(locale.cardExpiryDateEmptyText)
+  | "cvcNumberEmptyText" => Some(locale.cvcNumberEmptyText)
+  | "enterFieldsText" => Some(locale.enterFieldsText)
+  | "enterValidDetailsText" => Some(locale.enterValidDetailsText)
+  | "selectPaymentMethodText" => Some(locale.selectPaymentMethodText)
+  | "card" => Some(locale.card)
+  | "surchargeMsgAmountForOneClickWallets" => Some(locale.surchargeMsgAmountForOneClickWallets)
+  | "billingNameLabel" => Some(locale.billingNameLabel)
+  | "billingNamePlaceholder" => Some(locale.billingNamePlaceholder)
+  | "cardHolderName" => Some(locale.cardHolderName)
+  | "on" => Some(locale.on)
+  | "and" => Some(locale.\"and")
+  | "billingDetailsText" => Some(locale.billingDetailsText)
+  | "socialSecurityNumberLabel" => Some(locale.socialSecurityNumberLabel)
+  | "saveWalletDetails" => Some(locale.saveWalletDetails)
+  | "newPaymentMethods" => Some(locale.newPaymentMethods)
+  | "useExistingPaymentMethods" => Some(locale.useExistingPaymentMethods)
+  | "cardNickname" => Some(locale.cardNickname)
+  | "nicknamePlaceholder" => Some(locale.nicknamePlaceholder)
+  | "cardExpiredText" => Some(locale.cardExpiredText)
+  | "cardHeader" => Some(locale.cardHeader)
+  | "cardNotEligibleText" => Some(locale.cardNotEligibleText)
+  | "currencyNetwork" => Some(locale.currencyNetwork)
+  | "expiryPlaceholder" => Some(locale.expiryPlaceholder)
+  | "dateOfBirth" => Some(locale.dateOfBirth)
+  | "vpaIdLabel" => Some(locale.vpaIdLabel)
+  | "vpaIdEmptyText" => Some(locale.vpaIdEmptyText)
+  | "vpaIdInvalidText" => Some(locale.vpaIdInvalidText)
+  | "dateofBirthRequiredText" => Some(locale.dateofBirthRequiredText)
+  | "dateOfBirthInvalidText" => Some(locale.dateOfBirthInvalidText)
+  | "dateOfBirthPlaceholderText" => Some(locale.dateOfBirthPlaceholderText)
+  | "formFundsInfoText" => Some(locale.formFundsInfoText)
+  | "formEditText" => Some(locale.formEditText)
+  | "formSaveText" => Some(locale.formSaveText)
+  | "formSubmitText" => Some(locale.formSubmitText)
+  | "formSubmittingText" => Some(locale.formSubmittingText)
+  | "formSubheaderBillingDetailsText" => Some(locale.formSubheaderBillingDetailsText)
+  | "formSubheaderCardText" => Some(locale.formSubheaderCardText)
+  | "formHeaderReviewText" => Some(locale.formHeaderReviewText)
+  | "formHeaderEnterCardText" => Some(locale.formHeaderEnterCardText)
+  | "formHeaderSelectBankText" => Some(locale.formHeaderSelectBankText)
+  | "formHeaderSelectWalletText" => Some(locale.formHeaderSelectWalletText)
+  | "formHeaderSelectAccountText" => Some(locale.formHeaderSelectAccountText)
+  | "formFieldACHRoutingNumberLabel" => Some(locale.formFieldACHRoutingNumberLabel)
+  | "formFieldSepaIbanLabel" => Some(locale.formFieldSepaIbanLabel)
+  | "formFieldSepaBicLabel" => Some(locale.formFieldSepaBicLabel)
+  | "formFieldPixIdLabel" => Some(locale.formFieldPixIdLabel)
+  | "formFieldBankAccountNumberLabel" => Some(locale.formFieldBankAccountNumberLabel)
+  | "formFieldPhoneNumberLabel" => Some(locale.formFieldPhoneNumberLabel)
+  | "formFieldCountryCodeLabel" => Some(locale.formFieldCountryCodeLabel)
+  | "formFieldCountryCodeRequiredLabel" => Some(locale.formFieldCountryCodeRequiredLabel)
+  | "formFieldBankNameLabel" => Some(locale.formFieldBankNameLabel)
+  | "formFieldBankCityLabel" => Some(locale.formFieldBankCityLabel)
+  | "formFieldCardHoldernamePlaceholder" => Some(locale.formFieldCardHoldernamePlaceholder)
+  | "formFieldBankNamePlaceholder" => Some(locale.formFieldBankNamePlaceholder)
+  | "formFieldBankCityPlaceholder" => Some(locale.formFieldBankCityPlaceholder)
+  | "formFieldEmailPlaceholder" => Some(locale.formFieldEmailPlaceholder)
+  | "formFieldPhoneNumberPlaceholder" => Some(locale.formFieldPhoneNumberPlaceholder)
+  | "formFieldInvalidRoutingNumber" => Some(locale.formFieldInvalidRoutingNumber)
+  | "infoCardRefId" => Some(locale.infoCardRefId)
+  | "infoCardErrCode" => Some(locale.infoCardErrCode)
+  | "infoCardErrMsg" => Some(locale.infoCardErrMsg)
+  | "infoCardErrReason" => Some(locale.infoCardErrReason)
+  | "payoutFromText" => Some(locale.payoutFromText(""))
+  | "payoutStatusFailedMessage" => Some(locale.payoutStatusFailedMessage)
+  | "payoutStatusPendingMessage" => Some(locale.payoutStatusPendingMessage)
+  | "payoutStatusSuccessMessage" => Some(locale.payoutStatusSuccessMessage)
+  | "payoutStatusFailedText" => Some(locale.payoutStatusFailedText)
+  | "payoutStatusPendingText" => Some(locale.payoutStatusPendingText)
+  | "payoutStatusSuccessText" => Some(locale.payoutStatusSuccessText)
+  | "pixCNPJInvalidText" => Some(locale.pixCNPJInvalidText)
+  | "pixCNPJEmptyText" => Some(locale.pixCNPJEmptyText)
+  | "pixCNPJLabel" => Some(locale.pixCNPJLabel)
+  | "pixCNPJPlaceholder" => Some(locale.pixCNPJPlaceholder)
+  | "pixCPFInvalidText" => Some(locale.pixCPFInvalidText)
+  | "pixCPFEmptyText" => Some(locale.pixCPFEmptyText)
+  | "pixCPFLabel" => Some(locale.pixCPFLabel)
+  | "pixCPFPlaceholder" => Some(locale.pixCPFPlaceholder)
+  | "pixKeyEmptyText" => Some(locale.pixKeyEmptyText)
+  | "pixKeyLabel" => Some(locale.pixKeyLabel)
+  | "pixKeyPlaceholder" => Some(locale.pixKeyPlaceholder)
+  | "sourceBankAccountIdEmptyText" => Some(locale.sourceBankAccountIdEmptyText)
+  | "invalidCardHolderNameError" => Some(locale.invalidCardHolderNameError)
+  | "invalidNickNameError" => Some(locale.invalidNickNameError)
+  | "expiry" => Some(locale.expiry)
+  | "payment_methods_afterpay_clearpay" => Some(locale.payment_methods_afterpay_clearpay)
+  | "payment_methods_google_pay" => Some(locale.payment_methods_google_pay)
+  | "payment_methods_apple_pay" => Some(locale.payment_methods_apple_pay)
+  | "payment_methods_samsung_pay" => Some(locale.payment_methods_samsung_pay)
+  | "payment_methods_mb_way" => Some(locale.payment_methods_mb_way)
+  | "payment_methods_mobile_pay" => Some(locale.payment_methods_mobile_pay)
+  | "payment_methods_ali_pay" => Some(locale.payment_methods_ali_pay)
+  | "payment_methods_ali_pay_hk" => Some(locale.payment_methods_ali_pay_hk)
+  | "payment_methods_we_chat_pay" => Some(locale.payment_methods_we_chat_pay)
+  | "payment_methods_duit_now" => Some(locale.payment_methods_duit_now)
+  | "payment_methods_revolut_pay" => Some(locale.payment_methods_revolut_pay)
+  | "payment_methods_affirm" => Some(locale.payment_methods_affirm)
+  | "payment_methods_pay_safe_card" => Some(locale.payment_methods_pay_safe_card)
+  | "payment_methods_crypto_currency" => Some(locale.payment_methods_crypto_currency)
+  | "payment_methods_card" => Some(locale.payment_methods_card)
+  | "payment_methods_klarna" => Some(locale.payment_methods_klarna)
+  | "payment_methods_sofort" => Some(locale.payment_methods_sofort)
+  | "payment_methods_ach_transfer" => Some(locale.payment_methods_ach_transfer)
+  | "payment_methods_bacs_transfer" => Some(locale.payment_methods_bacs_transfer)
+  | "payment_methods_sepa_bank_transfer" => Some(locale.payment_methods_sepa_bank_transfer)
+  | "payment_methods_instant_bank_transfer" => Some(locale.payment_methods_instant_bank_transfer)
+  | "payment_methods_instant_bank_transfer_finland" =>
+    Some(locale.payment_methods_instant_bank_transfer_finland)
+  | "payment_methods_instant_bank_transfer_poland" =>
+    Some(locale.payment_methods_instant_bank_transfer_poland)
+  | "payment_methods_sepa_debit" => Some(locale.payment_methods_sepa_debit)
+  | "payment_methods_giropay" => Some(locale.payment_methods_giropay)
+  | "payment_methods_eps" => Some(locale.payment_methods_eps)
+  | "payment_methods_walley" => Some(locale.payment_methods_walley)
+  | "payment_methods_pay_bright" => Some(locale.payment_methods_pay_bright)
+  | "payment_methods_ach_debit" => Some(locale.payment_methods_ach_debit)
+  | "payment_methods_bacs_debit" => Some(locale.payment_methods_bacs_debit)
+  | "payment_methods_becs_debit" => Some(locale.payment_methods_becs_debit)
+  | "payment_methods_blik" => Some(locale.payment_methods_blik)
+  | "payment_methods_trustly" => Some(locale.payment_methods_trustly)
+  | "payment_methods_bancontact_card" => Some(locale.payment_methods_bancontact_card)
+  | "payment_methods_online_banking_czech_republic" =>
+    Some(locale.payment_methods_online_banking_czech_republic)
+  | "payment_methods_online_banking_slovakia" =>
+    Some(locale.payment_methods_online_banking_slovakia)
+  | "payment_methods_online_banking_finland" =>
+    Some(locale.payment_methods_online_banking_finland)
+  | "payment_methods_online_banking_poland" => Some(locale.payment_methods_online_banking_poland)
+  | "payment_methods_ideal" => Some(locale.payment_methods_ideal)
+  | "payment_methods_ban_connect" => Some(locale.payment_methods_ban_connect)
+  | "payment_methods_ach_bank_debit" => Some(locale.payment_methods_ach_bank_debit)
+  | "payment_methods_przelewy24" => Some(locale.payment_methods_przelewy24)
+  | "payment_methods_interac" => Some(locale.payment_methods_interac)
+  | "payment_methods_twint" => Some(locale.payment_methods_twint)
+  | "payment_methods_vipps" => Some(locale.payment_methods_vipps)
+  | "payment_methods_dana" => Some(locale.payment_methods_dana)
+  | "payment_methods_go_pay" => Some(locale.payment_methods_go_pay)
+  | "payment_methods_kakao_pay" => Some(locale.payment_methods_kakao_pay)
+  | "payment_methods_gcash" => Some(locale.payment_methods_gcash)
+  | "payment_methods_momo" => Some(locale.payment_methods_momo)
+  | "payment_methods_touch_n_go" => Some(locale.payment_methods_touch_n_go)
+  | "payment_methods_bizum" => Some(locale.payment_methods_bizum)
+  | "payment_methods_classic" => Some(locale.payment_methods_classic)
+  | "payment_methods_online_banking_fpx" => Some(locale.payment_methods_online_banking_fpx)
+  | "payment_methods_online_banking_thailand" =>
+    Some(locale.payment_methods_online_banking_thailand)
+  | "payment_methods_alma" => Some(locale.payment_methods_alma)
+  | "payment_methods_atome" => Some(locale.payment_methods_atome)
+  | "payment_methods_multibanco_transfer" => Some(locale.payment_methods_multibanco_transfer)
+  | "payment_methods_card_redirect" => Some(locale.payment_methods_card_redirect)
+  | "payment_methods_pay_by_bank" => Some(locale.payment_methods_pay_by_bank)
+  | "payment_methods_open_banking_pis" => Some(locale.payment_methods_open_banking_pis)
+  | "payment_methods_evoucher" => Some(locale.payment_methods_evoucher)
+  | "payment_methods_pix_transfer" => Some(locale.payment_methods_pix_transfer)
+  | "payment_methods_boleto" => Some(locale.payment_methods_boleto)
+  | "payment_methods_paypal" => Some(locale.payment_methods_paypal)
+  | "payment_methods_local_bank_transfer_transfer" =>
+    Some(locale.payment_methods_local_bank_transfer_transfer)
+  | "payment_methods_mifinity" => Some(locale.payment_methods_mifinity)
+  | "payment_methods_upi_collect" => Some(locale.payment_methods_upi_collect)
+  | "payment_methods_eft" => Some(locale.payment_methods_eft)
+  | "payment_methods_givex" => Some(locale.payment_methods_givex)
+  | "payment_methods_saved_methods" => Some(locale.payment_methods_saved_methods)
+  | "giftCardSectionTitle" => Some(locale.giftCardSectionTitle)
+  | "giftCardNumberLabel" => Some(locale.giftCardNumberLabel)
+  | "giftCardNumberPlaceholder" => Some(locale.giftCardNumberPlaceholder)
+  | "giftCardNumberEmptyText" => Some(locale.giftCardNumberEmptyText)
+  | "giftCardNumberInvalidText" => Some(locale.giftCardNumberInvalidText)
+  | "giftCardPinLabel" => Some(locale.giftCardPinLabel)
+  | "giftCardPinPlaceholder" => Some(locale.giftCardPinPlaceholder)
+  | "giftCardPinEmptyText" => Some(locale.giftCardPinEmptyText)
+  | "giftCardPinInvalidText" => Some(locale.giftCardPinInvalidText)
+  | "cardText" => Some(locale.cardText)
+  | "giftCardAppliedText" => Some(locale.giftCardAppliedText)
+  | "giftCardPaymentCompleteMessage" => Some(locale.giftCardPaymentCompleteMessage)
+  | "installmentPayInInstallments" => Some(locale.installmentPayInInstallments)
+  | "installmentInterestFree" => Some(locale.installmentInterestFree)
+  | "installmentWithInterest" => Some(locale.installmentWithInterest)
+  | "installmentTotal" => Some(locale.installmentTotal)
+  | "installmentSelectPlanError" => Some(locale.installmentSelectPlanError)
+  | "installmentSelectPlanPlaceholder" => Some(locale.installmentSelectPlanPlaceholder)
+  | "showMore" => Some(locale.showMore)
+  | "showLess" => Some(locale.showLess)
+  | "refreshingText" => Some(locale.refreshingText)
+  | _ => None
   }
+
+let resolveFieldTexts = (
+  ~field: SuperpositionTypes.fieldConfig,
+  ~localeObject: LocaleStringTypes.localeStrings,
+): fieldTexts => {
+  let label = switch field.merchantProvidedDisplayName {
+  | Some(name) => name
+  | None =>
+    field.labelLocalizationKey
+    ->Option.flatMap(key => lookupLocaleKey(key, localeObject))
+    ->Option.getOr(field.defaultLabelText)
+  }
+
+  let placeholder = switch field.merchantProvidedPlaceholderText {
+  | Some(text) => text
+  | None =>
+    field.placeholderLocalizationKey
+    ->Option.flatMap(key => lookupLocaleKey(key, localeObject))
+    ->Option.getOr(label)
+  }
+
+  {label, placeholder}
 }
 
-let getBillingAddressPathFromFieldType = (fieldType: PaymentMethodsRecord.paymentMethodsFields) => {
-  switch fieldType {
-  | AddressLine1 => "payment_method_data.billing.address.line1"
-  | AddressLine2 => "payment_method_data.billing.address.line2"
-  | AddressCity => "payment_method_data.billing.address.city"
-  | AddressState => "payment_method_data.billing.address.state"
-  | AddressCountry(_) => "payment_method_data.billing.address.country"
-  | AddressPincode => "payment_method_data.billing.address.zip"
-  | _ => ""
+let resolveValidator = (
+  ~field: SuperpositionTypes.fieldConfig,
+  ~localeObject: LocaleStringTypes.localeStrings,
+) => {
+  let requiredRule = field.isRequired ? [Validation.Required] : []
+
+  let semanticRule = switch field.validationRuleType {
+  | Some("email") => [Validation.Email]
+  | Some("phone") => [Validation.Phone]
+  | Some("iban") => [Validation.IBAN]
+  | Some("routing_number") => [Validation.RoutingNumber]
+  | Some("vpa_id") => [Validation.VpaId]
+  | Some("blik_code") => [Validation.BlikCode]
+  | Some("gift_card_number") => [Validation.GiftCardNumber]
+  | Some("gift_card_pin") => [Validation.GiftCardPin]
+  | Some("pix_key") => [Validation.PixKey]
+  | Some("pix_cpf") => [Validation.PixCPF]
+  | Some("pix_cnpj") => [Validation.PixCNPJ]
+  | Some("regex") =>
+    switch field.validationRegexPattern {
+    | Some(pattern) => [Validation.Generic(pattern)]
+    | None => []
+    }
+  | _ => []
   }
+
+  let maxLengthRule = [Validation.MaxLength(field.maxInputLength->Option.getOr(255))]
+
+  let rules = Array.concat(Array.concat(requiredRule, semanticRule), maxLengthRule)
+
+  Validation.createFieldValidator(
+    rules,
+    ~enabledCardSchemes=[],
+    ~localeObject=localeObject->Obj.magic,
+  )
+}
+
+let extractValuesFromPMLRequiredFields = (
+  requiredFields: array<PaymentMethodsRecord.required_fields>,
+) => {
+  requiredFields->Array.reduce(Dict.make(), (acc, field) => {
+    if field.required_field !== "" {
+      acc->Dict.set(field.required_field, field.value)
+    }
+    acc
+  })
 }
 
 let removeBillingDetailsIfUseBillingAddress = (
-  requiredFields: array<PaymentMethodsRecord.required_fields>,
+  missingRequiredFields: array<SuperpositionTypes.fieldConfig>,
   billingAddress: PaymentType.billingAddress,
 ) => {
   if billingAddress.isUseBillingAddress {
-    requiredFields->Array.filter(requiredField => {
-      !(requiredField.field_type->isBillingAddressFieldType)
+    missingRequiredFields->Array.filter(requiredField => {
+      !(requiredField.confirmRequestWritePath->String.startsWith("payment_method_data.billing."))
     })
   } else {
-    requiredFields
+    missingRequiredFields
   }
 }
 
-let addBillingAddressIfUseBillingAddress = (
-  fieldsArr,
-  billingAddress: PaymentType.billingAddress,
+let getEligibleConnectors = (
+  paymentMethodTypes: PaymentMethodsRecord.paymentMethodTypes,
+  paymentMethod: string,
 ) => {
-  if billingAddress.isUseBillingAddress {
-    fieldsArr->Array.concat(billingAddressFields)
+  if paymentMethod === "card" {
+    paymentMethodTypes.card_networks->Array.flatMap(network =>
+      network.eligible_connectors->Array.map(item => item->JSON.Encode.string)
+    )
   } else {
-    fieldsArr
+    paymentMethodTypes.payment_experience->Array.flatMap(exp =>
+      exp.eligible_connectors->Array.map(item => item->JSON.Encode.string)
+    )
   }
 }
 
-let isClickToPayFieldType = (fieldType: PaymentMethodsRecord.paymentMethodsFields) => {
-  switch fieldType {
-  | Email
-  | PhoneNumber => true
-  | _ => false
-  }
-}
-
-let removeClickToPayFieldsIfSaveDetailsWithClickToPay = (
-  requiredFields: array<PaymentMethodsRecord.required_fields>,
-  isSaveDetailsWithClickToPay,
+let buildSuperpositionBaseContext = (
+  ~paymentMethod: string,
+  ~paymentMethodType: string,
+  ~country: string,
+  ~paymentMethodListValue: PaymentMethodsRecord.paymentMethodList,
 ) => {
-  if isSaveDetailsWithClickToPay {
-    requiredFields->Array.filter(requiredField => {
-      !(requiredField.field_type->isClickToPayFieldType)
-    })
-  } else {
-    requiredFields
+  let mandateType = switch paymentMethodListValue.payment_type {
+  | NEW_MANDATE => "new_mandate"
+  | SETUP_MANDATE => "setup_mandate"
+  | NORMAL => "non_mandate"
+  | NONE => "non_mandate"
   }
-}
 
-let addClickToPayFieldsIfSaveDetailsWithClickToPay = (
-  fieldsArr,
-  isSaveDetailsWithClickToPay,
-  clickToPayConfig,
-) => {
-  open ClickToPayHelpers
-  open PaymentMethodsRecord
-  let isRecognizedClickToPayPayment =
-    clickToPayConfig.clickToPayCards->Option.getOr([])->Array.length != 0
-  let defaultCtpFields = [...fieldsArr, Email, PhoneNumber]
-  switch (
-    isSaveDetailsWithClickToPay,
-    clickToPayConfig.clickToPayProvider,
-    isRecognizedClickToPayPayment,
-  ) {
-  | (true, MASTERCARD, _) => defaultCtpFields
-  | (true, VISA, _)
-  | (false, VISA, true) =>
-    [...defaultCtpFields, FullName]
-  | _ => fieldsArr
+  let collectBilling =
+    paymentMethodListValue.collect_billing_details_from_wallets
+      ? "true"
+      : "false"
+  let collectShipping = "false"
+
+  let context: SuperpositionTypes.superpositionBaseContext = {
+    payment_method: paymentMethod,
+    payment_method_type: paymentMethodType,
+    country,
+    mandate_type: mandateType,
+    collect_shipping_details_from_wallet_connector: collectShipping,
+    collect_billing_details_from_wallet_connector: collectBilling,
   }
+  context
 }
 
 let checkIfNameIsValid = (
@@ -184,815 +383,6 @@ let checkIfNameIsValid = (
   })
 }
 
-let useRequiredFieldsEmptyAndValid = (
-  ~requiredFields,
-  ~fieldsArr: array<PaymentMethodsRecord.paymentMethodsFields>,
-  ~countryNames,
-  ~bankNames,
-  ~isCardValid,
-  ~isExpiryValid,
-  ~isCVCValid,
-  ~cardNumber,
-  ~cardExpiry,
-  ~cvcNumber,
-  ~isSavedCardFlow,
-) => {
-  let email = Recoil.useRecoilValueFromAtom(userEmailAddress)
-  let vpaId = Recoil.useRecoilValueFromAtom(userVpaId)
-  let pixCNPJ = Recoil.useRecoilValueFromAtom(userPixCNPJ)
-  let pixCPF = Recoil.useRecoilValueFromAtom(userPixCPF)
-  let pixKey = Recoil.useRecoilValueFromAtom(userPixKey)
-  let fullName = Recoil.useRecoilValueFromAtom(userFullName)
-  let billingName = Recoil.useRecoilValueFromAtom(userBillingName)
-  let line1 = Recoil.useRecoilValueFromAtom(userAddressline1)
-  let line2 = Recoil.useRecoilValueFromAtom(userAddressline2)
-  let phone = Recoil.useRecoilValueFromAtom(userPhoneNumber)
-  let state = Recoil.useRecoilValueFromAtom(userAddressState)
-  let city = Recoil.useRecoilValueFromAtom(userAddressCity)
-  let postalCode = Recoil.useRecoilValueFromAtom(userAddressPincode)
-  let blikCode = Recoil.useRecoilValueFromAtom(userBlikCode)
-  let country = Recoil.useRecoilValueFromAtom(userCountry)
-  let selectedBank = Recoil.useRecoilValueFromAtom(userBank)
-  let currency = Recoil.useRecoilValueFromAtom(userCurrency)
-  let documentType = Recoil.useRecoilValueFromAtom(userDocumentType)
-  let documentNumber = Recoil.useRecoilValueFromAtom(userDocumentNumber)
-
-  let (areRequiredFieldsValid, setAreRequiredFieldsValid) = Recoil.useRecoilState(
-    areRequiredFieldsValid,
-  )
-  let setAreRequiredFieldsEmpty = Recoil.useSetRecoilState(areRequiredFieldsEmpty)
-  let {billingAddress} = Recoil.useRecoilValueFromAtom(optionAtom)
-  let cryptoCurrencyNetworks = Recoil.useRecoilValueFromAtom(cryptoCurrencyNetworks)
-  let dateOfBirth = Recoil.useRecoilValueFromAtom(dateOfBirth)
-  let bankAccountNumber = Recoil.useRecoilValueFromAtom(userBankAccountNumber)
-  let sourceBankAccountId = Recoil.useRecoilValueFromAtom(sourceBankAccountId)
-  let giftCardNumber = Recoil.useRecoilValueFromAtom(userGiftCardNumber)
-  let giftCardPin = Recoil.useRecoilValueFromAtom(userGiftCardPin)
-
-  let fieldsArrWithBillingAddress = fieldsArr->addBillingAddressIfUseBillingAddress(billingAddress)
-
-  React.useEffect(() => {
-    let areRequiredFieldsValid = fieldsArr->Array.reduce(true, (acc, paymentMethodFields) => {
-      acc &&
-      switch paymentMethodFields {
-      | Email => email.isValid->Option.getOr(false)
-      | FullName =>
-        checkIfNameIsValid(requiredFields, paymentMethodFields, fullName) &&
-        fullName.isValid->Option.getOr(false)
-      | Country => country !== "" || countryNames->Array.length === 0
-      | AddressCountry(countryArr) => country !== "" || countryArr->Array.length === 0
-      | BillingName => checkIfNameIsValid(requiredFields, paymentMethodFields, billingName)
-      | AddressLine1 => line1.value !== ""
-      | AddressLine2 => billingAddress.isUseBillingAddress || line2.value !== ""
-      | Bank => selectedBank !== "" || bankNames->Array.length === 0
-      | PhoneNumberAndCountryCode => phone.value !== ""
-      | StateAndCity => state.value !== "" && city.value !== ""
-      | CountryAndPincode(countryArr) =>
-        (country !== "" || countryArr->Array.length === 0) && postalCode.value !== ""
-
-      | AddressCity => city.value !== ""
-      | AddressPincode => postalCode.value !== ""
-      | AddressState => state.value !== ""
-      | BlikCode => blikCode.value !== ""
-      | CryptoCurrencyNetworks => cryptoCurrencyNetworks !== ""
-      | Currency(currencyArr) => currency !== "" || currencyArr->Array.length === 0
-      | DocumentType(optArr) => documentType !== "" || optArr->Array.length === 0
-      | DocumentNumber => documentNumber.isValid->Option.getOr(false)
-      | CardNumber => isCardValid->Option.getOr(false)
-      | CardExpiryMonth
-      | CardExpiryYear
-      | CardExpiryMonthAndYear =>
-        isExpiryValid->Option.getOr(false)
-      | CardCvc => isCVCValid->Option.getOr(false)
-      | CardExpiryAndCvc => isExpiryValid->Option.getOr(false) && isCVCValid->Option.getOr(false)
-      | DateOfBirth =>
-        switch dateOfBirth->Nullable.toOption {
-        | Some(val) => val->Utils.checkIs18OrAbove
-        | None => false
-        }
-      | VpaId => vpaId.isValid->Option.getOr(false)
-      | PixCNPJ => pixCNPJ.isValid->Option.getOr(false)
-      | PixCPF => pixCPF.isValid->Option.getOr(false)
-      | PixKey => pixKey.isValid->Option.getOr(false)
-      | BankAccountNumber
-      | IBAN =>
-        bankAccountNumber.value !== ""
-      | GiftCardNumber => giftCardNumber.value !== ""
-      | GiftCardPin => giftCardPin.value !== ""
-      | SourceBankAccountId => sourceBankAccountId.value !== ""
-      | _ => true
-      }
-    })
-    setAreRequiredFieldsValid(_ => isSavedCardFlow || areRequiredFieldsValid)
-
-    let areRequiredFieldsEmpty = fieldsArrWithBillingAddress->Array.reduce(false, (
-      acc,
-      paymentMethodFields: PaymentMethodsRecord.paymentMethodsFields,
-    ) => {
-      open CardUtils
-      acc ||
-      switch paymentMethodFields {
-      | Email => email.value === ""
-      | FullName => fullName.value === ""
-      | Country => country === "" && countryNames->Array.length > 0
-      | AddressCountry(countryArr) => country === "" && countryArr->Array.length > 0
-      | BillingName => billingName.value === ""
-      | AddressLine1 => line1.value === ""
-      | AddressLine2 => !billingAddress.isUseBillingAddress && line2.value === ""
-      | Bank => selectedBank === "" && bankNames->Array.length > 0
-      | StateAndCity => city.value === "" || state.value === ""
-      | CountryAndPincode(countryArr) =>
-        (country === "" && countryArr->Array.length > 0) || postalCode.value === ""
-      | PhoneNumberAndCountryCode => phone.value === ""
-      | AddressCity => city.value === ""
-      | AddressPincode => postalCode.value === ""
-      | AddressState => state.value === ""
-      | BlikCode => blikCode.value === ""
-      | PixCNPJ => pixCNPJ.value === ""
-      | PixCPF => pixCPF.value === ""
-      | PixKey => pixKey.value === ""
-      | CryptoCurrencyNetworks => cryptoCurrencyNetworks === ""
-      | Currency(currencyArr) => currency === "" && currencyArr->Array.length > 0
-      | DocumentType(optArr) => documentType === "" && optArr->Array.length > 0
-      | DocumentNumber => documentNumber.value === ""
-      | CardNumber => cardNumber === ""
-      | CardExpiryMonth =>
-        let (month, _) = getExpiryDates(cardExpiry)
-        month === ""
-      | CardExpiryYear =>
-        let (_, year) = getExpiryDates(cardExpiry)
-        year === ""
-      | CardExpiryMonthAndYear =>
-        let (month, year) = getExpiryDates(cardExpiry)
-        month === "" || year === ""
-      | CardCvc => cvcNumber === ""
-      | CardExpiryAndCvc =>
-        let (month, year) = getExpiryDates(cardExpiry)
-        month === "" || year === "" || cvcNumber === ""
-      | DateOfBirth => dateOfBirth->Js.Nullable.isNullable
-      | BankAccountNumber
-      | IBAN =>
-        bankAccountNumber.value === ""
-      | GiftCardNumber => giftCardNumber.value === ""
-      | GiftCardPin => giftCardPin.value === ""
-      | SourceBankAccountId => sourceBankAccountId.value === ""
-      | _ => false
-      }
-    })
-    setAreRequiredFieldsEmpty(_ => areRequiredFieldsEmpty)
-    None
-  }, (
-    fieldsArr,
-    currency,
-    fullName.value,
-    country,
-    billingName.value,
-    line1.value,
-    dateOfBirth,
-    email,
-    vpaId,
-    line2.value,
-    selectedBank,
-    phone.value,
-    city.value,
-    postalCode,
-    state.value,
-    blikCode.value,
-    pixCNPJ.value,
-    pixKey.value,
-    pixCPF.value,
-    giftCardPin.value,
-    giftCardNumber.value,
-    isCardValid,
-    isExpiryValid,
-    isCVCValid,
-    cardNumber,
-    cardExpiry,
-    cvcNumber,
-    bankAccountNumber,
-    sourceBankAccountId.value,
-    cryptoCurrencyNetworks,
-    documentType,
-    documentNumber.value,
-  ))
-
-  React.useEffect(() => {
-    switch (isCardValid, isExpiryValid, isCVCValid) {
-    | (Some(cardValid), Some(expiryValid), Some(cvcValid)) =>
-      CardUtils.emitIsFormReadyForSubmission(
-        cardValid && expiryValid && cvcValid && areRequiredFieldsValid,
-      )
-    | _ => ()
-    }
-    None
-  }, (isCardValid, isExpiryValid, isCVCValid, areRequiredFieldsValid))
-}
-
-let useSetInitialRequiredFields = (
-  ~requiredFields: array<PaymentMethodsRecord.required_fields>,
-  ~paymentMethodType,
-) => {
-  let (email, setEmail) = Recoil.useRecoilState(userEmailAddress)
-  let (fullName, setFullName) = Recoil.useRecoilState(userFullName)
-  let (billingName, setBillingName) = Recoil.useRecoilState(userBillingName)
-  let (line1, setLine1) = Recoil.useRecoilState(userAddressline1)
-  let (line2, setLine2) = Recoil.useRecoilState(userAddressline2)
-  let (phone, setPhone) = Recoil.useRecoilState(userPhoneNumber)
-  let (state, setState) = Recoil.useRecoilState(userAddressState)
-  let (city, setCity) = Recoil.useRecoilState(userAddressCity)
-  let (postalCode, setPostalCode) = Recoil.useRecoilState(userAddressPincode)
-  let (blikCode, setBlikCode) = Recoil.useRecoilState(userBlikCode)
-  let (pixCNPJ, setPixCNPJ) = Recoil.useRecoilState(userPixCNPJ)
-  let (pixCPF, setPixCPF) = Recoil.useRecoilState(userPixCPF)
-  let (pixKey, setPixKey) = Recoil.useRecoilState(userPixKey)
-
-  let (country, setCountry) = Recoil.useRecoilState(userCountry)
-  let (selectedBank, setSelectedBank) = Recoil.useRecoilState(userBank)
-  let (currency, setCurrency) = Recoil.useRecoilState(userCurrency)
-  let (documentType, setDocumentType) = Recoil.useRecoilState(userDocumentType)
-  let (documentNumber, setDocumentNumber) = Recoil.useRecoilState(userDocumentNumber)
-  let (cryptoCurrencyNetworks, setCryptoCurrencyNetworks) = Recoil.useRecoilState(
-    cryptoCurrencyNetworks,
-  )
-  let (dateOfBirth, setDateOfBirth) = Recoil.useRecoilState(dateOfBirth)
-  let (bankAccountNumber, setBankAccountNumber) = Recoil.useRecoilState(userBankAccountNumber)
-  let (sourceBankAccountId, setSourceBankAccountId) = Recoil.useRecoilState(sourceBankAccountId)
-  let (giftCardNumber, setGiftCardNumber) = Recoil.useRecoilState(userGiftCardNumber)
-  let (giftCardPin, setGiftCardPin) = Recoil.useRecoilState(userGiftCardPin)
-
-  React.useEffect(() => {
-    let getNameValue = (item: PaymentMethodsRecord.required_fields) => {
-      requiredFields
-      ->Array.filter(requiredFields => requiredFields.field_type === item.field_type)
-      ->Array.reduce("", (acc, item) => {
-        let requiredFieldsArr = item.required_field->String.split(".")
-        switch requiredFieldsArr->Array.get(requiredFieldsArr->Array.length - 1)->Option.getOr("") {
-        | "first_name" => item.value->String.concat(acc)
-        | "last_name" => acc->String.concatMany([" ", item.value])
-        | _ => acc
-        }
-      })
-      ->String.trim
-    }
-
-    let setFields = (
-      setMethod: (RecoilAtomTypes.field => RecoilAtomTypes.field) => unit,
-      field: RecoilAtomTypes.field,
-      item: PaymentMethodsRecord.required_fields,
-      isNameField,
-      ~isCountryCodeAvailable=?,
-    ) => {
-      if isNameField && field.value === "" {
-        setMethod(prev => {
-          ...prev,
-          value: getNameValue(item),
-        })
-        if isCountryCodeAvailable->Option.isSome {
-          setMethod(prev => {
-            ...prev,
-            countryCode: getNameValue(item),
-          })
-        }
-      } else if field.value === "" {
-        if isCountryCodeAvailable->Option.isSome {
-          setMethod(prev => {
-            ...prev,
-            countryCode: item.value,
-          })
-        } else {
-          setMethod(prev => {
-            ...prev,
-            value: item.value,
-          })
-        }
-      }
-    }
-
-    requiredFields->Array.forEach(requiredField => {
-      let value = requiredField.value
-      switch requiredField.field_type {
-      | Email => {
-          let emailValue = email.value
-          setFields(setEmail, email, requiredField, false)
-          if emailValue === "" {
-            let newEmail: RecoilAtomTypes.field = {
-              value,
-              isValid: None,
-              errorString: "",
-            }
-            Utils.checkEmailValid(newEmail, setEmail)
-          }
-        }
-      | FullName => setFields(setFullName, fullName, requiredField, true)
-      | AddressLine1 => setFields(setLine1, line1, requiredField, false)
-      | AddressLine2 => setFields(setLine2, line2, requiredField, false)
-      | StateAndCity => {
-          setFields(setState, state, requiredField, false)
-          setFields(setCity, city, requiredField, false)
-        }
-      | CountryAndPincode(_) => {
-          setFields(setPostalCode, postalCode, requiredField, false)
-          if value !== "" && country === "" {
-            let countryCode =
-              Country.getCountry(paymentMethodType, countryList)
-              ->Array.filter(item => item.isoAlpha2 === value)
-              ->Array.get(0)
-              ->Option.getOr(Country.defaultTimeZone)
-            setCountry(_ => countryCode.countryName)
-          }
-        }
-      | AddressState => setFields(setState, state, requiredField, false)
-      | GiftCardNumber => setFields(setGiftCardNumber, giftCardNumber, requiredField, false)
-      | GiftCardPin => setFields(setGiftCardPin, giftCardPin, requiredField, false)
-      | AddressCity => setFields(setCity, city, requiredField, false)
-      | PhoneCountryCode =>
-        setFields(setPhone, phone, requiredField, false, ~isCountryCodeAvailable=true)
-      | AddressPincode => setFields(setPostalCode, postalCode, requiredField, false)
-      | PhoneNumber => setFields(setPhone, phone, requiredField, false)
-      | PhoneNumberAndCountryCode =>
-        setFields(setPhone, phone, requiredField, false, ~isCountryCodeAvailable=true)
-      | BlikCode => setFields(setBlikCode, blikCode, requiredField, false)
-      | PixKey => setFields(setPixKey, pixKey, requiredField, false)
-      | PixCNPJ => setFields(setPixCNPJ, pixCNPJ, requiredField, false)
-      | PixCPF => setFields(setPixCPF, pixCPF, requiredField, false)
-      | BillingName => setFields(setBillingName, billingName, requiredField, true)
-      | Country
-      | AddressCountry(_) =>
-        if value !== "" {
-          let defaultCountry =
-            Country.getCountry(paymentMethodType, countryList)
-            ->Array.filter(item => item.isoAlpha2 === value)
-            ->Array.get(0)
-            ->Option.getOr(Country.defaultTimeZone)
-          setCountry(_ => defaultCountry.countryName)
-        }
-      | Currency(_) =>
-        if value !== "" && currency === "" {
-          setCurrency(_ => value)
-        }
-      | Bank =>
-        if value !== "" && selectedBank === "" {
-          setSelectedBank(_ => value)
-        }
-      | CryptoCurrencyNetworks =>
-        if value !== "" && cryptoCurrencyNetworks === "" {
-          setCryptoCurrencyNetworks(_ => value)
-        }
-      | DateOfBirth =>
-        switch dateOfBirth->Nullable.toOption {
-        | Some(x) =>
-          if value !== "" && x->Date.toDateString === "" {
-            setDateOfBirth(_ => Nullable.make(x))
-          }
-        | None => ()
-        }
-      | IBAN
-      | BankAccountNumber =>
-        setFields(setBankAccountNumber, bankAccountNumber, requiredField, false)
-      | SourceBankAccountId =>
-        setFields(setSourceBankAccountId, sourceBankAccountId, requiredField, false)
-      | DocumentType(_) =>
-        if value !== "" && documentType === "" {
-          setDocumentType(_ => value)
-        }
-      | DocumentNumber => setFields(setDocumentNumber, documentNumber, requiredField, false)
-      | LanguagePreference(_)
-      | SpecialField(_)
-      | InfoElement
-      | CardNumber
-      | CardExpiryMonth
-      | CardExpiryYear
-      | CardExpiryMonthAndYear
-      | CardCvc
-      | CardExpiryAndCvc
-      | ShippingName // Shipping Details are currently supported by only one click widgets
-      | ShippingAddressLine1
-      | ShippingAddressLine2
-      | ShippingAddressCity
-      | ShippingAddressPincode
-      | ShippingAddressState
-      | ShippingAddressCountry(_)
-      | BankList(_)
-      | VpaId
-      | None => ()
-      }
-    })
-    None
-  }, [requiredFields])
-}
-
-let useRequiredFieldsBody = (
-  ~requiredFields: array<PaymentMethodsRecord.required_fields>,
-  ~paymentMethodType,
-  ~cardNumber,
-  ~cardExpiry,
-  ~cvcNumber,
-  ~isSavedCardFlow,
-  ~isAllStoredCardsHaveName,
-  ~setRequiredFieldsBody,
-) => {
-  let configValue = Recoil.useRecoilValueFromAtom(configAtom)
-  let email = Recoil.useRecoilValueFromAtom(userEmailAddress)
-  let vpaId = Recoil.useRecoilValueFromAtom(userVpaId)
-  let pixCNPJ = Recoil.useRecoilValueFromAtom(userPixCNPJ)
-  let pixCPF = Recoil.useRecoilValueFromAtom(userPixCPF)
-  let pixKey = Recoil.useRecoilValueFromAtom(userPixKey)
-  let fullName = Recoil.useRecoilValueFromAtom(userFullName)
-  let billingName = Recoil.useRecoilValueFromAtom(userBillingName)
-  let line1 = Recoil.useRecoilValueFromAtom(userAddressline1)
-  let line2 = Recoil.useRecoilValueFromAtom(userAddressline2)
-  let phone = Recoil.useRecoilValueFromAtom(userPhoneNumber)
-  let state = Recoil.useRecoilValueFromAtom(userAddressState)
-  let city = Recoil.useRecoilValueFromAtom(userAddressCity)
-  let postalCode = Recoil.useRecoilValueFromAtom(userAddressPincode)
-  let blikCode = Recoil.useRecoilValueFromAtom(userBlikCode)
-  let country = Recoil.useRecoilValueFromAtom(userCountry)
-  let selectedBank = Recoil.useRecoilValueFromAtom(userBank)
-  let currency = Recoil.useRecoilValueFromAtom(userCurrency)
-  let documentType = Recoil.useRecoilValueFromAtom(userDocumentType)
-  let documentNumber = Recoil.useRecoilValueFromAtom(userDocumentNumber)
-  let {billingAddress} = Recoil.useRecoilValueFromAtom(optionAtom)
-  let cryptoCurrencyNetworks = Recoil.useRecoilValueFromAtom(cryptoCurrencyNetworks)
-  let dateOfBirth = Recoil.useRecoilValueFromAtom(dateOfBirth)
-  let bankAccountNumber = Recoil.useRecoilValueFromAtom(userBankAccountNumber)
-  let sourceBankAccountId = Recoil.useRecoilValueFromAtom(sourceBankAccountId)
-  let countryCode = Utils.getCountryCode(country).isoAlpha2
-  let stateCode = Utils.getStateCodeFromStateName(state.value, countryCode)
-  let giftCardNumber = Recoil.useRecoilValueFromAtom(userGiftCardNumber)
-  let giftCardPin = Recoil.useRecoilValueFromAtom(userGiftCardPin)
-
-  let getFieldValueFromFieldType = (fieldType: PaymentMethodsRecord.paymentMethodsFields) => {
-    switch fieldType {
-    | Email => email.value
-    | AddressLine1 => line1.value
-    | AddressLine2 => line2.value
-    | AddressCity => city.value
-    | AddressPincode => postalCode.value
-    | AddressState => stateCode
-    | BlikCode => blikCode.value->Utils.removeHyphen
-    | PhoneNumber => phone.value
-    | PhoneCountryCode => phone.countryCode->Option.getOr("")
-    | Currency(_) => currency
-    | DocumentType(_) => documentType
-    | DocumentNumber => documentNumber.value
-    | Country => country
-    | LanguagePreference(languageOptions) =>
-      languageOptions->Array.includes(
-        configValue.config.locale->String.toUpperCase->String.split("-")->Array.join("_"),
-      )
-        ? configValue.config.locale
-        : "en"
-    | Bank =>
-      (
-        Bank.getBanks(paymentMethodType)
-        ->Array.find(item => item.displayName == selectedBank)
-        ->Option.getOr(Bank.defaultBank)
-      ).value
-    | AddressCountry(_) => {
-        let countryCode =
-          Country.getCountry(paymentMethodType, countryList)
-          ->Array.filter(item => item.countryName === country)
-          ->Array.get(0)
-          ->Option.getOr(Country.defaultTimeZone)
-        countryCode.isoAlpha2
-      }
-    | BillingName => billingName.value
-    | CardNumber => cardNumber->CardValidations.clearSpaces
-    | GiftCardNumber => giftCardNumber.value
-    | GiftCardPin => giftCardPin.value
-    | CardExpiryMonth =>
-      let (month, _) = CardUtils.getExpiryDates(cardExpiry)
-      month
-    | CardExpiryYear =>
-      let (_, year) = CardUtils.getExpiryDates(cardExpiry)
-      year
-    | CryptoCurrencyNetworks => cryptoCurrencyNetworks
-    | DateOfBirth =>
-      switch dateOfBirth->Nullable.toOption {
-      | Some(x) => x->Date.toISOString->String.slice(~start=0, ~end=10)
-      | None => ""
-      }
-    | CardCvc => cvcNumber
-    | VpaId => vpaId.value
-    | PixCNPJ => pixCNPJ.value
-    | PixCPF => pixCPF.value
-    | PixKey => pixKey.value
-    | IBAN
-    | BankAccountNumber =>
-      bankAccountNumber.value
-    | SourceBankAccountId => sourceBankAccountId.value
-    | StateAndCity
-    | PhoneNumberAndCountryCode
-    | CountryAndPincode(_)
-    | SpecialField(_)
-    | InfoElement
-    | CardExpiryMonthAndYear
-    | CardExpiryAndCvc
-    | FullName
-    | ShippingName // Shipping Details are currently supported by only one click widgets
-    | ShippingAddressLine1
-    | ShippingAddressLine2
-    | ShippingAddressCity
-    | ShippingAddressPincode
-    | ShippingAddressState
-    | ShippingAddressCountry(_)
-    | BankList(_)
-    | None => ""
-    }
-  }
-
-  let addBillingDetailsIfUseBillingAddress = requiredFieldsBody => {
-    if billingAddress.isUseBillingAddress {
-      billingAddressFields->Array.reduce(requiredFieldsBody, (acc, item) => {
-        let value = item->getFieldValueFromFieldType
-        if item === BillingName {
-          let arr = value->String.split(" ")
-          acc->Dict.set(
-            "payment_method_data.billing.address.first_name",
-            arr->Array.get(0)->Option.getOr("")->JSON.Encode.string,
-          )
-          acc->Dict.set(
-            "payment_method_data.billing.address.last_name",
-            arr->Array.get(1)->Option.getOr("")->JSON.Encode.string,
-          )
-        } else {
-          let path = item->getBillingAddressPathFromFieldType
-          acc->Dict.set(path, value->JSON.Encode.string)
-        }
-        acc
-      })
-    } else {
-      requiredFieldsBody
-    }
-  }
-
-  React.useEffect(() => {
-    let requiredFieldsBody =
-      requiredFields
-      ->Array.filter(item => item.field_type !== None)
-      ->Array.reduce(Dict.make(), (acc, item) => {
-        let value = switch item.field_type {
-        | BillingName => getName(item, billingName)
-        | FullName => getName(item, fullName)
-        | _ => item.field_type->getFieldValueFromFieldType
-        }
-        if value != "" {
-          if (
-            isSavedCardFlow &&
-            (item.field_type === BillingName || item.field_type === FullName) &&
-            item.display_name === "card_holder_name" &&
-            item.required_field === "payment_method_data.card.card_holder_name"
-          ) {
-            if !isAllStoredCardsHaveName {
-              acc->Dict.set(
-                "payment_method_data.card_token.card_holder_name",
-                value->JSON.Encode.string,
-              )
-            }
-          } else {
-            acc->Dict.set(item.required_field, value->JSON.Encode.string)
-          }
-        }
-        acc
-      })
-      ->addBillingDetailsIfUseBillingAddress
-
-    setRequiredFieldsBody(_ => requiredFieldsBody)
-    None
-  }, (
-    fullName.value,
-    email.value,
-    vpaId.value,
-    line1.value,
-    line2.value,
-    pixCNPJ.value,
-    pixCPF.value,
-    pixKey.value,
-    documentType,
-    documentNumber.value,
-    city.value,
-    postalCode.value,
-    state.value,
-    blikCode.value,
-    phone.value,
-    phone.countryCode,
-    currency,
-    billingName.value,
-    giftCardPin.value,
-    giftCardNumber.value,
-    country,
-    cardNumber,
-    cardExpiry,
-    cvcNumber,
-    selectedBank,
-    cryptoCurrencyNetworks,
-    dateOfBirth,
-    bankAccountNumber,
-    sourceBankAccountId,
-  ))
-}
-
-let isFieldTypeToRenderOutsideBilling = (fieldType: PaymentMethodsRecord.paymentMethodsFields) => {
-  switch fieldType {
-  | FullName
-  | CardNumber
-  | GiftCardNumber
-  | CardExpiryMonth
-  | CardExpiryYear
-  | CardExpiryMonthAndYear
-  | CardCvc
-  | GiftCardPin
-  | CardExpiryAndCvc
-  | CryptoCurrencyNetworks
-  | PixKey
-  | PixCPF
-  | PixCNPJ
-  | DateOfBirth
-  | Currency(_)
-  | DocumentType(_)
-  | DocumentNumber
-  | VpaId
-  | IBAN
-  | SourceBankAccountId
-  | BankAccountNumber
-  | InfoElement => true
-  | _ => false
-  }
-}
-
-let combineStateAndCity = arr => {
-  open PaymentMethodsRecord
-  let hasStateAndCity = arr->Array.includes(AddressState) && arr->Array.includes(AddressCity)
-  if hasStateAndCity {
-    arr->Array.push(StateAndCity)->ignore
-    arr->Array.filter(item =>
-      switch item {
-      | AddressCity
-      | AddressState => false
-      | _ => true
-      }
-    )
-  } else {
-    arr
-  }
-}
-
-let combineCountryAndPostal = arr => {
-  open PaymentMethodsRecord
-  let hasCountryAndPostal =
-    arr
-    ->Array.filter(item =>
-      switch item {
-      | AddressCountry(_) => true
-      | AddressPincode => true
-      | _ => false
-      }
-    )
-    ->Array.length == 2
-
-  let options = arr->Array.reduce([], (acc, item) => {
-    acc->Array.concat(
-      switch item {
-      | AddressCountry(val) => val
-      | _ => []
-      },
-    )
-  })
-
-  if hasCountryAndPostal {
-    arr->Array.push(CountryAndPincode(options))->ignore
-    arr->Array.filter(item =>
-      switch item {
-      | AddressPincode
-      | AddressCountry(_) => false
-      | _ => true
-      }
-    )
-  } else {
-    arr
-  }
-}
-
-let combineCardExpiryMonthAndYear = arr => {
-  open PaymentMethodsRecord
-  let hasCardExpiryMonthAndYear =
-    arr->Array.includes(CardExpiryMonth) && arr->Array.includes(CardExpiryYear)
-  if hasCardExpiryMonthAndYear {
-    arr->Array.push(CardExpiryMonthAndYear)->ignore
-    arr->Array.filter(item =>
-      switch item {
-      | CardExpiryMonth
-      | CardExpiryYear => false
-      | _ => true
-      }
-    )
-  } else {
-    arr
-  }
-}
-
-let combineCardExpiryAndCvc = arr => {
-  open PaymentMethodsRecord
-  let hasCardExpiryAndCvc =
-    arr->Array.includes(CardExpiryMonthAndYear) && arr->Array.includes(CardCvc)
-  if hasCardExpiryAndCvc {
-    arr->Array.push(CardExpiryAndCvc)->ignore
-    arr->Array.filter(item =>
-      switch item {
-      | CardExpiryMonthAndYear
-      | CardCvc => false
-      | _ => true
-      }
-    )
-  } else {
-    arr
-  }
-}
-
-let combinePhoneNumberAndCountryCode = arr => {
-  open PaymentMethodsRecord
-  let hasPhoneNumberOrCountryCodeField =
-    arr->Array.includes(PhoneCountryCode) || arr->Array.includes(PhoneNumber)
-  if hasPhoneNumberOrCountryCodeField {
-    arr->Array.push(PhoneNumberAndCountryCode)->ignore
-    arr->Array.filter(item =>
-      switch item {
-      | PhoneCountryCode
-      | PhoneNumber => false
-      | _ => true
-      }
-    )
-  } else {
-    arr
-  }
-}
-
-let updateDynamicFields = (
-  arr: array<PaymentMethodsRecord.paymentMethodsFields>,
-  billingAddress,
-  isSaveDetailsWithClickToPay,
-  clickToPayConfig,
-) => {
-  arr
-  ->Utils.removeDuplicate
-  ->Array.filter(item => item !== None)
-  ->addBillingAddressIfUseBillingAddress(billingAddress)
-  ->addClickToPayFieldsIfSaveDetailsWithClickToPay(isSaveDetailsWithClickToPay, clickToPayConfig)
-  ->combineStateAndCity
-  ->combineCountryAndPostal
-  ->combineCardExpiryMonthAndYear
-  ->combineCardExpiryAndCvc
-  ->combinePhoneNumberAndCountryCode
-}
-
-let useSubmitCallback = () => {
-  let (line1, setLine1) = Recoil.useRecoilState(userAddressline1)
-  let (line2, setLine2) = Recoil.useRecoilState(userAddressline2)
-  let (state, setState) = Recoil.useRecoilState(userAddressState)
-  let (postalCode, setPostalCode) = Recoil.useRecoilState(userAddressPincode)
-  let (city, setCity) = Recoil.useRecoilState(userAddressCity)
-  let {billingAddress} = Recoil.useRecoilValueFromAtom(optionAtom)
-
-  let {localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-
-  React.useCallback((ev: Window.event) => {
-    let json = ev.data->Utils.safeParse
-    let confirm = json->Utils.getDictFromJson->ConfirmType.itemToObjMapper
-    if confirm.doSubmit {
-      if line1.value == "" {
-        setLine1(prev => {
-          ...prev,
-          errorString: localeString.line1EmptyText,
-        })
-      }
-      if line2.value == "" {
-        setLine2(prev => {
-          ...prev,
-          errorString: billingAddress.isUseBillingAddress ? "" : localeString.line2EmptyText,
-        })
-      }
-      if state.value == "" {
-        setState(prev => {
-          ...prev,
-          errorString: localeString.stateEmptyText,
-        })
-      }
-      if postalCode.value == "" {
-        setPostalCode(prev => {
-          ...prev,
-          errorString: localeString.postalCodeEmptyText,
-        })
-      }
-      if city.value == "" {
-        setCity(prev => {
-          ...prev,
-          errorString: localeString.cityEmptyText,
-        })
-      }
-    }
-  }, (line1, line2, state, city, postalCode))
-}
-
 let usePaymentMethodTypeFromList = (
   ~paymentMethodListValue,
   ~paymentMethod,
@@ -1008,26 +398,6 @@ let usePaymentMethodTypeFromList = (
       ),
     )->Option.getOr(PaymentMethodsRecord.defaultPaymentMethodType)
   }, (paymentMethodListValue, paymentMethod, paymentMethodType))
-}
-
-let removeRequiredFieldsDuplicates = (
-  requiredFields: array<PaymentMethodsRecord.required_fields>,
-) => {
-  let (_, requiredFields) = requiredFields->Array.reduce(([], []), (
-    (requiredFieldKeys, uniqueRequiredFields),
-    item,
-  ) => {
-    let requiredField = item.required_field
-
-    if requiredFieldKeys->Array.includes(requiredField)->not {
-      requiredFieldKeys->Array.push(requiredField)
-      uniqueRequiredFields->Array.push(item)
-    }
-
-    (requiredFieldKeys, uniqueRequiredFields)
-  })
-
-  requiredFields
 }
 
 let getNameFromString = (name, requiredFieldsArr) => {
@@ -1156,7 +526,6 @@ let getApplePayRequiredFields = (
     | ShippingAddressLine2 => shippingContact.addressLines->getAddressLine(1)
     | ShippingAddressCity => shippingContact.locality
     | ShippingAddressState => shippingContact.administrativeArea
-
     | ShippingAddressCountry(_) => shippingCountryCode
     | ShippingAddressPincode => shippingContact.postalCode
     | _ => ""

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -171,8 +171,7 @@ let lookupLocaleKey = (key: string, locale: LocaleStringTypes.localeStrings): op
     Some(locale.payment_methods_online_banking_czech_republic)
   | "payment_methods_online_banking_slovakia" =>
     Some(locale.payment_methods_online_banking_slovakia)
-  | "payment_methods_online_banking_finland" =>
-    Some(locale.payment_methods_online_banking_finland)
+  | "payment_methods_online_banking_finland" => Some(locale.payment_methods_online_banking_finland)
   | "payment_methods_online_banking_poland" => Some(locale.payment_methods_online_banking_poland)
   | "payment_methods_ideal" => Some(locale.payment_methods_ideal)
   | "payment_methods_ban_connect" => Some(locale.payment_methods_ban_connect)
@@ -263,11 +262,9 @@ let resolveValidator = (
   let requiredRule = field.isRequired ? [Validation.Required] : []
 
   let semanticRule = switch field.validationRuleType {
-  | Some("email") => [Validation.Email]
   | Some("phone") => [Validation.Phone]
   | Some("iban") => [Validation.IBAN]
   | Some("routing_number") => [Validation.RoutingNumber]
-  | Some("vpa_id") => [Validation.VpaId]
   | Some("blik_code") => [Validation.BlikCode]
   | Some("gift_card_number") => [Validation.GiftCardNumber]
   | Some("gift_card_pin") => [Validation.GiftCardPin]
@@ -345,10 +342,9 @@ let buildSuperpositionBaseContext = (
   | NONE => "non_mandate"
   }
 
-  let collectBilling =
-    paymentMethodListValue.collect_billing_details_from_wallets
-      ? "true"
-      : "false"
+  let collectBilling = paymentMethodListValue.collect_billing_details_from_wallets
+    ? "true"
+    : "false"
   let collectShipping = "false"
 
   let context: SuperpositionTypes.superpositionBaseContext = {

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -290,6 +290,10 @@ let resolveValidator = (
   )
 }
 
+let findCryptoCurrencyField = (~allFields: array<SuperpositionTypes.fieldConfig>): option<
+  SuperpositionTypes.fieldConfig,
+> => allFields->Array.find(f => f.fieldRenderType === SuperpositionTypes.CryptoCurrency)
+
 let extractValuesFromPMLRequiredFields = (
   requiredFields: array<PaymentMethodsRecord.required_fields>,
 ) => {
@@ -311,21 +315,6 @@ let removeBillingDetailsIfUseBillingAddress = (
     })
   } else {
     missingRequiredFields
-  }
-}
-
-let getEligibleConnectors = (
-  paymentMethodTypes: PaymentMethodsRecord.paymentMethodTypes,
-  paymentMethod: string,
-) => {
-  if paymentMethod === "card" {
-    paymentMethodTypes.card_networks->Array.flatMap(network =>
-      network.eligible_connectors->Array.map(item => item->JSON.Encode.string)
-    )
-  } else {
-    paymentMethodTypes.payment_experience->Array.flatMap(exp =>
-      exp.eligible_connectors->Array.map(item => item->JSON.Encode.string)
-    )
   }
 }
 

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -1,4 +1,5 @@
 let paymentMethodListValue = Recoil.atom("paymentMethodListValue", PaymentMethodsRecord.defaultList)
+let sdkConfigsValue = Recoil.atom("sdkConfigsValue", SdkConfigTypes.defaultSdkConfigValue)
 let paymentManagementListValue = Recoil.atom(
   "paymentManagementListValue",
   UnifiedHelpersV2.defaultPaymentsList,

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1761,17 +1761,19 @@ let checkIs18OrAbove = dateOfBirth => {
   dateOfBirth <= compareDate
 }
 
-let getFirstAndLastNameFromFullName = fullName => {
+let splitFullName = fullName => {
   let nameStrings = fullName->String.split(" ")
-  let firstName =
-    nameStrings
-    ->Array.get(0)
-    ->Option.flatMap(x => Some(x->JSON.Encode.string))
-    ->Option.getOr(JSON.Encode.null)
-  let lastNameStr = nameStrings->Array.sliceToEnd(~start=1)->Array.join(" ")->String.trim
+  let firstName = nameStrings->Array.get(0)->Option.getOr("")
+  let lastName = nameStrings->Array.sliceToEnd(~start=1)->Array.join(" ")->String.trim
+  (firstName, lastName)
+}
+
+let getFirstAndLastNameFromFullName = fullName => {
+  let (firstNameStr, lastNameStr) = fullName->splitFullName
+  let firstNameJson = firstNameStr->JSON.Encode.string
   let lastNameJson = lastNameStr === "" ? JSON.Encode.null : lastNameStr->JSON.Encode.string
 
-  (firstName, lastNameJson)
+  (firstNameJson, lastNameJson)
 }
 
 let isKeyPresentInDict = (dict, key) => dict->Dict.get(key)->Option.isSome

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -808,6 +808,24 @@ let getCountryCode = country => {
   ->Option.getOr(Country.defaultTimeZone)
 }
 
+// Reverse of getCountryCode: given an ISO Alpha-2 code returns the country display name.
+// Falls back to the code itself if not found.
+let getCountryNameFromCode = (isoCode: string): string => {
+  CountryStateDataRefs.countryDataRef.contents
+  ->Array.find(item => item.isoAlpha2 == isoCode)
+  ->Option.map(item => item.countryName)
+  ->Option.getOr(isoCode)
+}
+
+// Given an array of ISO Alpha-2 codes, returns display names for codes that exist
+// in countryDataRef. Codes with no match are excluded (e.g. "AC").
+let isoOptionsToCountryNames = (isoOptions: array<string>): array<string> =>
+  isoOptions->Array.filterMap(iso =>
+    CountryStateDataRefs.countryDataRef.contents
+    ->Array.find(item => item.isoAlpha2 === iso)
+    ->Option.map(item => item.countryName)
+  )
+
 let getStateNames = (country: RecoilAtomTypes.field) => {
   let options =
     CountryStateDataRefs.stateDataRef.contents
@@ -1664,6 +1682,23 @@ let getStateCodeFromStateName = (stateName: string, countryCode: string): string
 
   stateCode->Option.getOr(stateName)
 }
+
+let getStateNameFromCode = (stateCode: string, countryIso: string): string => {
+  let countryStates =
+    CountryStateDataRefs.stateDataRef.contents
+    ->getDictFromJson
+    ->getOptionalArrayFromDict(countryIso)
+
+  countryStates
+  ->Option.flatMap(states =>
+    states->Array.find(item => {
+      item->getDictFromJson->getString("code", "") === stateCode
+    })
+  )
+  ->Option.map(item => item->getDictFromJson->getString("value", ""))
+  ->Option.getOr(stateCode)
+}
+
 let removeHyphen = str => str->String.replaceRegExp(%re("/-/g"), "")
 
 let compareLogic = (a, b) => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- `DynamicFields.res` — Rewritten to use `useConfigurationService` → `getSuperpositionFinalFields`; RFF `<Form>` wraps all fields; billing split is path-based; card fields filtered at source to avoid double-render with CardPayment
- `DynamicFields/` — New per-field components: `CardHolderNameField`, `StateDropdownField`, `EmailField`, `CountryDropdownField`, `PhoneField`, etc.
- `DateOfBirth.res` — Refactored as RFF-wired DateField; this component was only getting used by `DynamicFields`
- `package.json` — Added `react-final-form`.
- `ReactFinalForm` owns all field state, validation, and initial values.

### Architectural Decisions
- No backward compatibility with the old `paymentMethodsFields` enum pipeline. `setRequiredFieldsBody` contract with all consumers is unchanged — they still receive `Dict.t<JSON.t>` keyed by API paths.
- RFF owns all field state, validation, and initial values. `useFormStateHandler` syncs `formProps.values` → `setRequiredFieldsBody` and `formProps.valid` → `areRequiredFieldsValid`.

### Why include RFF change in this PR?
- Using react-final-forms, the I/O based on `fieldConfigs` from superposition becomes very readable and easier to manage.
- Same change-radius.

### References
- [fieldConfig — key reference](https://docs.google.com/document/d/1RAQGhQLB391d8vXS3VzJ8BJOQLmeaV-0csDQnUM33vo/edit?usp=sharing) : This doc details about different fieldConfig keys.
- [Superposition HLD](https://docs.google.com/document/d/1js2JHCPXm6LHhpd_Hyt6pM81pSY7IVHbMsvVOnLuKdM/edit?tab=t.drlrmr5q5sl)

### Base PRs
- **[Shared code]** https://github.com/juspay/hyperswitch-sdk-utils/pull/57
- **[sdk configs api integration]** https://github.com/juspay/hyperswitch-web/pull/1577

### Stacked PRs
- Validation fixes and locales for error texts: https://github.com/juspay/hyperswitch-web/pull/1609.
- **[Shared code]** https://github.com/juspay/hyperswitch-sdk-utils/pull/59
- Intent Data collection from sdk-configs api: https://github.com/juspay/hyperswitch-web/pull/1602

## How did you test it?

### SCREEN RECORDING
https://github.com/user-attachments/assets/a6af807c-1cca-47e8-aad3-45ec137b3a28

### TESTING MATRIX
- Klarna - works
- Card - works
- AliPay - works
- Classic (cash2code) - works
- Evoucher - works
- Duit now (QR flow) - works
- Sepa debit - works
- Affirm - sandbox itself seems to be broken, superposition fix needed
- Eps - superposition fix needed
- Sepa bank transfer - works, but superposition changes needed
- Mifinity - Superposition changes required, works
- Online Banking FPX - Superposition changes required Bank selection]

## Issue
Fixes #1518 


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
