### PR TITLE
feat: add WCAG 2.2 AA form input & error-message accessibility

### DIFF
--- a/src/Components/DropdownField.res
+++ b/src/Components/DropdownField.res
@@ -33,6 +33,7 @@ let make = (
   ~disabled=false,
   ~className="",
   ~width="w-full",
+  ~isRequired=true,
 ) => {
   let {themeObj, localeString, config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {readOnly} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -142,7 +143,8 @@ let make = (
           onChange=handleChange
           onFocus=handleFocus
           className={`${inputClassStyles} ${className} w-full appearance-none outline-none overflow-hidden whitespace-nowrap text-ellipsis ${cursorClass}`}
-          ariaLabel={`${fieldName} option tab`}>
+          ariaLabel={`${fieldName} option tab`}
+          ariaRequired=?{isRequired ? Some(true) : None}>
           {options
           ->Array.mapWithIndex((item, index) => {
             <option key={Int.toString(index)} value=item.value>

--- a/src/Components/DynamicFields/BankNamesSelectField.res
+++ b/src/Components/DynamicFields/BankNamesSelectField.res
@@ -21,5 +21,6 @@ let make = (~fieldConfig: fieldConfig, ~options: array<DropdownField.optionType>
     setValue={fn => field.input.onChange(fn(value))}
     disabled=false
     options
+    isRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -77,6 +77,7 @@ module FullNameFieldInput = {
       errorString
       placeholder
       inputRef
+      isRequired={firstNameFieldConfig.isRequired || lastNameFieldConfig.isRequired}
       ?autocomplete
     />
   }

--- a/src/Components/DynamicFields/CountryDropdownField.res
+++ b/src/Components/DynamicFields/CountryDropdownField.res
@@ -40,5 +40,6 @@ let make = (~fieldConfig: fieldConfig, ~options: array<DropdownField.optionType>
     }}
     disabled=false
     options
+    isRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/DynamicFields/EmailField.res
+++ b/src/Components/DynamicFields/EmailField.res
@@ -41,6 +41,7 @@ module EmailInput = {
       errorString
       placeholder
       inputRef={fieldRef}
+      isRequired={primaryFieldConfig.isRequired}
       autocomplete
     />
   }

--- a/src/Components/DynamicFields/GenericDropdownField.res
+++ b/src/Components/DynamicFields/GenericDropdownField.res
@@ -20,5 +20,6 @@ let make = (~fieldConfig: fieldConfig, ~options: array<DropdownField.optionType>
     setValue={fn => field.input.onChange(fn(value))}
     disabled=false
     options
+    isRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/DynamicFields/GenericInputField.res
+++ b/src/Components/DynamicFields/GenericInputField.res
@@ -30,6 +30,7 @@ let make = (~fieldConfig: fieldConfig) => {
     errorString
     placeholder
     inputRef={fieldRef}
+    isRequired={fieldConfig.isRequired}
     ?autocomplete
     maxLength=?{fieldConfig.maxInputLength}
   />

--- a/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
+++ b/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
@@ -82,5 +82,6 @@ let make = (~fieldConfig: fieldConfig) => {
     displayValue
     setDisplayValue
     isDisplayValueVisible=true
+    isRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/DynamicFields/PhoneField.res
+++ b/src/Components/DynamicFields/PhoneField.res
@@ -39,6 +39,7 @@ let make = (~fieldConfig: fieldConfig) => {
     errorString
     placeholder
     inputRef={fieldRef}
+    isRequired={fieldConfig.isRequired}
     autocomplete
     ?maxLength
   />

--- a/src/Components/DynamicFields/StateDropdownField.res
+++ b/src/Components/DynamicFields/StateDropdownField.res
@@ -47,6 +47,7 @@ let make = (~fieldConfig: fieldConfig) => {
       }}
       disabled=false
       options={stateOptions}
+      isRequired={fieldConfig.isRequired}
     />
   </RenderIf>
 }

--- a/src/Components/ErrorComponent.res
+++ b/src/Components/ErrorComponent.res
@@ -23,13 +23,15 @@ let make = (~errorStr=None, ~cardError="", ~expiryError="", ~cvcError="") => {
   switch innerLayout {
   | Spaced =>
     <RenderIf condition=isSpacedErrorShown>
-      <div className="Error pt-1" style=errorTextStyle>
+      <div role="alert" className="Error pt-1" style=errorTextStyle>
         {React.string(errorStr->Belt.Option.getWithDefault(""))}
       </div>
     </RenderIf>
   | Compressed =>
     <RenderIf condition=isCompressedErrorShown>
-      <div className="Error pt-1" style=errorTextStyle> {React.string("Invalid input")} </div>
+      <div role="alert" className="Error pt-1" style=errorTextStyle>
+        {React.string("Invalid input")}
+      </div>
     </RenderIf>
   }
 }

--- a/src/Components/Input.res
+++ b/src/Components/Input.res
@@ -18,6 +18,7 @@ let make = (
   ~placeholder="",
   ~className="",
   ~inputRef,
+  ~isRequired=true,
 ) => {
   let options = Recoil.useRecoilValueFromAtom(elementOptions)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
@@ -58,13 +59,18 @@ let make = (
     ""
   }
 
+  let {inputId, errorId, hasError} = AccessibilityHooks.useFieldAccessibility(
+    ~id,
+    ~errorString=errorString->Option.getOr(""),
+  )
+
   <div className={` flex flex-col w-full`} style={color: themeObj.colorText}>
     <RenderIf condition={fieldName->String.length > 0}>
       <div> {React.string(fieldName)} </div>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <input
-        id
+        id={inputId}
         style={
           background: themeObj.colorBackground,
           padding: themeObj.spacingUnit,
@@ -83,6 +89,9 @@ let make = (
         onBlur=handleBlur
         onFocus=handleFocus
         ariaLabel={`Type to fill ${fieldName} input`}
+        ariaInvalid={hasError ? #"true" : #"false"}
+        ariaDescribedby=?{hasError ? Some(errorId) : None}
+        ariaRequired=?{isRequired ? Some(true) : None}
       />
       <div className={`flex -ml-10  items-center`}> {rightIcon} </div>
     </div>
@@ -90,6 +99,8 @@ let make = (
     | Some(val) =>
       <RenderIf condition={val->String.length > 0}>
         <div
+          id={errorId}
+          role="alert"
           className="py-1 text-xs text-red-600 transition-colors transition-border ease-out duration-200">
           {React.string(val)}
         </div>

--- a/src/Components/InputField.res
+++ b/src/Components/InputField.res
@@ -25,6 +25,7 @@ let make = (
   ~labelClassName="",
   ~paymentType: option<CardThemeType.mode>=?,
   ~autocomplete="on",
+  ~isRequired=true,
 ) => {
   open ElementType
   let (eleClassName, setEleClassName) = React.useState(_ => "input-base")
@@ -122,13 +123,18 @@ let make = (
     None
   }, (isValid, setIsValid, value, onChange, onBlur))
 
+  let {inputId, errorId, hasError} = AccessibilityHooks.useFieldAccessibility(
+    ~id,
+    ~errorString=errorString->Option.getOr(""),
+  )
+
   <div className={` flex flex-col w-full`}>
     <RenderIf condition={fieldName->String.length > 0}>
       <div className={`${labelClassName}`}> {React.string(fieldName)} </div>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <input
-        id
+        id={inputId}
         style={
           background: "transparent",
           width: "-webkit-fill-available",
@@ -148,6 +154,9 @@ let make = (
         onFocus=handleFocus
         autoComplete={autocomplete}
         ariaLabel={`Type to fill ${fieldName} input`}
+        ariaInvalid={hasError ? #"true" : #"false"}
+        ariaDescribedby=?{hasError ? Some(errorId) : None}
+        ariaRequired=?{isRequired ? Some(true) : None}
       />
       <div className={`flex -ml-10  items-center`}> {rightIcon} </div>
     </div>
@@ -156,7 +165,9 @@ let make = (
       switch errorString {
       | Some(val) =>
         <RenderIf condition={val->String.length > 0}>
-          <div className={`py-1 ${errorClases}`}> {React.string(val)} </div>
+          <div id={errorId} role="alert" className={`py-1 ${errorClases}`}>
+            {React.string(val)}
+          </div>
         </RenderIf>
       | None => React.null
       }

--- a/src/Components/NicknamePaymentInput.res
+++ b/src/Components/NicknamePaymentInput.res
@@ -27,5 +27,6 @@ let make = () => {
     inputRef={React.useRef(Nullable.null)}
     placeholder=localeString.nicknamePlaceholder
     maxLength=12
+    isRequired=false
   />
 }

--- a/src/Components/PaymentDropDownField.res
+++ b/src/Components/PaymentDropDownField.res
@@ -7,6 +7,7 @@ let make = (
   ~options,
   ~disabled=false,
   ~className="",
+  ~isRequired=true,
 ) => {
   let {config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
@@ -71,6 +72,11 @@ let make = (
     themeObj.colorBackground
   }, [themeObj])
   let cursorClass = !disabled ? "cursor-pointer" : "cursor-not-allowed"
+
+  let {inputId, errorId, hasError} = AccessibilityHooks.useFieldAccessibility(
+    ~errorString=value.errorString,
+  )
+
   <RenderIf condition={options->Array.length > 0}>
     <div className="flex flex-col w-full" style={color: themeObj.colorText}>
       <RenderIf
@@ -104,7 +110,11 @@ let make = (
           onFocus={handleFocus}
           onChange=handleChange
           className={`${inputClassStyles} ${inputClass} ${className} w-full appearance-none outline-none overflow-hidden whitespace-nowrap text-ellipsis ${cursorClass}`}
-          ariaLabel={`${fieldName} option tab`}>
+          ariaLabel={`${fieldName} option tab`}
+          id={inputId}
+          ariaInvalid={hasError ? #"true" : #"false"}
+          ariaDescribedby=?{hasError ? Some(errorId) : None}
+          ariaRequired=?{isRequired ? Some(true) : None}>
           {options
           ->Array.mapWithIndex((item: string, i) => {
             <option key={Int.toString(i)} value=item> {React.string(item)} </option>
@@ -140,6 +150,8 @@ let make = (
         </div>
         <RenderIf condition={value.errorString->String.length > 0}>
           <div
+            id={errorId}
+            role="alert"
             className="Error pt-1"
             style={
               color: themeObj.colorDangerText,

--- a/src/Components/PaymentField.res
+++ b/src/Components/PaymentField.res
@@ -24,6 +24,7 @@ let make = (
   ~inputRef,
   ~displayValue=?,
   ~setDisplayValue=?,
+  ~isRequired=true,
 ) => {
   let {config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
@@ -104,6 +105,10 @@ let make = (
     onChange(ev)
   }
 
+  let {inputId, errorId, hasError} = AccessibilityHooks.useFieldAccessibility(
+    ~errorString=value.errorString,
+  )
+
   <div className="flex flex-col w-full">
     <RenderIf
       condition={name === "phone" &&
@@ -177,6 +182,10 @@ let make = (
             onBlur=handleBlur
             onFocus=handleFocus
             ariaLabel={`Type to fill ${fieldName->String.length > 0 ? fieldName : name} input`}
+            id={inputId}
+            ariaInvalid={hasError ? #"true" : #"false"}
+            ariaDescribedby=?{hasError ? Some(errorId) : None}
+            ariaRequired=?{isRequired ? Some(true) : None}
           />
           <RenderIf condition={config.appearance.labels == Floating}>
             <div
@@ -201,14 +210,15 @@ let make = (
       </div>
       <RenderIf condition={value.errorString->String.length > 0}>
         <div
+          id={errorId}
+          role="alert"
           className="Error pt-1"
           style={
             color: themeObj.colorDangerText,
             fontSize: themeObj.fontSizeSm,
             alignSelf: "start",
             textAlign: "left",
-          }
-          ariaHidden=true>
+          }>
           {React.string(value.errorString)}
         </div>
       </RenderIf>

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -25,6 +25,7 @@ let make = (
   ~paymentType=?,
   ~isDisabled=false,
   ~autocomplete="on",
+  ~isRequired=true,
 ) => {
   let {themeObj, config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {innerLayout} = config.appearance
@@ -90,6 +91,10 @@ let make = (
   let inputLogoClass = getClassName("InputLogo")
   let inputClassStyles = innerLayout === Spaced ? "Input" : "Input-Compressed"
 
+  let {inputId, errorId, hasError} = AccessibilityHooks.useFieldAccessibility(
+    ~errorString=errorString->Option.getOr(""),
+  )
+
   <div className="flex flex-col w-full" style={color: themeObj.colorText}>
     <RenderIf
       condition={fieldName->String.length > 0 &&
@@ -131,6 +136,10 @@ let make = (
           onBlur=handleBlur
           onFocus=handleFocus
           ariaLabel={`Type to fill ${fieldName->String.length > 0 ? fieldName : name} input`}
+          id={inputId}
+          ariaInvalid={hasError ? #"true" : #"false"}
+          ariaDescribedby=?{hasError ? Some(errorId) : None}
+          ariaRequired=?{isRequired ? Some(true) : None}
         />
         <RenderIf condition={config.appearance.labels == Floating}>
           <div
@@ -156,6 +165,8 @@ let make = (
       | Some(val) =>
         <RenderIf condition={val->String.length > 0}>
           <div
+            id={errorId}
+            role="alert"
             className="Error pt-1"
             style={
               color: themeObj.colorDangerText,

--- a/src/Hooks/AccessibilityHooks.res
+++ b/src/Hooks/AccessibilityHooks.res
@@ -1,0 +1,14 @@
+type fieldAccessibility = {
+  inputId: string,
+  errorId: string,
+  hasError: bool,
+}
+
+let useFieldAccessibility = (~id="", ~errorString="") => {
+  let reactId = React.useId()
+  {
+    inputId: id->String.length > 0 ? id : `input${reactId}`,
+    errorId: `error${reactId}`,
+    hasError: errorString->String.length > 0,
+  }
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

> Includes one bug fix (a screen-reader-hidden error message) folded into the enhancement — see Description.

## Description

<!-- Describe your changes in detail -->

**Form Input & Error-Message Accessibility (PR 1 of a phased WCAG 2.2 AA plan).**

This PR wires ARIA semantics into every form field the SDK renders, so screen readers announce field state, requiredness, and validation errors. It is the foundational slice of the accessibility roadmap in [`docs/ACCESSIBILITY_PLAN.md`](./ACCESSIBILITY_PLAN.md) and supersedes the stale PR #1384 (a lot has changed since — superposition dynamic fields landed; the disposition of every #1384 change is tracked in the plan).

### What changed

**Shared helper (new):** `src/Hooks/AccessibilityHooks.res` — `useFieldAccessibility` generates a collision-free input/error `id` pair via `React.useId()` and reports whether an error is present. Kept as a dedicated zero-dependency module to avoid a build cycle (a `UtilityHooks`-level home pulls in `PaymentMethodsRecord`).

**ARIA wiring on all reusable field components** (`Input`, `InputField`, `PaymentField`, `PaymentInputField`, `DropdownField`, `PaymentDropDownField`):

| Attribute | Behavior |
|---|---|
| `id` | Unique per input + error, from `React.useId()` (valid token, no collisions). |
| `aria-invalid` | `"true"` when an error string is shown, else `"false"`. |
| `aria-describedby` | Points the input at its error `id`, set only when an error is present (native SDK iframe). |
| `aria-required` | `"true"` when the field is required (see requiredness rules below). |
| `role="alert"` | On every error `<div>` (incl. `PaymentDropDownField`'s, which previously had **no** error markup), so errors are announced on insertion. |

**Bug fix:** removed `ariaHidden=true` from the `PaymentField` error message — it was hiding the validation error from screen readers entirely. `ErrorComponent` (card-level aggregate error) also gains `role="alert"`.

**Requiredness (`aria-required`):**
- **Superposition fields** pass `isRequired` explicitly from `fieldConfig.isRequired` at every render site — `GenericInputField`, `EmailField`, `PhoneField`, `CardHolderNameField`, `GenericDropdownField`, `CountryDropdownField`, `StateDropdownField`, `BankNamesSelectField`, `PhoneCountryCodeDropdownField`.
- **Non-superposition fields** default to required (the `~isRequired` default on the base components is `true`), so all hardcoded payment/bank/card fields are announced as required. The single exception is the **card nickname** field (`NicknamePaymentInput`), which passes `isRequired=false`.

### Scope & safety notes
- **No visual/CSS change.** These are attribute-only additions (`aria-*`, `role`, `id`); no `className`, inline style, or DOM structure changed. Styling is class-based and the classes are untouched. The only attribute selectors in the codebase target VGS divs (`[id*="vgs-cc-"]`), which these `React.useId()` ids do not match.
- **`aria-required` is the screen-reader signal only** — it does not add the HTML5 `required` attribute and does not change validation/submit behavior.
- **VGS card fields** (third-party iframes) are intentionally untouched; `aria-describedby` cannot cross that iframe boundary. The components here are the SDK's own native-iframe inputs.
- Out-of-scope items recovered from PR #1384 (`<label htmlFor>`, specific `autocomplete` tokens, `inputMode`/`type` changes) are deferred to later PRs and documented in the plan — they are intentionally **not** in this PR to keep it conflict-free.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible <!-- no React unit harness in this repo; verified via compiled-DOM inspection + recommended axe-core/Cypress runtime scan -->
