### PR TITLE
fix: validation error chaining in superposition

### DIFF
--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -85,7 +85,7 @@ let resolveValidator = (
 
   let maxLengthRule = [Validation.MaxLength(field.maxInputLength->Option.getOr(255))]
 
-  let rules = [...requiredRule, ...semanticRule, ...maxLengthRule]
+  let rules = [...semanticRule, ...requiredRule, ...maxLengthRule]
 
   Validation.createFieldValidator(
     rules,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Validation error propagation in `DynamicFields` via `createFieldValidator` function in sdk-utils.
- `semanticRule` already guards against empty values, hence we can keep it upfront.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- CardHolderName field error is fixed.

| Before                                                                                                                              | After                                                                                                                               |
|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1057" height="777" alt="image" src="https://github.com/user-attachments/assets/6b38ad6f-8a1b-43ce-b84a-3fd44c5c5296" /> | <img width="1065" height="777" alt="image" src="https://github.com/user-attachments/assets/859837e0-71df-43d6-a8f3-16515e4cfd3f" /> |

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible


## Issue
- https://github.com/juspay/hyperswitch-web/issues/1630