### PR TITLE
feat: add subscription events

### DIFF
--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -4,7 +4,6 @@ open Utils
 @react.component
 let make = (~cvcProps: CardUtils.cvcProps, ~paymentType: CardThemeType.mode) => {
   let {config, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-  let {emitCvcInfo} = SubscriptionEventHooks.useLegacyEvents()
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
   let {innerLayout} = config.appearance
   let keys = Recoil.useRecoilValueFromAtom(keys)
@@ -145,7 +144,12 @@ let make = (~cvcProps: CardUtils.cvcProps, ~paymentType: CardThemeType.mode) => 
   }, (keys.iframeId, paymentType))
 
   React.useEffect(() => {
-    emitCvcInfo(~isCvcEmpty)
+    let cvcInfoDict = [("isCvcEmpty", isCvcEmpty->JSON.Encode.bool)]->Dict.fromArray
+    Utils.messageParentWindow([("cvcInfo", cvcInfoDict->JSON.Encode.object)])
+    None
+  }, [isCvcEmpty])
+
+  React.useEffect(() => {
     emitter.emitCvcStatus(~iframeId=keys.iframeId, ~isCvcEmpty, ~isCvcComplete)
     None
   }, (isCvcEmpty, isCvcComplete, keys.iframeId))

--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -4,6 +4,8 @@ open Utils
 @react.component
 let make = (~cvcProps: CardUtils.cvcProps, ~paymentType: CardThemeType.mode) => {
   let {config, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
+  let {emitCvcInfo} = SubscriptionEventHooks.useLegacyEvents()
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
   let {innerLayout} = config.appearance
   let keys = Recoil.useRecoilValueFromAtom(keys)
   let customPodUri = Recoil.useRecoilValueFromAtom(customPodUri)
@@ -21,6 +23,7 @@ let make = (~cvcProps: CardUtils.cvcProps, ~paymentType: CardThemeType.mode) => 
     setCvcError,
   } = cvcProps
   let isCvcEmpty = cvcNumber === ""
+  let isCvcComplete = cvcNumber->String.length >= 3
   let compressedLayoutStyleForCvcError =
     innerLayout === Compressed && cvcError->String.length > 0 ? "!border-l-0" : ""
 
@@ -134,18 +137,18 @@ let make = (~cvcProps: CardUtils.cvcProps, ~paymentType: CardThemeType.mode) => 
   }, (cvcNumber, keys, paymentType, loggerState, customPodUri, redirectionFlags, localeString))
 
   React.useEffect0(() => {
-    messageParentWindow([
-      ("ready", true->JSON.Encode.bool),
-      ("elementType", CardThemeType.getPaymentModeToString(paymentType)->JSON.Encode.string),
-    ])
+    SubscriptionEventHooks.emitReady(
+      ~iframeId=keys.iframeId,
+      ~elementType=CardThemeType.getPaymentModeToString(paymentType),
+    )
     None
   })
 
   React.useEffect(() => {
-    let cvcInfoDict = [("isCvcEmpty", isCvcEmpty->JSON.Encode.bool)]->Dict.fromArray
-    Utils.messageParentWindow([("cvcInfo", cvcInfoDict->JSON.Encode.object)])
+    emitCvcInfo(~isCvcEmpty)
+    emitter.emitCvcStatus(~iframeId=keys.iframeId, ~isCvcEmpty, ~isCvcComplete)
     None
-  }, [isCvcEmpty])
+  }, (isCvcEmpty, isCvcComplete, keys.iframeId))
 
   <PaymentInputField
     fieldName=localeString.cvcTextLabel

--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -136,13 +136,13 @@ let make = (~cvcProps: CardUtils.cvcProps, ~paymentType: CardThemeType.mode) => 
     )
   }, (cvcNumber, keys, paymentType, loggerState, customPodUri, redirectionFlags, localeString))
 
-  React.useEffect0(() => {
+  React.useEffect(() => {
     SubscriptionEventHooks.emitReady(
       ~iframeId=keys.iframeId,
       ~elementType=CardThemeType.getPaymentModeToString(paymentType),
     )
     None
-  })
+  }, (keys.iframeId, paymentType))
 
   React.useEffect(() => {
     emitCvcInfo(~isCvcEmpty)

--- a/src/Components/AccordionContainer.res
+++ b/src/Components/AccordionContainer.res
@@ -86,13 +86,13 @@ let make = (
     ~cvcProps,
     ~isLegacy,
   )
-  SubscriptionEventHooks.usePaymentMethodStatus(
+  SubscriptionEventHooks.useEmitPaymentMethodStatus(
     ~paymentMethodName=selectedOption,
     ~paymentMethods=paymentMethodListValue.payment_methods,
     ~isSavedPaymentMethod=false,
     ~isOneClickWallet=false,
   )
-  SubscriptionEventHooks.useBillingAddress()
+  SubscriptionEventHooks.useEmitBillingAddress()
 
   let cardOptionDetails =
     paymentOptions

--- a/src/Components/AccordionContainer.res
+++ b/src/Components/AccordionContainer.res
@@ -71,6 +71,7 @@ let make = (
   let (showMore, setShowMore) = React.useState(_ => false)
   let (selectedOption, setSelectedOption) = Recoil.useRecoilState(selectedOptionAtom)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
+  let {isLegacy} = SubscriptionEventHooks.useLegacyEvents()
   let {
     displayInSeparateScreen,
     groupByPaymentMethods,
@@ -83,7 +84,15 @@ let make = (
     ~cardProps,
     ~expiryProps,
     ~cvcProps,
+    ~isLegacy,
   )
+  SubscriptionEventHooks.usePaymentMethodStatus(
+    ~paymentMethodName=selectedOption,
+    ~paymentMethods=paymentMethodListValue.payment_methods,
+    ~isSavedPaymentMethod=false,
+    ~isOneClickWallet=false,
+  )
+  SubscriptionEventHooks.useBillingAddress()
 
   let cardOptionDetails =
     paymentOptions

--- a/src/Components/AccordionContainer.res
+++ b/src/Components/AccordionContainer.res
@@ -71,7 +71,6 @@ let make = (
   let (showMore, setShowMore) = React.useState(_ => false)
   let (selectedOption, setSelectedOption) = Recoil.useRecoilState(selectedOptionAtom)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
-  let {isLegacy} = SubscriptionEventHooks.useLegacyEvents()
   let {
     displayInSeparateScreen,
     groupByPaymentMethods,
@@ -84,7 +83,6 @@ let make = (
     ~cardProps,
     ~expiryProps,
     ~cvcProps,
-    ~isLegacy,
   )
   SubscriptionEventHooks.useEmitPaymentMethodStatus(
     ~paymentMethodName=selectedOption,

--- a/src/Components/DropdownField.res
+++ b/src/Components/DropdownField.res
@@ -39,12 +39,13 @@ let make = (
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let dropdownRef = React.useRef(Nullable.null)
   let (inputFocused, setInputFocused) = React.useState(_ => false)
-  let {parentURL} = Recoil.useRecoilValueFromAtom(keys)
+  let {parentURL, iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let isSpacedInnerLayout = config.appearance.innerLayout === Spaced
+  let elementType = PaymentTypeContext.usePaymentType()->CardThemeType.getPaymentModeToString
 
   let handleFocus = _ => {
     setInputFocused(_ => true)
-    Utils.handleOnFocusPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnFocusPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
 
   let handleChange = ev => {

--- a/src/Components/Input.res
+++ b/src/Components/Input.res
@@ -22,7 +22,8 @@ let make = (
   let options = Recoil.useRecoilValueFromAtom(elementOptions)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let (_inputFocused, setInputFocused) = React.useState(_ => false)
-  let {parentURL} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let {parentURL, iframeId} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let elementType = PaymentTypeContext.usePaymentType()->CardThemeType.getPaymentModeToString
 
   let setFocus = (val: bool) => {
     switch onFocus {
@@ -41,7 +42,7 @@ let make = (
     setFocus(true)
     setValid(None)
     setInputFocused(_ => true)
-    Utils.handleOnFocusPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnFocusPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
 
   let handleBlur = ev => {

--- a/src/Components/InputField.res
+++ b/src/Components/InputField.res
@@ -32,6 +32,7 @@ let make = (
   let options = Recoil.useRecoilValueFromAtom(elementOptions)
   let contextPaymentType = usePaymentType()
   let paymentType = paymentType->Option.getOr(contextPaymentType)
+  let elementType = contextPaymentType->CardThemeType.getPaymentModeToString
 
   let setFocus = (val: bool) => {
     switch onFocus {
@@ -69,7 +70,7 @@ let make = (
     }
     setFocus(true)
     setIsValid(_ => None)
-    Utils.handleOnFocusPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnFocusPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
 
   let handleBlur = ev => {
@@ -80,7 +81,7 @@ let make = (
     }
     setFocus(false)
     onBlur(ev)
-    Utils.handleOnBlurPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnBlurPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
   React.useEffect(() => {
     if value->String.length > 0 {

--- a/src/Components/LoaderPaymentShimmer.res
+++ b/src/Components/LoaderPaymentShimmer.res
@@ -4,6 +4,7 @@ let make = () => {
   let selectedOption = Recoil.useRecoilValueFromAtom(selectedOptionAtom)
   let {redirectionInfo} = Recoil.useRecoilValueFromAtom(optionAtom)
   UtilityHooks.useHandlePostMessages(~complete=false, ~empty=false, ~paymentType=selectedOption)
+  SubscriptionEventHooks.useFormStatus(~empty=false, ~complete=false)
   <RenderIf condition={redirectionInfo === PaymentType.ShowRedirectionInfo}>
     <PaymentShimmer />
   </RenderIf>

--- a/src/Components/LoaderPaymentShimmer.res
+++ b/src/Components/LoaderPaymentShimmer.res
@@ -4,7 +4,7 @@ let make = () => {
   let selectedOption = Recoil.useRecoilValueFromAtom(selectedOptionAtom)
   let {redirectionInfo} = Recoil.useRecoilValueFromAtom(optionAtom)
   UtilityHooks.useHandlePostMessages(~complete=false, ~empty=false, ~paymentType=selectedOption)
-  SubscriptionEventHooks.useFormStatus(~empty=false, ~complete=false)
+  SubscriptionEventHooks.useEmitFormStatus(~empty=false, ~complete=false)
   <RenderIf condition={redirectionInfo === PaymentType.ShowRedirectionInfo}>
     <PaymentShimmer />
   </RenderIf>

--- a/src/Components/PaymentDropDownField.res
+++ b/src/Components/PaymentDropDownField.res
@@ -14,8 +14,9 @@ let make = (
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let dropdownRef = React.useRef(Nullable.null)
   let (inputFocused, setInputFocused) = React.useState(_ => false)
-  let {parentURL} = Recoil.useRecoilValueFromAtom(keys)
+  let {parentURL, iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let isSpacedInnerLayout = config.appearance.innerLayout === Spaced
+  let elementType = PaymentTypeContext.usePaymentType()->CardThemeType.getPaymentModeToString
 
   let getClassName = initialLabel => {
     if value.value->String.length == 0 {
@@ -40,7 +41,7 @@ let make = (
   }, [options])
   let handleFocus = _ => {
     setInputFocused(_ => true)
-    Utils.handleOnFocusPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnFocusPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
   let focusClass = if inputFocused || value.value->String.length > 0 {
     `mb-7 pb-1 pt-2 ${themeObj.fontSizeXs} transition-all ease-in duration-75`

--- a/src/Components/PaymentField.res
+++ b/src/Components/PaymentField.res
@@ -28,11 +28,12 @@ let make = (
   let {config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let {readOnly} = Recoil.useRecoilValueFromAtom(optionAtom)
-  let {parentURL} = Recoil.useRecoilValueFromAtom(keys)
+  let {parentURL, iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let isSpacedInnerLayout = config.appearance.innerLayout === Spaced
   let contextPaymentType = usePaymentType()
   let paymentType = paymentType->Option.getOr(contextPaymentType)
+  let elementType = contextPaymentType->CardThemeType.getPaymentModeToString
 
   let (inputFocused, setInputFocused) = React.useState(_ => false)
 
@@ -47,7 +48,7 @@ let make = (
       })
     | None => ()
     }
-    Utils.handleOnFocusPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnFocusPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
 
   let handleBlur = ev => {
@@ -57,7 +58,7 @@ let make = (
     | Some(fn) => fn(ev)
     | None => ()
     }
-    Utils.handleOnBlurPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnBlurPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
 
   let backgroundClass = switch paymentType {

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -29,9 +29,10 @@ let make = (
   let {themeObj, config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {innerLayout} = config.appearance
   let {readOnly} = Recoil.useRecoilValueFromAtom(optionAtom)
-  let {parentURL} = Recoil.useRecoilValueFromAtom(keys)
+  let {parentURL, iframeId} = Recoil.useRecoilValueFromAtom(keys)
   let contextPaymentType = usePaymentType()
   let paymentType = paymentType->Option.getOr(contextPaymentType)
+  let elementType = contextPaymentType->CardThemeType.getPaymentModeToString
 
   let (inputFocused, setInputFocused) = React.useState(_ => false)
 
@@ -45,7 +46,8 @@ let make = (
     | Some(fn) => fn(ev)
     | None => ()
     }
-    Utils.handleOnFocusPostMessage(~targetOrigin=parentURL)
+
+    Utils.handleOnFocusPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
 
   let handleBlur = ev => {
@@ -55,7 +57,7 @@ let make = (
     | Some(fn) => fn(ev)
     | None => ()
     }
-    Utils.handleOnBlurPostMessage(~targetOrigin=parentURL)
+    Utils.handleOnBlurPostMessage(~iframeId, ~elementType, ~targetOrigin=parentURL)
   }
 
   let backgroundClass = switch paymentType {

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -171,7 +171,6 @@ let make = (
 
   React.useEffect(() => {
     // TODO - Handle Events for VGS/Vault case
-    CardUtils.emitIsFormReadyForSubmission(isCVCValid->Option.getOr(false))
     emitIsFormReadyForSubmission(isCVCValid->Option.getOr(false))
     None
   }, [isCVCValid])

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -109,6 +109,13 @@ let make = (
   | None => "debit"
   }
   let {country, state, pinCode} = PaymentUtils.useNonPiiAddressData()
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {
+    emitIsFormReadyForSubmission,
+    emitExpiryDate,
+    isLegacy,
+    emitPaymentMethodInfo,
+  } = SubscriptionEventHooks.useLegacyEvents()
 
   React.useEffect(() => {
     setSelectedInstallmentPlan(_ => None)
@@ -116,35 +123,48 @@ let make = (
     None
   }, [paymentItem])
 
+  let isOneClickWallet = paymentItem.paymentMethod === "wallet"
+
   React.useEffect(() => {
     if isActive {
-      PaymentUtils.emitPaymentMethodInfo(
+      if isLegacy {
+        emitPaymentMethodInfo(
+          ~paymentMethod=paymentItem.paymentMethod,
+          ~paymentMethodType,
+          ~cardBrand=paymentItem.card.scheme->Option.getOr("")->CardUtils.getCardType,
+          ~country,
+          ~state,
+          ~pinCode,
+          ~cardExpiryMonth=expiryMonth,
+          ~cardExpiryYear=expiryYear,
+          ~cardLast4,
+          ~cardBin,
+          ~isSavedPaymentMethod=true,
+          ~isCvcEmpty,
+        )
+      }
+      emitter.emitPaymentMethodStatus(
         ~paymentMethod=paymentItem.paymentMethod,
         ~paymentMethodType,
-        ~cardBrand=paymentItem.card.scheme->Option.getOr("")->CardUtils.getCardType,
-        ~country,
-        ~state,
-        ~pinCode,
-        ~cardExpiryMonth=expiryMonth,
-        ~cardExpiryYear=expiryYear,
-        ~cardLast4,
-        ~cardBin,
         ~isSavedPaymentMethod=true,
-        ~isCvcEmpty,
+        ~isOneClickWallet,
       )
+      emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
     }
     None
   }, (isActive, paymentItem, country, state, pinCode, isCvcEmpty))
 
   React.useEffect(() => {
-    open CardUtils
     if isActive {
       // * Focus CVC
       focusCVC()
+
       // * Sending card expiry to handle cases where the card expires before the use date.
-      `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
-      ->CardValidations.formatCardExpiryNumber
-      ->emitExpiryDate
+      if isLegacy {
+        `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
+        ->CardValidations.formatCardExpiryNumber
+        ->emitExpiryDate
+      }
     }
     None
   }, (isActive, paymentItem, country, state, pinCode))
@@ -152,6 +172,7 @@ let make = (
   React.useEffect(() => {
     // TODO - Handle Events for VGS/Vault case
     CardUtils.emitIsFormReadyForSubmission(isCVCValid->Option.getOr(false))
+    emitIsFormReadyForSubmission(isCVCValid->Option.getOr(false))
     None
   }, [isCVCValid])
 

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -113,7 +113,6 @@ let make = (
   let {
     emitIsFormReadyForSubmission,
     emitExpiryDate,
-    isLegacy,
     emitPaymentMethodInfo,
   } = SubscriptionEventHooks.useLegacyEvents()
 
@@ -127,22 +126,20 @@ let make = (
 
   React.useEffect(() => {
     if isActive {
-      if isLegacy {
-        emitPaymentMethodInfo(
-          ~paymentMethod=paymentItem.paymentMethod,
-          ~paymentMethodType,
-          ~cardBrand=paymentItem.card.scheme->Option.getOr("")->CardUtils.getCardType,
-          ~country,
-          ~state,
-          ~pinCode,
-          ~cardExpiryMonth=expiryMonth,
-          ~cardExpiryYear=expiryYear,
-          ~cardLast4,
-          ~cardBin,
-          ~isSavedPaymentMethod=true,
-          ~isCvcEmpty,
-        )
-      }
+      emitPaymentMethodInfo(
+        ~paymentMethod=paymentItem.paymentMethod,
+        ~paymentMethodType,
+        ~cardBrand=paymentItem.card.scheme->Option.getOr("")->CardUtils.getCardType,
+        ~country,
+        ~state,
+        ~pinCode,
+        ~cardExpiryMonth=expiryMonth,
+        ~cardExpiryYear=expiryYear,
+        ~cardLast4,
+        ~cardBin,
+        ~isSavedPaymentMethod=true,
+        ~isCvcEmpty,
+      )
       emitter.emitPaymentMethodStatus(
         ~paymentMethod=paymentItem.paymentMethod,
         ~paymentMethodType,
@@ -160,11 +157,9 @@ let make = (
       focusCVC()
 
       // * Sending card expiry to handle cases where the card expires before the use date.
-      if isLegacy {
-        `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
-        ->CardValidations.formatCardExpiryNumber
-        ->emitExpiryDate
-      }
+      `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
+      ->CardValidations.formatCardExpiryNumber
+      ->emitExpiryDate
     }
     None
   }, (isActive, paymentItem, country, state, pinCode))

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -110,11 +110,6 @@ let make = (
   }
   let {country, state, pinCode} = PaymentUtils.useNonPiiAddressData()
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {
-    emitIsFormReadyForSubmission,
-    emitExpiryDate,
-    emitPaymentMethodInfo,
-  } = SubscriptionEventHooks.useLegacyEvents()
 
   React.useEffect(() => {
     setSelectedInstallmentPlan(_ => None)
@@ -126,7 +121,7 @@ let make = (
 
   React.useEffect(() => {
     if isActive {
-      emitPaymentMethodInfo(
+      PaymentUtils.emitPaymentMethodInfo(
         ~paymentMethod=paymentItem.paymentMethod,
         ~paymentMethodType,
         ~cardBrand=paymentItem.card.scheme->Option.getOr("")->CardUtils.getCardType,
@@ -159,14 +154,14 @@ let make = (
       // * Sending card expiry to handle cases where the card expires before the use date.
       `${expiryMonth}${String.substring(~start=2, ~end=4, expiryYear)}`
       ->CardValidations.formatCardExpiryNumber
-      ->emitExpiryDate
+      ->CardUtils.emitExpiryDate
     }
     None
   }, (isActive, paymentItem, country, state, pinCode))
 
   React.useEffect(() => {
     // TODO - Handle Events for VGS/Vault case
-    emitIsFormReadyForSubmission(isCVCValid->Option.getOr(false))
+    CardUtils.emitIsFormReadyForSubmission(isCVCValid->Option.getOr(false))
     None
   }, [isCVCValid])
 

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -285,6 +285,25 @@ let make = (
     customerMethod.paymentMethodType->Option.getOr(customerMethod.paymentMethod)
 
   useHandlePostMessages(~complete, ~empty, ~paymentType=paymentMethodType, ~savedMethod=true)
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+
+  React.useEffect(() => {
+    if isCardPaymentMethod {
+      let card = customerMethod.card
+      let cardInfo = PaymentEventData.buildCardInfoFromSavedCard(
+        ~bin=card.cardBin,
+        ~last4=card.last4Digits,
+        ~brand=card.scheme->Option.getOr(""),
+        ~expiryMonth=card.expiryMonth,
+        ~expiryYear=card.expiryYear,
+        ~isCvcComplete=complete,
+      )
+      emitter.emitCardInfo(~cardInfo)
+    }
+    None
+  }, (customerMethod, isCardPaymentMethod, complete))
 
   GooglePayHelpers.useHandleGooglePayResponse(
     ~connectors=[],

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -286,7 +286,7 @@ let make = (
 
   useHandlePostMessages(~complete, ~empty, ~paymentType=paymentMethodType, ~savedMethod=true)
   SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
-  SubscriptionEventHooks.useEmitSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
+  SubscriptionEventHooks.useEmitSurchargeInfo(~surchargeDetails=eligibilitySurchargeDetails)
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
 
   React.useEffect(() => {

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -285,8 +285,8 @@ let make = (
     customerMethod.paymentMethodType->Option.getOr(customerMethod.paymentMethod)
 
   useHandlePostMessages(~complete, ~empty, ~paymentType=paymentMethodType, ~savedMethod=true)
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
-  SubscriptionEventHooks.useSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useEmitSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
 
   React.useEffect(() => {

--- a/src/Components/SavedMethodsV2.res
+++ b/src/Components/SavedMethodsV2.res
@@ -15,6 +15,7 @@ let make = (~cvcProps: CardUtils.cvcProps) => {
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
   let updateCard = PaymentHelpersV2.useUpdateCard(Some(loggerState), Card)
   let {iframeId, sdkAuthorization} = keys
+  let elementType = PaymentTypeContext.usePaymentType()->CardThemeType.getPaymentModeToString
   let {isCVCValid, cvcNumber, setCvcError} = cvcProps
   let complete = isCVCValid->Option.getOr(false) && paymentTokenAtom.paymentToken !== ""
   let isEmpty = cvcNumber == ""
@@ -120,7 +121,7 @@ let make = (~cvcProps: CardUtils.cvcProps) => {
   }
 
   React.useEffect(() => {
-    messageParentWindow([("ready", true->JSON.Encode.bool)])
+    SubscriptionEventHooks.emitReady(~iframeId, ~elementType)
     None
   }, [])
 

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -4,6 +4,7 @@ open RecoilAtoms
 
 let useCardForm = (~logger, ~paymentType) => {
   let {localeString} = Recoil.useRecoilValueFromAtom(configAtom)
+  let {emitExpiryDate, isLegacy} = SubscriptionEventHooks.useLegacyEvents()
   let cardScheme = Recoil.useRecoilValueFromAtom(cardBrand)
   let showPaymentMethodsScreen = Recoil.useRecoilValueFromAtom(showPaymentMethodsScreen)
   let selectedOption = Recoil.useRecoilValueFromAtom(selectedOptionAtom)
@@ -209,7 +210,9 @@ let useCardForm = (~logger, ~paymentType) => {
     let formattedExpiry = val->CardValidations.formatCardExpiryNumber
     if isExipryValid(formattedExpiry) {
       handleInputFocus(~currentRef=expiryRef, ~destinationRef=cvcRef)
-      emitExpiryDate(formattedExpiry)
+      if isLegacy {
+        emitExpiryDate(formattedExpiry)
+      }
     }
     setExpiryValid(formattedExpiry, setIsExpiryValid)
     setCardExpiry(_ => formattedExpiry)

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -4,7 +4,6 @@ open RecoilAtoms
 
 let useCardForm = (~logger, ~paymentType) => {
   let {localeString} = Recoil.useRecoilValueFromAtom(configAtom)
-  let {emitExpiryDate, isLegacy} = SubscriptionEventHooks.useLegacyEvents()
   let cardScheme = Recoil.useRecoilValueFromAtom(cardBrand)
   let showPaymentMethodsScreen = Recoil.useRecoilValueFromAtom(showPaymentMethodsScreen)
   let selectedOption = Recoil.useRecoilValueFromAtom(selectedOptionAtom)
@@ -210,9 +209,7 @@ let useCardForm = (~logger, ~paymentType) => {
     let formattedExpiry = val->CardValidations.formatCardExpiryNumber
     if isExipryValid(formattedExpiry) {
       handleInputFocus(~currentRef=expiryRef, ~destinationRef=cvcRef)
-      if isLegacy {
-        emitExpiryDate(formattedExpiry)
-      }
+      CardUtils.emitExpiryDate(formattedExpiry)
     }
     setExpiryValid(formattedExpiry, setIsExpiryValid)
     setCardExpiry(_ => formattedExpiry)

--- a/src/Hooks/SubscriptionEventHooks.res
+++ b/src/Hooks/SubscriptionEventHooks.res
@@ -1,0 +1,349 @@
+open SubscriptionEventTypes
+open PaymentEventData
+open PaymentEventTypes
+
+// Internal helper: returns true if the event should be emitted.
+// None  → all events emitted (backward compat — merchant did not configure subscriptionEvents)
+// Some([]) → no events (empty list is normalised to None in getSubscriptionEvents, but guard here anyway)
+// Some([...]) → only listed events
+let shouldEmit = (subscribedEvents: option<array<PaymentEventTypes.events>>, eventType) =>
+  subscribedEvents->Option.isNone ||
+    PaymentEventData.shouldEmitEvent(
+      ~subscribedEvents=subscribedEvents->Option.getOr([]),
+      ~eventType,
+    )
+
+// ---------------------------------------------------------------------------
+// useSubscriptionEventEmitter
+// ---------------------------------------------------------------------------
+// Call once at the top of any component that needs to emit events imperatively
+// (e.g. inside event handlers or callbacks, not in effects).
+// Reads subscriptionEvents from Recoil — no prop drilling required.
+
+type emitter = {
+  emitCardInfo: (~cardInfo: PaymentEventData.cardInfo) => unit,
+  emitPaymentMethodStatus: (
+    ~paymentMethod: string,
+    ~paymentMethodType: string,
+    ~isSavedPaymentMethod: bool,
+    ~isOneClickWallet: bool=?,
+  ) => unit,
+  emitBillingAddress: (~country: string, ~state: string, ~postalCode: string) => unit,
+  emitCvcStatus: (~iframeId: string, ~isCvcEmpty: bool, ~isCvcComplete: bool) => unit,
+  emitSurcharge: (
+    ~surchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+  ) => unit,
+}
+
+let useSubscriptionEventEmitter = (): emitter => {
+  let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let subscribedEvents = options.subscriptionEvents
+
+  let emitCardInfo = (~cardInfo: PaymentEventData.cardInfo) => {
+    if shouldEmit(subscribedEvents, PaymentMethodInfoCard) {
+      Utils.messageParentWindow(createCardInfoPayload(cardInfo))
+    }
+  }
+
+  let emitPaymentMethodStatus = (
+    ~paymentMethod,
+    ~paymentMethodType,
+    ~isSavedPaymentMethod,
+    ~isOneClickWallet=false,
+  ) => {
+    if shouldEmit(subscribedEvents, PaymentMethodStatus) {
+      Utils.messageParentWindow(
+        createPaymentMethodStatusPayload(
+          ~paymentMethod,
+          ~paymentMethodType,
+          ~isSavedPaymentMethod,
+          ~isOneClickWallet,
+        ),
+      )
+    }
+  }
+
+  let emitBillingAddress = (~country, ~state, ~postalCode) => {
+    if shouldEmit(subscribedEvents, PaymentMethodInfoBillingAddress) {
+      Utils.messageParentWindow(createBillingAddressPayload(~country, ~state, ~postalCode))
+    }
+  }
+
+  let emitCvcStatus = (~iframeId, ~isCvcEmpty, ~isCvcComplete) => {
+    if shouldEmit(subscribedEvents, CvcStatus) {
+      Utils.messageParentWindow(createCvcStatusPayload(~iframeId, ~isCvcEmpty, ~isCvcComplete))
+    }
+  }
+
+  let emitSurcharge = (~surchargeDetails) => {
+    if shouldEmit(subscribedEvents, Surcharge) {
+      Utils.messageParentWindow(createSurchargePayload(~surchargeDetails))
+    }
+  }
+
+  {emitCardInfo, emitPaymentMethodStatus, emitBillingAddress, emitCvcStatus, emitSurcharge}
+}
+
+// ---------------------------------------------------------------------------
+// useIsLegacyEventMode
+// ---------------------------------------------------------------------------
+// Returns true when the merchant has NOT configured subscriptionEvents,
+// meaning old-style unconditional events should still fire for backward compat.
+let useIsLegacyEventMode = (): bool => {
+  let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  options.subscriptionEvents->Option.isNone
+}
+
+// ---------------------------------------------------------------------------
+// useLegacyEvents
+// ---------------------------------------------------------------------------
+// Single hook that wraps ALL old-style event functions with the legacy gate.
+// When subscriptionEvents is not set (None) → fires as before (backward compat).
+// When subscriptionEvents is explicitly set → all legacy events are suppressed.
+//
+// Use this hook instead of calling CardUtils / PaymentUtils / Utils event
+// functions directly, so the gate lives in exactly one place.
+type legacyEvents = {
+  isLegacy: bool,
+  emitIsFormReadyForSubmission: bool => unit,
+  emitExpiryDate: string => unit,
+  handlePostMessageEvents: (
+    ~iframeId: string,
+    ~complete: bool,
+    ~empty: bool,
+    ~paymentType: string,
+    ~loggerState: HyperLoggerTypes.loggerMake,
+    ~savedMethod: bool=?,
+  ) => unit,
+  emitCvcInfo: (~isCvcEmpty: bool) => unit,
+  emitPaymentMethodInfo: (
+    ~paymentMethod: string,
+    ~paymentMethodType: string,
+    ~cardBrand: CardUtils.cardIssuer=?,
+    ~cardLast4: string=?,
+    ~cardBin: string=?,
+    ~cardExpiryMonth: string=?,
+    ~cardExpiryYear: string=?,
+    ~country: string=?,
+    ~state: string=?,
+    ~pinCode: string=?,
+    ~isSavedPaymentMethod: bool=?,
+    ~isCvcEmpty: bool=?,
+  ) => unit,
+}
+
+// ---------------------------------------------------------------------------
+// emitReady
+// ---------------------------------------------------------------------------
+// NOT a legacy event — fires unconditionally so every merchant receives the
+// ready lifecycle event regardless of whether subscriptionEvents is configured.
+// elementType is informational only; LoaderPaymentElement does not filter
+// ready/focus/blur by elementType (only Change is filtered that way).
+let emitReady = (~iframeId, ~elementType) =>
+  Utils.messageParentWindow([
+    ("ready", true->JSON.Encode.bool),
+    ("elementType", elementType->JSON.Encode.string),
+    ("iframeId", iframeId->JSON.Encode.string),
+  ])
+
+let useLegacyEvents = (): legacyEvents => {
+  let isLegacy = useIsLegacyEventMode()
+
+  let emitIsFormReadyForSubmission = isReady =>
+    if isLegacy {
+      CardUtils.emitIsFormReadyForSubmission(isReady)
+    }
+
+  let emitExpiryDate = expiry =>
+    if isLegacy {
+      CardUtils.emitExpiryDate(expiry)
+    }
+
+  let handlePostMessageEvents = (
+    ~iframeId,
+    ~complete,
+    ~empty,
+    ~paymentType,
+    ~loggerState,
+    ~savedMethod=false,
+  ) =>
+    if isLegacy {
+      Utils.handlePostMessageEvents(
+        ~iframeId,
+        ~complete,
+        ~empty,
+        ~paymentType,
+        ~loggerState,
+        ~savedMethod,
+      )
+    }
+
+  let emitCvcInfo = (~isCvcEmpty) =>
+    if isLegacy {
+      let cvcInfoDict = [("isCvcEmpty", isCvcEmpty->JSON.Encode.bool)]->Dict.fromArray
+      Utils.messageParentWindow([("cvcInfo", cvcInfoDict->JSON.Encode.object)])
+    }
+
+  let emitPaymentMethodInfo = (
+    ~paymentMethod,
+    ~paymentMethodType,
+    ~cardBrand=CardUtils.NOTFOUND,
+    ~cardLast4="",
+    ~cardBin="",
+    ~cardExpiryMonth="",
+    ~cardExpiryYear="",
+    ~country="",
+    ~state="",
+    ~pinCode="",
+    ~isSavedPaymentMethod=false,
+    ~isCvcEmpty=true,
+  ) =>
+    if isLegacy {
+      PaymentUtils.emitPaymentMethodInfo(
+        ~paymentMethod,
+        ~paymentMethodType,
+        ~cardBrand,
+        ~cardLast4,
+        ~cardBin,
+        ~cardExpiryMonth,
+        ~cardExpiryYear,
+        ~country,
+        ~state,
+        ~pinCode,
+        ~isSavedPaymentMethod,
+        ~isCvcEmpty,
+      )
+    }
+
+  {
+    isLegacy,
+    emitIsFormReadyForSubmission,
+    emitExpiryDate,
+    handlePostMessageEvents,
+    emitCvcInfo,
+    emitPaymentMethodInfo,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useFormStatus
+// ---------------------------------------------------------------------------
+// Effect hook: emits FORM_STATUS whenever empty/complete/isOneClickWallet changes.
+let useFormStatus = (~empty: bool, ~complete: bool, ~isOneClickWallet: bool=false) => {
+  let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let subscribedEvents = options.subscriptionEvents
+
+  React.useEffect(() => {
+    if !isOneClickWallet {
+      let formStatusValue = PaymentEventData.computeFormStatus(~isComplete=complete, ~isEmpty=empty)
+      if shouldEmit(subscribedEvents, FormStatus) {
+        Utils.messageParentWindow(createFormStatusPayload(~status=formStatusValue))
+      }
+    }
+    None
+  }, (empty, complete, isOneClickWallet, subscribedEvents))
+}
+
+// ---------------------------------------------------------------------------
+// useBillingAddress
+// ---------------------------------------------------------------------------
+// Effect hook: emits PAYMENT_METHOD_INFO_BILLING_ADDRESS whenever address atoms change.
+let useBillingAddress = () => {
+  let country = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
+  let state = Recoil.useRecoilValueFromAtom(RecoilAtoms.userAddressState).value
+  let pinCode = Recoil.useRecoilValueFromAtom(RecoilAtoms.userAddressPincode).value
+  let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let subscribedEvents = options.subscriptionEvents
+
+  React.useEffect(() => {
+    if shouldEmit(subscribedEvents, PaymentMethodInfoBillingAddress) {
+      Utils.messageParentWindow(createBillingAddressPayload(~country, ~state, ~postalCode=pinCode))
+    }
+    None
+  }, (country, state, pinCode, subscribedEvents))
+}
+
+// Internal helper: resolves (paymentMethod, paymentMethodType) from method name + list.
+// Mirrors the old PaymentUtils.getPaymentMethodAndType which was removed from the new main.
+let getPaymentMethodAndType = (
+  ~paymentMethodName: string,
+  ~paymentMethods: array<PaymentMethodsRecord.methods>,
+  ~logger: HyperLoggerTypes.loggerMake,
+) => {
+  if paymentMethodName->String.includes("_debit") {
+    Some(("bank_debit", paymentMethodName))
+  } else if paymentMethodName->String.includes("_transfer") {
+    Some(("bank_transfer", paymentMethodName))
+  } else if paymentMethodName === "card" {
+    Some(("card", "debit"))
+  } else {
+    let found =
+      paymentMethods
+      ->Array.filter(pm =>
+        pm.payment_method_types
+        ->Array.filter(t => t.payment_method_type === paymentMethodName)
+        ->Array.length > 0
+      )
+      ->Array.get(0)
+
+    switch found {
+    | Some(pm) => Some((pm.payment_method, paymentMethodName))
+    | None =>
+      logger.setLogError(
+        ~value="Payment method type not found",
+        ~eventName=PAYMENT_METHOD_TYPE_DETECTION_FAILED,
+      )
+      None
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// usePaymentMethodStatus
+// ---------------------------------------------------------------------------
+// Effect hook: emits PAYMENT_METHOD_STATUS when the selected payment method changes.
+let usePaymentMethodStatus = (
+  ~paymentMethodName: string,
+  ~paymentMethods: array<PaymentMethodsRecord.methods>,
+  ~isSavedPaymentMethod: bool,
+  ~isOneClickWallet: bool,
+) => {
+  let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
+  let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let subscribedEvents = options.subscriptionEvents
+
+  React.useEffect(() => {
+    if shouldEmit(subscribedEvents, PaymentMethodStatus) {
+      switch getPaymentMethodAndType(~paymentMethodName, ~paymentMethods, ~logger=loggerState) {
+      | Some((paymentMethod, paymentMethodType)) =>
+        Utils.messageParentWindow(
+          createPaymentMethodStatusPayload(
+            ~paymentMethod,
+            ~paymentMethodType,
+            ~isSavedPaymentMethod,
+            ~isOneClickWallet,
+          ),
+        )
+      | None => ()
+      }
+    }
+    None
+  }, (paymentMethodName, paymentMethods, isSavedPaymentMethod, isOneClickWallet, subscribedEvents))
+}
+
+// ---------------------------------------------------------------------------
+// useSurcharge
+// ---------------------------------------------------------------------------
+// Effect hook: emits SURCHARGE when the eligibility surcharge details change.
+// Pass the surcharge details option from the component's React state.
+let useSurcharge = (~surchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>) => {
+  let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let subscribedEvents = options.subscriptionEvents
+
+  React.useEffect(() => {
+    if shouldEmit(subscribedEvents, Surcharge) {
+      Utils.messageParentWindow(createSurchargePayload(~surchargeDetails))
+    }
+    None
+  }, (surchargeDetails, subscribedEvents))
+}

--- a/src/Hooks/SubscriptionEventHooks.res
+++ b/src/Hooks/SubscriptionEventHooks.res
@@ -226,10 +226,10 @@ let useLegacyEvents = (): legacyEvents => {
 }
 
 // ---------------------------------------------------------------------------
-// useFormStatus
+// useEmitFormStatus
 // ---------------------------------------------------------------------------
 // Effect hook: emits FORM_STATUS whenever empty/complete/isOneClickWallet changes.
-let useFormStatus = (~empty: bool, ~complete: bool, ~isOneClickWallet: bool=false) => {
+let useEmitFormStatus = (~empty: bool, ~complete: bool, ~isOneClickWallet: bool=false) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let subscribedEvents = options.subscriptionEvents
 
@@ -245,10 +245,10 @@ let useFormStatus = (~empty: bool, ~complete: bool, ~isOneClickWallet: bool=fals
 }
 
 // ---------------------------------------------------------------------------
-// useBillingAddress
+// useEmitBillingAddress
 // ---------------------------------------------------------------------------
 // Effect hook: emits PAYMENT_METHOD_INFO_BILLING_ADDRESS whenever address atoms change.
-let useBillingAddress = () => {
+let useEmitBillingAddress = () => {
   let country = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let state = Recoil.useRecoilValueFromAtom(RecoilAtoms.userAddressState).value
   let pinCode = Recoil.useRecoilValueFromAtom(RecoilAtoms.userAddressPincode).value
@@ -299,10 +299,10 @@ let getPaymentMethodAndType = (
 }
 
 // ---------------------------------------------------------------------------
-// usePaymentMethodStatus
+// useEmitPaymentMethodStatus
 // ---------------------------------------------------------------------------
 // Effect hook: emits PAYMENT_METHOD_STATUS when the selected payment method changes.
-let usePaymentMethodStatus = (
+let useEmitPaymentMethodStatus = (
   ~paymentMethodName: string,
   ~paymentMethods: array<PaymentMethodsRecord.methods>,
   ~isSavedPaymentMethod: bool,
@@ -332,11 +332,13 @@ let usePaymentMethodStatus = (
 }
 
 // ---------------------------------------------------------------------------
-// useSurcharge
+// useEmitSurcharge
 // ---------------------------------------------------------------------------
 // Effect hook: emits SURCHARGE when the eligibility surcharge details change.
 // Pass the surcharge details option from the component's React state.
-let useSurcharge = (~surchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>) => {
+let useEmitSurcharge = (
+  ~surchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let subscribedEvents = options.subscriptionEvents
 

--- a/src/Hooks/SubscriptionEventHooks.res
+++ b/src/Hooks/SubscriptionEventHooks.res
@@ -1,5 +1,4 @@
 open SubscriptionEventTypes
-open PaymentEventData
 open PaymentEventTypes
 
 // ---------------------------------------------------------------------------
@@ -114,7 +113,7 @@ let emitReady = (~iframeId, ~elementType) =>
 // ---------------------------------------------------------------------------
 // useEmitFormStatus
 // ---------------------------------------------------------------------------
-// Effect hook: emits FORM_STATUS whenever empty/complete/isOneClickWallet changes.
+// Effect hook: emits formStatus whenever empty/complete/isOneClickWallet changes.
 let useEmitFormStatus = (~empty: bool, ~complete: bool, ~isOneClickWallet: bool=false) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let subscribedEvents = options.subscriptionEvents
@@ -138,7 +137,7 @@ let useEmitFormStatus = (~empty: bool, ~complete: bool, ~isOneClickWallet: bool=
 // ---------------------------------------------------------------------------
 // useEmitBillingAddress
 // ---------------------------------------------------------------------------
-// Effect hook: emits PAYMENT_METHOD_INFO_BILLING_ADDRESS whenever address atoms change.
+// Effect hook: emits paymentMethodInfoBillingAddress whenever address atoms change.
 let useEmitBillingAddress = () => {
   let country = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let state = Recoil.useRecoilValueFromAtom(RecoilAtoms.userAddressState).value
@@ -197,7 +196,7 @@ let getPaymentMethodAndType = (
 // ---------------------------------------------------------------------------
 // useEmitPaymentMethodStatus
 // ---------------------------------------------------------------------------
-// Effect hook: emits PAYMENT_METHOD_STATUS when the selected payment method changes.
+// Effect hook: emits paymentMethodStatus when the selected payment method changes.
 let useEmitPaymentMethodStatus = (
   ~paymentMethodName: string,
   ~paymentMethods: array<PaymentMethodsRecord.methods>,
@@ -233,11 +232,11 @@ let useEmitPaymentMethodStatus = (
 }
 
 // ---------------------------------------------------------------------------
-// useEmitSurcharge
+// useEmitSurchargeInfo
 // ---------------------------------------------------------------------------
-// Effect hook: emits SURCHARGE when the eligibility surcharge details change.
+// Effect hook: emits surcharge when the eligibility surcharge details change.
 // Pass the surcharge details option from the component's React state.
-let useEmitSurcharge = (
+let useEmitSurchargeInfo = (
   ~surchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
 ) => {
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)

--- a/src/Hooks/SubscriptionEventHooks.res
+++ b/src/Hooks/SubscriptionEventHooks.res
@@ -2,17 +2,6 @@ open SubscriptionEventTypes
 open PaymentEventData
 open PaymentEventTypes
 
-// Internal helper: returns true if the event should be emitted.
-// None  → all events emitted (backward compat — merchant did not configure subscriptionEvents)
-// Some([]) → no events (empty list is normalised to None in getSubscriptionEvents, but guard here anyway)
-// Some([...]) → only listed events
-let shouldEmit = (subscribedEvents: option<array<PaymentEventTypes.events>>, eventType) =>
-  subscribedEvents->Option.isNone ||
-    PaymentEventData.shouldEmitEvent(
-      ~subscribedEvents=subscribedEvents->Option.getOr([]),
-      ~eventType,
-    )
-
 // ---------------------------------------------------------------------------
 // useSubscriptionEventEmitter
 // ---------------------------------------------------------------------------
@@ -40,7 +29,12 @@ let useSubscriptionEventEmitter = (): emitter => {
   let subscribedEvents = options.subscriptionEvents
 
   let emitCardInfo = (~cardInfo: PaymentEventData.cardInfo) => {
-    if shouldEmit(subscribedEvents, PaymentMethodInfoCard) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=PaymentMethodInfoCard,
+      )
+    ) {
       Utils.messageParentWindow(createCardInfoPayload(cardInfo))
     }
   }
@@ -51,7 +45,12 @@ let useSubscriptionEventEmitter = (): emitter => {
     ~isSavedPaymentMethod,
     ~isOneClickWallet=false,
   ) => {
-    if shouldEmit(subscribedEvents, PaymentMethodStatus) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=PaymentMethodStatus,
+      )
+    ) {
       Utils.messageParentWindow(
         createPaymentMethodStatusPayload(
           ~paymentMethod,
@@ -64,19 +63,35 @@ let useSubscriptionEventEmitter = (): emitter => {
   }
 
   let emitBillingAddress = (~country, ~state, ~postalCode) => {
-    if shouldEmit(subscribedEvents, PaymentMethodInfoBillingAddress) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=PaymentMethodInfoBillingAddress,
+      )
+    ) {
       Utils.messageParentWindow(createBillingAddressPayload(~country, ~state, ~postalCode))
     }
   }
 
   let emitCvcStatus = (~iframeId, ~isCvcEmpty, ~isCvcComplete) => {
-    if shouldEmit(subscribedEvents, CvcStatus) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=CvcStatus,
+      )
+    ) {
       Utils.messageParentWindow(createCvcStatusPayload(~iframeId, ~isCvcEmpty, ~isCvcComplete))
     }
   }
 
   let emitSurcharge = (~surchargeDetails) => {
-    if shouldEmit(subscribedEvents, Surcharge) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=Surcharge,
+      ) &&
+      surchargeDetails->Option.isSome
+    ) {
       Utils.messageParentWindow(createSurchargePayload(~surchargeDetails))
     }
   }
@@ -85,145 +100,16 @@ let useSubscriptionEventEmitter = (): emitter => {
 }
 
 // ---------------------------------------------------------------------------
-// useIsLegacyEventMode
-// ---------------------------------------------------------------------------
-// Returns true when the merchant has NOT configured subscriptionEvents,
-// meaning old-style unconditional events should still fire for backward compat.
-let useIsLegacyEventMode = (): bool => {
-  let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
-  options.subscriptionEvents->Option.isNone
-}
-
-// ---------------------------------------------------------------------------
-// useLegacyEvents
-// ---------------------------------------------------------------------------
-// Single hook that wraps ALL old-style event functions with the legacy gate.
-// When subscriptionEvents is not set (None) → fires as before (backward compat).
-// When subscriptionEvents is explicitly set → all legacy events are suppressed.
-//
-// Use this hook instead of calling CardUtils / PaymentUtils / Utils event
-// functions directly, so the gate lives in exactly one place.
-type legacyEvents = {
-  isLegacy: bool,
-  emitIsFormReadyForSubmission: bool => unit,
-  emitExpiryDate: string => unit,
-  handlePostMessageEvents: (
-    ~iframeId: string,
-    ~complete: bool,
-    ~empty: bool,
-    ~paymentType: string,
-    ~loggerState: HyperLoggerTypes.loggerMake,
-    ~savedMethod: bool=?,
-  ) => unit,
-  emitCvcInfo: (~isCvcEmpty: bool) => unit,
-  emitPaymentMethodInfo: (
-    ~paymentMethod: string,
-    ~paymentMethodType: string,
-    ~cardBrand: CardUtils.cardIssuer=?,
-    ~cardLast4: string=?,
-    ~cardBin: string=?,
-    ~cardExpiryMonth: string=?,
-    ~cardExpiryYear: string=?,
-    ~country: string=?,
-    ~state: string=?,
-    ~pinCode: string=?,
-    ~isSavedPaymentMethod: bool=?,
-    ~isCvcEmpty: bool=?,
-  ) => unit,
-}
-
-// ---------------------------------------------------------------------------
 // emitReady
 // ---------------------------------------------------------------------------
-// NOT a legacy event — fires unconditionally so every merchant receives the
-// ready lifecycle event regardless of whether subscriptionEvents is configured.
-// elementType is informational only; LoaderPaymentElement does not filter
-// ready/focus/blur by elementType (only Change is filtered that way).
+// Fires unconditionally so every merchant receives the ready lifecycle event
+// regardless of whether subscriptionEvents is configured.
 let emitReady = (~iframeId, ~elementType) =>
   Utils.messageParentWindow([
     ("ready", true->JSON.Encode.bool),
     ("elementType", elementType->JSON.Encode.string),
     ("iframeId", iframeId->JSON.Encode.string),
   ])
-
-let useLegacyEvents = (): legacyEvents => {
-  let isLegacy = useIsLegacyEventMode()
-
-  let emitIsFormReadyForSubmission = isReady =>
-    if isLegacy {
-      CardUtils.emitIsFormReadyForSubmission(isReady)
-    }
-
-  let emitExpiryDate = expiry =>
-    if isLegacy {
-      CardUtils.emitExpiryDate(expiry)
-    }
-
-  let handlePostMessageEvents = (
-    ~iframeId,
-    ~complete,
-    ~empty,
-    ~paymentType,
-    ~loggerState,
-    ~savedMethod=false,
-  ) =>
-    if isLegacy {
-      Utils.handlePostMessageEvents(
-        ~iframeId,
-        ~complete,
-        ~empty,
-        ~paymentType,
-        ~loggerState,
-        ~savedMethod,
-      )
-    }
-
-  let emitCvcInfo = (~isCvcEmpty) =>
-    if isLegacy {
-      let cvcInfoDict = [("isCvcEmpty", isCvcEmpty->JSON.Encode.bool)]->Dict.fromArray
-      Utils.messageParentWindow([("cvcInfo", cvcInfoDict->JSON.Encode.object)])
-    }
-
-  let emitPaymentMethodInfo = (
-    ~paymentMethod,
-    ~paymentMethodType,
-    ~cardBrand=CardUtils.NOTFOUND,
-    ~cardLast4="",
-    ~cardBin="",
-    ~cardExpiryMonth="",
-    ~cardExpiryYear="",
-    ~country="",
-    ~state="",
-    ~pinCode="",
-    ~isSavedPaymentMethod=false,
-    ~isCvcEmpty=true,
-  ) =>
-    if isLegacy {
-      PaymentUtils.emitPaymentMethodInfo(
-        ~paymentMethod,
-        ~paymentMethodType,
-        ~cardBrand,
-        ~cardLast4,
-        ~cardBin,
-        ~cardExpiryMonth,
-        ~cardExpiryYear,
-        ~country,
-        ~state,
-        ~pinCode,
-        ~isSavedPaymentMethod,
-        ~isCvcEmpty,
-      )
-    }
-
-  {
-    isLegacy,
-    emitIsFormReadyForSubmission,
-    emitExpiryDate,
-    handlePostMessageEvents,
-    emitCvcInfo,
-    emitPaymentMethodInfo,
-  }
-}
 
 // ---------------------------------------------------------------------------
 // useEmitFormStatus
@@ -236,7 +122,12 @@ let useEmitFormStatus = (~empty: bool, ~complete: bool, ~isOneClickWallet: bool=
   React.useEffect(() => {
     if !isOneClickWallet {
       let formStatusValue = PaymentEventData.computeFormStatus(~isComplete=complete, ~isEmpty=empty)
-      if shouldEmit(subscribedEvents, FormStatus) {
+      if (
+        PaymentEventData.shouldEmitEvent(
+          ~subscribedEvents=subscribedEvents->Option.getOr([]),
+          ~eventType=FormStatus,
+        )
+      ) {
         Utils.messageParentWindow(createFormStatusPayload(~status=formStatusValue))
       }
     }
@@ -256,7 +147,12 @@ let useEmitBillingAddress = () => {
   let subscribedEvents = options.subscriptionEvents
 
   React.useEffect(() => {
-    if shouldEmit(subscribedEvents, PaymentMethodInfoBillingAddress) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=PaymentMethodInfoBillingAddress,
+      )
+    ) {
       Utils.messageParentWindow(createBillingAddressPayload(~country, ~state, ~postalCode=pinCode))
     }
     None
@@ -313,7 +209,12 @@ let useEmitPaymentMethodStatus = (
   let subscribedEvents = options.subscriptionEvents
 
   React.useEffect(() => {
-    if shouldEmit(subscribedEvents, PaymentMethodStatus) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=PaymentMethodStatus,
+      )
+    ) {
       switch getPaymentMethodAndType(~paymentMethodName, ~paymentMethods, ~logger=loggerState) {
       | Some((paymentMethod, paymentMethodType)) =>
         Utils.messageParentWindow(
@@ -343,7 +244,13 @@ let useEmitSurcharge = (
   let subscribedEvents = options.subscriptionEvents
 
   React.useEffect(() => {
-    if shouldEmit(subscribedEvents, Surcharge) {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=Surcharge,
+      ) &&
+      surchargeDetails->Option.isSome
+    ) {
       Utils.messageParentWindow(createSurchargePayload(~surchargeDetails))
     }
     None

--- a/src/Hooks/UtilityHooks.res
+++ b/src/Hooks/UtilityHooks.res
@@ -26,21 +26,18 @@ let useHandlePostMessages = (~complete, ~empty, ~paymentType, ~savedMethod=false
 
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
-  let {isLegacy, handlePostMessageEvents} = SubscriptionEventHooks.useLegacyEvents()
 
   React.useEffect(() => {
-    if isLegacy {
-      handlePostMessageEvents(
-        ~iframeId,
-        ~complete,
-        ~empty,
-        ~paymentType,
-        ~loggerState,
-        ~savedMethod,
-      )
-    }
+    Utils.handlePostMessageEvents(
+      ~iframeId,
+      ~complete,
+      ~empty,
+      ~paymentType,
+      ~loggerState,
+      ~savedMethod,
+    )
     None
-  }, (complete, empty, paymentType, isLegacy))
+  }, (complete, empty, paymentType, savedMethod))
 }
 
 let useIsCustomerAcceptanceRequired = (

--- a/src/Hooks/UtilityHooks.res
+++ b/src/Hooks/UtilityHooks.res
@@ -25,11 +25,22 @@ let useHandlePostMessages = (~complete, ~empty, ~paymentType, ~savedMethod=false
   open RecoilAtoms
 
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
+  let {iframeId} = Recoil.useRecoilValueFromAtom(keys)
+  let {isLegacy, handlePostMessageEvents} = SubscriptionEventHooks.useLegacyEvents()
 
   React.useEffect(() => {
-    Utils.handlePostMessageEvents(~complete, ~empty, ~paymentType, ~loggerState, ~savedMethod)
+    if isLegacy {
+      handlePostMessageEvents(
+        ~iframeId,
+        ~complete,
+        ~empty,
+        ~paymentType,
+        ~loggerState,
+        ~savedMethod,
+      )
+    }
     None
-  }, (complete, empty, paymentType))
+  }, (complete, empty, paymentType, isLegacy))
 }
 
 let useIsCustomerAcceptanceRequired = (

--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -94,8 +94,14 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
     | CardNumberElement
     | CardExpiryElement
     | CardCVCElement
-    | Card =>
-      setOptions(_ => ElementType.itemToObjMapper(optionsDict, logger))
+    | Card => {
+        setOptions(_ => ElementType.itemToObjMapper(optionsDict, logger))
+        let subscriptionEvents = SubscriptionEventTypes.getSubscriptionEvents(
+          optionsDict,
+          "subscriptionEvents",
+        )
+        setOptionsPayment(prev => {...prev, subscriptionEvents})
+      }
     | PaymentMethodCollectElement => {
         let paymentMethodCollectOptions = PaymentMethodCollectUtils.itemToObjMapper(optionsDict)
         setPaymentMethodCollectOptions(_ => paymentMethodCollectOptions)

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -16,7 +16,6 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(areRequiredFieldsValid)
   let (isFocus, setIsFocus) = React.useState(_ => false)
-  let {emitIsFormReadyForSubmission} = SubscriptionEventHooks.useLegacyEvents()
 
   let intent = PaymentHelpers.usePaymentIntent(Some(logger), Card)
 
@@ -38,7 +37,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   React.useEffect(() => {
     switch (isCardValid, isExpiryValid, isCVCValid) {
     | (Some(cardValid), Some(expiryValid), Some(cvcValid)) =>
-      emitIsFormReadyForSubmission(cardValid && expiryValid && cvcValid && areRequiredFieldsValid)
+      CardUtils.emitIsFormReadyForSubmission(cardValid && expiryValid && cvcValid && areRequiredFieldsValid)
     | _ => ()
     }
     None

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -16,6 +16,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
   let areRequiredFieldsValid = Recoil.useRecoilValueFromAtom(areRequiredFieldsValid)
   let (isFocus, setIsFocus) = React.useState(_ => false)
+  let {emitIsFormReadyForSubmission} = SubscriptionEventHooks.useLegacyEvents()
 
   let intent = PaymentHelpers.usePaymentIntent(Some(logger), Card)
 
@@ -37,9 +38,7 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   React.useEffect(() => {
     switch (isCardValid, isExpiryValid, isCVCValid) {
     | (Some(cardValid), Some(expiryValid), Some(cvcValid)) =>
-      CardUtils.emitIsFormReadyForSubmission(
-        cardValid && expiryValid && cvcValid && areRequiredFieldsValid,
-      )
+      emitIsFormReadyForSubmission(cardValid && expiryValid && cvcValid && areRequiredFieldsValid)
     | _ => ()
     }
     None

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -37,7 +37,9 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
   React.useEffect(() => {
     switch (isCardValid, isExpiryValid, isCVCValid) {
     | (Some(cardValid), Some(expiryValid), Some(cvcValid)) =>
-      CardUtils.emitIsFormReadyForSubmission(cardValid && expiryValid && cvcValid && areRequiredFieldsValid)
+      CardUtils.emitIsFormReadyForSubmission(
+        cardValid && expiryValid && cvcValid && areRequiredFieldsValid,
+      )
     | _ => ()
     }
     None

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -32,7 +32,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
   )
   let (isTokenize, setIsTokenize) = Recoil.useRecoilState(RecoilAtoms.isTokenize)
   let sdkConfigsValue = Recoil.useRecoilValueFromAtom(PaymentUtils.sdkConfigsValue)
-  let {publishableKey} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
+  let {publishableKey, iframeId} = Recoil.useRecoilValueFromAtom(RecoilAtoms.keys)
   let sessionToken = Recoil.useRecoilValueFromAtom(RecoilAtoms.sessions)
 
   let clickToPayConfig = Recoil.useRecoilValueFromAtom(RecoilAtoms.clickToPayConfig)
@@ -510,10 +510,10 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     let evalMethodsList = () =>
       switch paymentMethodList {
       | SemiLoaded | LoadError(_) | Loaded(_) =>
-        messageParentWindow([
-          ("ready", true->JSON.Encode.bool),
-          ("elementType", CardThemeType.getPaymentModeToString(paymentType)->JSON.Encode.string),
-        ])
+        SubscriptionEventHooks.emitReady(
+          ~iframeId,
+          ~elementType=CardThemeType.getPaymentModeToString(paymentType),
+        )
       | _ => ()
       }
     if !displaySavedPaymentMethods {
@@ -523,13 +523,10 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
       | LoadingSavedCards => ()
       | LoadedSavedCards(list, _) =>
         list->Array.length > 0
-          ? messageParentWindow([
-              ("ready", true->JSON.Encode.bool),
-              (
-                "elementType",
-                CardThemeType.getPaymentModeToString(paymentType)->JSON.Encode.string,
-              ),
-            ])
+          ? SubscriptionEventHooks.emitReady(
+              ~iframeId,
+              ~elementType=CardThemeType.getPaymentModeToString(paymentType),
+            )
           : evalMethodsList()
       | NoResult(_) => evalMethodsList()
       }

--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -59,6 +59,7 @@ let make = (
 ) => {
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {readOnly, customMethodNames, layout} = Recoil.useRecoilValueFromAtom(optionAtom)
+  let {isLegacy} = SubscriptionEventHooks.useLegacyEvents()
   let layoutClass = CardUtils.getLayoutClass(layout)
   let payOptionsRef = React.useRef(Nullable.null)
   let selectRef = React.useRef(Nullable.null)
@@ -122,7 +123,15 @@ let make = (
     ~cardProps,
     ~expiryProps,
     ~cvcProps,
+    ~isLegacy,
   )
+  SubscriptionEventHooks.usePaymentMethodStatus(
+    ~paymentMethodName=selectedPaymentOption.paymentMethodName,
+    ~paymentMethods=paymentMethodListValue.payment_methods,
+    ~isSavedPaymentMethod=false,
+    ~isOneClickWallet=false,
+  )
+  SubscriptionEventHooks.useBillingAddress()
 
   let displayIcon = ele => {
     <span className={`scale-90 animate-slowShow ${toggleIconElement ? "hidden" : ""}`}> ele </span>

--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -125,13 +125,13 @@ let make = (
     ~cvcProps,
     ~isLegacy,
   )
-  SubscriptionEventHooks.usePaymentMethodStatus(
+  SubscriptionEventHooks.useEmitPaymentMethodStatus(
     ~paymentMethodName=selectedPaymentOption.paymentMethodName,
     ~paymentMethods=paymentMethodListValue.payment_methods,
     ~isSavedPaymentMethod=false,
     ~isOneClickWallet=false,
   )
-  SubscriptionEventHooks.useBillingAddress()
+  SubscriptionEventHooks.useEmitBillingAddress()
 
   let displayIcon = ele => {
     <span className={`scale-90 animate-slowShow ${toggleIconElement ? "hidden" : ""}`}> ele </span>

--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -59,7 +59,6 @@ let make = (
 ) => {
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {readOnly, customMethodNames, layout} = Recoil.useRecoilValueFromAtom(optionAtom)
-  let {isLegacy} = SubscriptionEventHooks.useLegacyEvents()
   let layoutClass = CardUtils.getLayoutClass(layout)
   let payOptionsRef = React.useRef(Nullable.null)
   let selectRef = React.useRef(Nullable.null)
@@ -123,7 +122,6 @@ let make = (
     ~cardProps,
     ~expiryProps,
     ~cvcProps,
-    ~isLegacy,
   )
   SubscriptionEventHooks.useEmitPaymentMethodStatus(
     ~paymentMethodName=selectedPaymentOption.paymentMethodName,

--- a/src/Payments/ACHBankDebit.res
+++ b/src/Payments/ACHBankDebit.res
@@ -66,7 +66,7 @@ let make = () => {
   let empty = email.value == "" || fullName.value != ""
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="ach_bank_debit")
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/ACHBankDebit.res
+++ b/src/Payments/ACHBankDebit.res
@@ -66,6 +66,7 @@ let make = () => {
   let empty = email.value == "" || fullName.value != ""
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="ach_bank_debit")
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/ACHBankTransfer.res
+++ b/src/Payments/ACHBankTransfer.res
@@ -19,7 +19,7 @@ let make = () => {
   let empty = areRequiredFieldsEmpty
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="bank_transfer")
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/ACHBankTransfer.res
+++ b/src/Payments/ACHBankTransfer.res
@@ -15,11 +15,11 @@ let make = () => {
 
   let (requiredFieldsBody, setRequiredFieldsBody) = React.useState(_ => Dict.make())
 
-  UtilityHooks.useHandlePostMessages(
-    ~complete=areRequiredFieldsValid && !areRequiredFieldsEmpty,
-    ~empty=areRequiredFieldsEmpty,
-    ~paymentType="bank_transfer",
-  )
+  let complete = areRequiredFieldsValid && !areRequiredFieldsEmpty
+  let empty = areRequiredFieldsEmpty
+
+  UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="bank_transfer")
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -88,6 +88,13 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
     ~empty=areRequiredFieldsEmpty,
     ~paymentType="apple_pay",
   )
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
+  SubscriptionEventHooks.useFormStatus(
+    ~empty=areRequiredFieldsEmpty,
+    ~complete=areRequiredFieldsValid,
+    ~isOneClickWallet=isWallet,
+  )
 
   let applePayPaymentMethodType = React.useMemo(() => {
     switch PaymentMethodsRecord.getPaymentMethodTypeFromList(
@@ -271,13 +278,22 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
         ~eventName=APPLE_PAY_FLOW,
         ~paymentMethod="APPLE_PAY",
       )
-      PaymentUtils.emitPaymentMethodInfo(
+      if isLegacy {
+        emitPaymentMethodInfo(
+          ~paymentMethod="wallet",
+          ~paymentMethodType="apple_pay",
+          ~country,
+          ~state,
+          ~pinCode,
+        )
+      }
+      emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="apple_pay",
-        ~country,
-        ~state,
-        ~pinCode,
+        ~isSavedPaymentMethod=false,
+        ~isOneClickWallet=isWallet,
       )
+      emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
       setApplePayClicked(_ => true)
       makeOneClickHandlerPromise(sdkHandleIsThere)
       ->then(result => {

--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -89,7 +89,6 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
     ~paymentType="apple_pay",
   )
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   SubscriptionEventHooks.useEmitFormStatus(
     ~empty=areRequiredFieldsEmpty,
     ~complete=areRequiredFieldsValid,
@@ -278,15 +277,13 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
         ~eventName=APPLE_PAY_FLOW,
         ~paymentMethod="APPLE_PAY",
       )
-      if isLegacy {
-        emitPaymentMethodInfo(
-          ~paymentMethod="wallet",
-          ~paymentMethodType="apple_pay",
-          ~country,
-          ~state,
-          ~pinCode,
-        )
-      }
+      PaymentUtils.emitPaymentMethodInfo(
+        ~paymentMethod="wallet",
+        ~paymentMethodType="apple_pay",
+        ~country,
+        ~state,
+        ~pinCode,
+      )
       emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="apple_pay",

--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -90,7 +90,7 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
   )
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
   let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
-  SubscriptionEventHooks.useFormStatus(
+  SubscriptionEventHooks.useEmitFormStatus(
     ~empty=areRequiredFieldsEmpty,
     ~complete=areRequiredFieldsValid,
     ~isOneClickWallet=isWallet,

--- a/src/Payments/BacsBankDebit.res
+++ b/src/Payments/BacsBankDebit.res
@@ -79,6 +79,7 @@ let make = () => {
     state.value == ""
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="bacs_bank_debit")
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/BacsBankDebit.res
+++ b/src/Payments/BacsBankDebit.res
@@ -79,7 +79,7 @@ let make = () => {
     state.value == ""
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="bacs_bank_debit")
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/BacsBankTransfer.res
+++ b/src/Payments/BacsBankTransfer.res
@@ -23,7 +23,7 @@ let default = () => {
   let paymentMethod = "bank_transfer"
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType=paymentMethod)
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/BacsBankTransfer.res
+++ b/src/Payments/BacsBankTransfer.res
@@ -23,6 +23,7 @@ let default = () => {
   let paymentMethod = "bank_transfer"
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType=paymentMethod)
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/BecsBankDebit.res
+++ b/src/Payments/BecsBankDebit.res
@@ -44,7 +44,7 @@ let make = () => {
     }
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="becs_bank_debit")
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/BecsBankDebit.res
+++ b/src/Payments/BecsBankDebit.res
@@ -44,6 +44,7 @@ let make = () => {
     }
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="becs_bank_debit")
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/Boleto.res
+++ b/src/Payments/Boleto.res
@@ -44,7 +44,7 @@ let make = () => {
   }, [socialSecurityNumber])
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="boleto")
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/Boleto.res
+++ b/src/Payments/Boleto.res
@@ -44,6 +44,7 @@ let make = () => {
   }, [socialSecurityNumber])
 
   UtilityHooks.useHandlePostMessages(~complete, ~empty, ~paymentType="boleto")
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete)
 
   React.useEffect(() => {
     setComplete(_ => complete)

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -152,6 +152,19 @@ let make = (
     isInstallmentValid
 
   let empty = cardNumber == "" || cardExpiry == "" || cvcNumber == ""
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete=complete && areRequiredFieldsValid)
+  SubscriptionEventHooks.useSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
+  React.useEffect(() => {
+    let cardInfo = PaymentEventData.buildCardInfo(
+      ~cardNumber,
+      ~expiry=cardExpiry,
+      ~cvc=cvcNumber,
+      ~brand=cardBrand,
+    )
+    emitter.emitCardInfo(~cardInfo)
+    None
+  }, (cardNumber, cardExpiry, cvcNumber, cardBrand))
   React.useEffect(() => {
     setComplete(_ => complete)
     setShowPaymentMethodsScreen(_ => true)

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -153,8 +153,8 @@ let make = (
 
   let empty = cardNumber == "" || cardExpiry == "" || cvcNumber == ""
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete=complete && areRequiredFieldsValid)
-  SubscriptionEventHooks.useSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete=complete && areRequiredFieldsValid)
+  SubscriptionEventHooks.useEmitSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
   React.useEffect(() => {
     let cardInfo = PaymentEventData.buildCardInfo(
       ~cardNumber,

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -154,7 +154,7 @@ let make = (
   let empty = cardNumber == "" || cardExpiry == "" || cvcNumber == ""
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
   SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete=complete && areRequiredFieldsValid)
-  SubscriptionEventHooks.useEmitSurcharge(~surchargeDetails=eligibilitySurchargeDetails)
+  SubscriptionEventHooks.useEmitSurchargeInfo(~surchargeDetails=eligibilitySurchargeDetails)
   React.useEffect(() => {
     let cardInfo = PaymentEventData.buildCardInfo(
       ~cardNumber,

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -49,7 +49,7 @@ let make = (
   )
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
   let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
-  SubscriptionEventHooks.useFormStatus(
+  SubscriptionEventHooks.useEmitFormStatus(
     ~empty=areRequiredFieldsEmpty,
     ~complete=areRequiredFieldsValid,
     ~isOneClickWallet=isWallet,

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -48,7 +48,6 @@ let make = (
     ~paymentType="google_pay",
   )
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   SubscriptionEventHooks.useEmitFormStatus(
     ~empty=areRequiredFieldsEmpty,
     ~complete=areRequiredFieldsValid,
@@ -167,15 +166,13 @@ let make = (
         ~eventName=GOOGLE_PAY_FLOW,
         ~paymentMethod="GOOGLE_PAY",
       )
-      if isLegacy {
-        emitPaymentMethodInfo(
-          ~paymentMethod="wallet",
-          ~paymentMethodType="google_pay",
-          ~country,
-          ~state,
-          ~pinCode,
-        )
-      }
+      PaymentUtils.emitPaymentMethodInfo(
+        ~paymentMethod="wallet",
+        ~paymentMethodType="google_pay",
+        ~country,
+        ~state,
+        ~pinCode,
+      )
       emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="google_pay",

--- a/src/Payments/GPay.res
+++ b/src/Payments/GPay.res
@@ -47,6 +47,13 @@ let make = (
     ~empty=areRequiredFieldsEmpty,
     ~paymentType="google_pay",
   )
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
+  SubscriptionEventHooks.useFormStatus(
+    ~empty=areRequiredFieldsEmpty,
+    ~complete=areRequiredFieldsValid,
+    ~isOneClickWallet=isWallet,
+  )
 
   let googlePayPaymentMethodType = switch PaymentMethodsRecord.getPaymentMethodTypeFromList(
     ~paymentMethodListValue,
@@ -160,13 +167,22 @@ let make = (
         ~eventName=GOOGLE_PAY_FLOW,
         ~paymentMethod="GOOGLE_PAY",
       )
-      PaymentUtils.emitPaymentMethodInfo(
+      if isLegacy {
+        emitPaymentMethodInfo(
+          ~paymentMethod="wallet",
+          ~paymentMethodType="google_pay",
+          ~country,
+          ~state,
+          ~pinCode,
+        )
+      }
+      emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="google_pay",
-        ~country,
-        ~state,
-        ~pinCode,
+        ~isSavedPaymentMethod=false,
+        ~isOneClickWallet=isWallet,
       )
+      emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
       makeOneClickHandlerPromise(isSDKHandleClick)
       ->then(result => {
         let result = result->JSON.Decode.bool->Option.getOr(false)

--- a/src/Payments/InstantBankTransfer.res
+++ b/src/Payments/InstantBankTransfer.res
@@ -24,7 +24,7 @@ let make = () => {
     ~empty=areRequiredFieldsEmpty,
     ~paymentType=paymentMethod,
   )
-  SubscriptionEventHooks.useFormStatus(
+  SubscriptionEventHooks.useEmitFormStatus(
     ~empty=areRequiredFieldsEmpty,
     ~complete=areRequiredFieldsValid && !areRequiredFieldsEmpty,
   )

--- a/src/Payments/InstantBankTransfer.res
+++ b/src/Payments/InstantBankTransfer.res
@@ -24,6 +24,10 @@ let make = () => {
     ~empty=areRequiredFieldsEmpty,
     ~paymentType=paymentMethod,
   )
+  SubscriptionEventHooks.useFormStatus(
+    ~empty=areRequiredFieldsEmpty,
+    ~complete=areRequiredFieldsValid && !areRequiredFieldsEmpty,
+  )
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/InstantBankTransferFinland.res
+++ b/src/Payments/InstantBankTransferFinland.res
@@ -24,7 +24,7 @@ let make = () => {
     ~empty=areRequiredFieldsEmpty,
     ~paymentType=paymentMethod,
   )
-  SubscriptionEventHooks.useFormStatus(
+  SubscriptionEventHooks.useEmitFormStatus(
     ~empty=areRequiredFieldsEmpty,
     ~complete=areRequiredFieldsValid && !areRequiredFieldsEmpty,
   )

--- a/src/Payments/InstantBankTransferFinland.res
+++ b/src/Payments/InstantBankTransferFinland.res
@@ -24,6 +24,10 @@ let make = () => {
     ~empty=areRequiredFieldsEmpty,
     ~paymentType=paymentMethod,
   )
+  SubscriptionEventHooks.useFormStatus(
+    ~empty=areRequiredFieldsEmpty,
+    ~complete=areRequiredFieldsValid && !areRequiredFieldsEmpty,
+  )
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/InstantBankTransferPoland.res
+++ b/src/Payments/InstantBankTransferPoland.res
@@ -24,7 +24,7 @@ let make = () => {
     ~empty=areRequiredFieldsEmpty,
     ~paymentType=paymentMethod,
   )
-  SubscriptionEventHooks.useFormStatus(
+  SubscriptionEventHooks.useEmitFormStatus(
     ~empty=areRequiredFieldsEmpty,
     ~complete=areRequiredFieldsValid && !areRequiredFieldsEmpty,
   )

--- a/src/Payments/InstantBankTransferPoland.res
+++ b/src/Payments/InstantBankTransferPoland.res
@@ -24,6 +24,10 @@ let make = () => {
     ~empty=areRequiredFieldsEmpty,
     ~paymentType=paymentMethod,
   )
+  SubscriptionEventHooks.useFormStatus(
+    ~empty=areRequiredFieldsEmpty,
+    ~complete=areRequiredFieldsValid && !areRequiredFieldsEmpty,
+  )
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/KlarnaSDK.res
+++ b/src/Payments/KlarnaSDK.res
@@ -46,7 +46,6 @@ let make = (~sessionObj: SessionsType.token) => {
     ~paymentType="klarna",
   )
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   let {country, state, pinCode} = PaymentUtils.useNonPiiAddressData()
 
   React.useEffect(() => {
@@ -77,15 +76,13 @@ let make = (~sessionObj: SessionsType.token) => {
                 ~eventName=KLARNA_SDK_FLOW,
                 ~paymentMethod="KLARNA",
               )
-              if isLegacy {
-                emitPaymentMethodInfo(
-                  ~paymentMethod="wallet",
-                  ~paymentMethodType="klarna",
-                  ~country,
-                  ~state,
-                  ~pinCode,
-                )
-              }
+              PaymentUtils.emitPaymentMethodInfo(
+                ~paymentMethod="wallet",
+                ~paymentMethodType="klarna",
+                ~country,
+                ~state,
+                ~pinCode,
+              )
               emitter.emitPaymentMethodStatus(
                 ~paymentMethod="wallet",
                 ~paymentMethodType="klarna",

--- a/src/Payments/KlarnaSDK.res
+++ b/src/Payments/KlarnaSDK.res
@@ -45,6 +45,8 @@ let make = (~sessionObj: SessionsType.token) => {
     ~empty=!isCompleted,
     ~paymentType="klarna",
   )
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   let {country, state, pinCode} = PaymentUtils.useNonPiiAddressData()
 
   React.useEffect(() => {
@@ -75,13 +77,22 @@ let make = (~sessionObj: SessionsType.token) => {
                 ~eventName=KLARNA_SDK_FLOW,
                 ~paymentMethod="KLARNA",
               )
-              PaymentUtils.emitPaymentMethodInfo(
+              if isLegacy {
+                emitPaymentMethodInfo(
+                  ~paymentMethod="wallet",
+                  ~paymentMethodType="klarna",
+                  ~country,
+                  ~state,
+                  ~pinCode,
+                )
+              }
+              emitter.emitPaymentMethodStatus(
                 ~paymentMethod="wallet",
                 ~paymentMethodType="klarna",
-                ~country,
-                ~state,
-                ~pinCode,
+                ~isSavedPaymentMethod=false,
+                ~isOneClickWallet=true,
               )
+              emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
               makeOneClickHandlerPromise(sdkHandleIsThere)->then(
                 result => {
                   let result = result->JSON.Decode.bool->Option.getOr(false)

--- a/src/Payments/PayPal.res
+++ b/src/Payments/PayPal.res
@@ -68,6 +68,13 @@ let make = (~walletOptions) => {
     ~empty=!paypalClicked,
     ~paymentType=paymentMethodType,
   )
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
+  SubscriptionEventHooks.useFormStatus(
+    ~empty=!paypalClicked,
+    ~complete=paypalClicked,
+    ~isOneClickWallet=isWallet,
+  )
   let onPaypalClick = _ev => {
     if isTestMode {
       Console.warn("PayPal button clicked in test mode - interaction disabled")
@@ -82,13 +89,16 @@ let make = (~walletOptions) => {
         ~eventName=PAYPAL_FLOW,
         ~paymentMethod="PAYPAL",
       )
-      PaymentUtils.emitPaymentMethodInfo(
+      if isLegacy {
+        emitPaymentMethodInfo(~paymentMethod, ~paymentMethodType, ~country, ~state, ~pinCode)
+      }
+      emitter.emitPaymentMethodStatus(
         ~paymentMethod,
         ~paymentMethodType,
-        ~country,
-        ~state,
-        ~pinCode,
+        ~isSavedPaymentMethod=false,
+        ~isOneClickWallet=isWallet,
       )
+      emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
       setPaypalClicked(_ => true)
       open Promise
       Utils.makeOneClickHandlerPromise(sdkHandleIsThere)

--- a/src/Payments/PayPal.res
+++ b/src/Payments/PayPal.res
@@ -69,7 +69,6 @@ let make = (~walletOptions) => {
     ~paymentType=paymentMethodType,
   )
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   SubscriptionEventHooks.useEmitFormStatus(
     ~empty=!paypalClicked,
     ~complete=paypalClicked,
@@ -89,9 +88,13 @@ let make = (~walletOptions) => {
         ~eventName=PAYPAL_FLOW,
         ~paymentMethod="PAYPAL",
       )
-      if isLegacy {
-        emitPaymentMethodInfo(~paymentMethod, ~paymentMethodType, ~country, ~state, ~pinCode)
-      }
+      PaymentUtils.emitPaymentMethodInfo(
+        ~paymentMethod,
+        ~paymentMethodType,
+        ~country,
+        ~state,
+        ~pinCode,
+      )
       emitter.emitPaymentMethodStatus(
         ~paymentMethod,
         ~paymentMethodType,

--- a/src/Payments/PayPal.res
+++ b/src/Payments/PayPal.res
@@ -70,7 +70,7 @@ let make = (~walletOptions) => {
   )
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
   let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
-  SubscriptionEventHooks.useFormStatus(
+  SubscriptionEventHooks.useEmitFormStatus(
     ~empty=!paypalClicked,
     ~complete=paypalClicked,
     ~isOneClickWallet=isWallet,

--- a/src/Payments/PaymentMethodsWrapper.res
+++ b/src/Payments/PaymentMethodsWrapper.res
@@ -56,7 +56,7 @@ let make = (~paymentMethodName: string) => {
     ~empty,
     ~paymentType=paymentMethodDetails.paymentMethodName,
   )
-  SubscriptionEventHooks.useFormStatus(~empty, ~complete=areRequiredFieldsValid)
+  SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete=areRequiredFieldsValid)
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/PaymentMethodsWrapper.res
+++ b/src/Payments/PaymentMethodsWrapper.res
@@ -56,6 +56,7 @@ let make = (~paymentMethodName: string) => {
     ~empty,
     ~paymentType=paymentMethodDetails.paymentMethodName,
   )
+  SubscriptionEventHooks.useFormStatus(~empty, ~complete=areRequiredFieldsValid)
 
   let submitCallback = React.useCallback((ev: Window.event) => {
     let json = ev.data->safeParse

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -36,6 +36,8 @@ let make = (~sessionObj: SessionsType.token) => {
   let isTestMode = Recoil.useRecoilValueFromAtom(RecoilAtoms.isTestMode)
 
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {isLegacy} = SubscriptionEventHooks.useLegacyEvents()
 
   let buttonStyle = switch options.wallets.payPal {
   | PaypalConfigObj(cfg) =>
@@ -183,6 +185,8 @@ let make = (~sessionObj: SessionsType.token) => {
         ~isTestMode,
         ~nonPiiAdderessData,
         ~sdkAuthorization,
+        ~emitter,
+        ~isLegacy,
       )
     })
     Window.body->Window.appendChild(paypalScript)

--- a/src/Payments/PaypalSDK.res
+++ b/src/Payments/PaypalSDK.res
@@ -37,7 +37,6 @@ let make = (~sessionObj: SessionsType.token) => {
 
   let options = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {isLegacy} = SubscriptionEventHooks.useLegacyEvents()
 
   let buttonStyle = switch options.wallets.payPal {
   | PaypalConfigObj(cfg) =>
@@ -186,7 +185,6 @@ let make = (~sessionObj: SessionsType.token) => {
         ~nonPiiAdderessData,
         ~sdkAuthorization,
         ~emitter,
-        ~isLegacy,
       )
     })
     Window.body->Window.appendChild(paypalScript)

--- a/src/Payments/PaypalSDKHelpers.res
+++ b/src/Payments/PaypalSDKHelpers.res
@@ -28,6 +28,8 @@ let loadPaypalSDK = (
   ~isTestMode=false,
   ~nonPiiAdderessData: PaymentUtils.nonPiiAdderessData,
   ~sdkAuthorization,
+  ~emitter: SubscriptionEventHooks.emitter,
+  ~isLegacy: bool,
 ) => {
   open Promise
 
@@ -64,13 +66,22 @@ let loadPaypalSDK = (
         resolve("")
       } else {
         let {country, state, pinCode} = nonPiiAdderessData
-        PaymentUtils.emitPaymentMethodInfo(
+        if isLegacy {
+          PaymentUtils.emitPaymentMethodInfo(
+            ~paymentMethod="wallet",
+            ~paymentMethodType="paypal",
+            ~country,
+            ~state,
+            ~pinCode,
+          )
+        }
+        emitter.emitPaymentMethodStatus(
           ~paymentMethod="wallet",
           ~paymentMethodType="paypal",
-          ~country,
-          ~state,
-          ~pinCode,
+          ~isSavedPaymentMethod=false,
+          ~isOneClickWallet=true,
         )
+        emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
         makeOneClickHandlerPromise(sdkHandleIsThere)->then(result => {
           let result = result->JSON.Decode.bool->Option.getOr(false)
           if result {

--- a/src/Payments/PaypalSDKHelpers.res
+++ b/src/Payments/PaypalSDKHelpers.res
@@ -29,7 +29,6 @@ let loadPaypalSDK = (
   ~nonPiiAdderessData: PaymentUtils.nonPiiAdderessData,
   ~sdkAuthorization,
   ~emitter: SubscriptionEventHooks.emitter,
-  ~isLegacy: bool,
 ) => {
   open Promise
 
@@ -66,15 +65,13 @@ let loadPaypalSDK = (
         resolve("")
       } else {
         let {country, state, pinCode} = nonPiiAdderessData
-        if isLegacy {
-          PaymentUtils.emitPaymentMethodInfo(
-            ~paymentMethod="wallet",
-            ~paymentMethodType="paypal",
-            ~country,
-            ~state,
-            ~pinCode,
-          )
-        }
+        PaymentUtils.emitPaymentMethodInfo(
+          ~paymentMethod="wallet",
+          ~paymentMethodType="paypal",
+          ~country,
+          ~state,
+          ~pinCode,
+        )
         emitter.emitPaymentMethodStatus(
           ~paymentMethod="wallet",
           ~paymentMethodType="paypal",

--- a/src/Payments/PazeButton.res
+++ b/src/Payments/PazeButton.res
@@ -12,6 +12,8 @@ let make = (~token: SessionsType.token) => {
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
   let updateSession = Recoil.useRecoilValueFromAtom(updateSession)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
@@ -38,13 +40,22 @@ let make = (~token: SessionsType.token) => {
         ~eventName=PAZE_SDK_FLOW,
         ~paymentMethod="PAZE",
       )
-      PaymentUtils.emitPaymentMethodInfo(
+      if isLegacy {
+        emitPaymentMethodInfo(
+          ~paymentMethod="wallet",
+          ~paymentMethodType="paze",
+          ~country,
+          ~state,
+          ~pinCode,
+        )
+      }
+      emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="paze",
-        ~country,
-        ~state,
-        ~pinCode,
+        ~isSavedPaymentMethod=false,
+        ~isOneClickWallet=true,
       )
+      emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
       setShowLoader(_ => true)
       let metadata =
         [

--- a/src/Payments/PazeButton.res
+++ b/src/Payments/PazeButton.res
@@ -13,7 +13,6 @@ let make = (~token: SessionsType.token) => {
   let updateSession = Recoil.useRecoilValueFromAtom(updateSession)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let isManualRetryEnabled = Recoil.useRecoilValueFromAtom(isManualRetryEnabled)
@@ -40,15 +39,13 @@ let make = (~token: SessionsType.token) => {
         ~eventName=PAZE_SDK_FLOW,
         ~paymentMethod="PAZE",
       )
-      if isLegacy {
-        emitPaymentMethodInfo(
-          ~paymentMethod="wallet",
-          ~paymentMethodType="paze",
-          ~country,
-          ~state,
-          ~pinCode,
-        )
-      }
+      PaymentUtils.emitPaymentMethodInfo(
+        ~paymentMethod="wallet",
+        ~paymentMethodType="paze",
+        ~country,
+        ~state,
+        ~pinCode,
+      )
       emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="paze",

--- a/src/Payments/SamsungPayComponent.res
+++ b/src/Payments/SamsungPayComponent.res
@@ -8,7 +8,6 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
-  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   let updateSession = Recoil.useRecoilValueFromAtom(updateSession)
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
   let areOneClickWalletsRendered = Recoil.useSetRecoilState(areOneClickWalletsRendered)
@@ -47,15 +46,13 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
         ~eventName=SAMSUNG_PAY,
         ~paymentMethod="SAMSUNG_PAY",
       )
-      if isLegacy {
-        emitPaymentMethodInfo(
-          ~paymentMethod="wallet",
-          ~paymentMethodType="samsung_pay",
-          ~country,
-          ~state,
-          ~pinCode,
-        )
-      }
+      PaymentUtils.emitPaymentMethodInfo(
+        ~paymentMethod="wallet",
+        ~paymentMethodType="samsung_pay",
+        ~country,
+        ~state,
+        ~pinCode,
+      )
       emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="samsung_pay",

--- a/src/Payments/SamsungPayComponent.res
+++ b/src/Payments/SamsungPayComponent.res
@@ -7,6 +7,8 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
   let isSamsungPayReady = Recoil.useRecoilValueFromAtom(isSamsungPayReady)
   let loggerState = Recoil.useRecoilValueFromAtom(loggerAtom)
   let options = Recoil.useRecoilValueFromAtom(optionAtom)
+  let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
+  let {isLegacy, emitPaymentMethodInfo} = SubscriptionEventHooks.useLegacyEvents()
   let updateSession = Recoil.useRecoilValueFromAtom(updateSession)
   let setIsShowOrPayUsing = Recoil.useSetRecoilState(isShowOrPayUsing)
   let areOneClickWalletsRendered = Recoil.useSetRecoilState(areOneClickWalletsRendered)
@@ -45,13 +47,22 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
         ~eventName=SAMSUNG_PAY,
         ~paymentMethod="SAMSUNG_PAY",
       )
-      PaymentUtils.emitPaymentMethodInfo(
+      if isLegacy {
+        emitPaymentMethodInfo(
+          ~paymentMethod="wallet",
+          ~paymentMethodType="samsung_pay",
+          ~country,
+          ~state,
+          ~pinCode,
+        )
+      }
+      emitter.emitPaymentMethodStatus(
         ~paymentMethod="wallet",
         ~paymentMethodType="samsung_pay",
-        ~country,
-        ~state,
-        ~pinCode,
+        ~isSavedPaymentMethod=false,
+        ~isOneClickWallet=true,
       )
+      emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
       SamsungPayHelpers.handleSamsungPayClicked(
         ~sessionObj=sessionObj->Option.getOr(JSON.Encode.null)->getDictFromJson,
         ~componentName,

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -263,6 +263,7 @@ type options = {
   business: business,
   customerPaymentMethods: savedCardsLoadState,
   paymentMethodOrder: option<array<string>>,
+  subscriptionEvents: option<array<PaymentEventTypes.events>>,
   displaySavedPaymentMethodsCheckbox: bool,
   displaySavedPaymentMethods: bool,
   savedPaymentMethodsCheckboxCheckedByDefault: bool,
@@ -460,6 +461,7 @@ let defaultOptions = {
   customerPaymentMethods: LoadingSavedCards,
   layout: ObjectLayout(defaultLayout),
   paymentMethodOrder: None,
+  subscriptionEvents: None,
   fields: defaultFields,
   displaySavedPaymentMethodsCheckbox: true,
   displaySavedPaymentMethods: true,
@@ -1688,6 +1690,7 @@ let itemToObjMapper = (dict, logger: HyperLoggerTypes.loggerMake) => {
     layout: getLayout(dict, "layout", logger),
     customerPaymentMethods: getCustomerMethods(dict, "customerPaymentMethods"),
     paymentMethodOrder: getOptionalStrArray(dict, "paymentMethodOrder"),
+    subscriptionEvents: SubscriptionEventTypes.getSubscriptionEvents(dict, "subscriptionEvents"),
     fields: getFields(dict, "fields", logger),
     branding: getWarningString(dict, "branding", "auto", ~logger)->getShowType("options.branding"),
     displaySavedPaymentMethodsCheckbox: getBoolWithWarning(

--- a/src/Types/SubscriptionEventTypes.res
+++ b/src/Types/SubscriptionEventTypes.res
@@ -1,23 +1,11 @@
 open ErrorUtils
 open PaymentEventTypes
 
-let validSubscriptionEvents = [
-  "PAYMENT_METHOD_INFO_CARD",
-  "PAYMENT_METHOD_STATUS",
-  "FORM_STATUS",
-  "PAYMENT_METHOD_INFO_BILLING_ADDRESS",
-  "CVC_STATUS",
-  "SURCHARGE",
-]
+let validSubscriptionEvents = ["surchargeInfo"]
 
 let stringToEvent = (str, key) =>
   switch str {
-  | "PAYMENT_METHOD_INFO_CARD" => PaymentMethodInfoCard
-  | "PAYMENT_METHOD_STATUS" => PaymentMethodStatus
-  | "FORM_STATUS" => FormStatus
-  | "PAYMENT_METHOD_INFO_BILLING_ADDRESS" => PaymentMethodInfoBillingAddress
-  | "CVC_STATUS" => CvcStatus
-  | "SURCHARGE" => Surcharge
+  | "surchargeInfo" => Surcharge
   | _ => {
       str->unknownPropValueWarning(validSubscriptionEvents, key)
       UnknownEvent
@@ -143,7 +131,7 @@ let createSurchargePayload = (
   let payload = PaymentEventData.surchargeEventToJson(event)
   [
     ("elementType", "payment"->JSON.Encode.string),
-    ("eventName", Surcharge->eventToString->JSON.Encode.string),
+    ("eventName", "surchargeInfo"->JSON.Encode.string),
     ("payload", payload),
   ]
 }

--- a/src/Types/SubscriptionEventTypes.res
+++ b/src/Types/SubscriptionEventTypes.res
@@ -37,7 +37,10 @@ let getSubscriptionEvents = (dict, key) => {
     ->Array.map(item =>
       switch JSON.Decode.string(item) {
       | Some(str) => stringToEvent(str, context)
-      | None => UnknownEvent
+      | None => {
+          item->JSON.stringify->unknownPropValueWarning(validSubscriptionEvents, context)
+          UnknownEvent
+        }
       }
     )
     ->Array.filter(opt => opt != UnknownEvent)

--- a/src/Types/SubscriptionEventTypes.res
+++ b/src/Types/SubscriptionEventTypes.res
@@ -1,0 +1,146 @@
+open ErrorUtils
+open PaymentEventTypes
+
+let validSubscriptionEvents = [
+  "PAYMENT_METHOD_INFO_CARD",
+  "PAYMENT_METHOD_STATUS",
+  "FORM_STATUS",
+  "PAYMENT_METHOD_INFO_BILLING_ADDRESS",
+  "CVC_STATUS",
+  "SURCHARGE",
+]
+
+let stringToEvent = (str, key) =>
+  switch str {
+  | "PAYMENT_METHOD_INFO_CARD" => PaymentMethodInfoCard
+  | "PAYMENT_METHOD_STATUS" => PaymentMethodStatus
+  | "FORM_STATUS" => FormStatus
+  | "PAYMENT_METHOD_INFO_BILLING_ADDRESS" => PaymentMethodInfoBillingAddress
+  | "CVC_STATUS" => CvcStatus
+  | "SURCHARGE" => Surcharge
+  | _ => {
+      str->unknownPropValueWarning(validSubscriptionEvents, key)
+      UnknownEvent
+    }
+  }
+
+let getSubscriptionEvents = (dict, key) => {
+  let context = `options.${key}`
+  let subscriptionList =
+    dict
+    ->Dict.get(key)
+    ->Option.flatMap(JSON.Decode.array)
+    ->Option.getOr([])
+
+  let mappedSubscriptionEvents =
+    subscriptionList
+    ->Array.map(item =>
+      switch JSON.Decode.string(item) {
+      | Some(str) => stringToEvent(str, context)
+      | None => UnknownEvent
+      }
+    )
+    ->Array.filter(opt => opt != UnknownEvent)
+
+  if mappedSubscriptionEvents->Array.length === 0 {
+    None
+  } else {
+    Some(mappedSubscriptionEvents)
+  }
+}
+
+type paymentMethodStatus = {
+  paymentMethod: string,
+  paymentMethodType: string,
+  isSavedPaymentMethod: bool,
+  isOneClickWallet: bool,
+}
+
+type billingAddress = {
+  country: string,
+  state: string,
+  postalCode: string,
+}
+let createCardInfoPayload = (cardInfo: PaymentEventData.cardInfo) => {
+  let payload = PaymentEventData.cardInfoToJson(cardInfo)
+  [
+    ("elementType", "payment"->JSON.Encode.string),
+    ("eventName", PaymentMethodInfoCard->PaymentEventTypes.eventToString->JSON.Encode.string),
+    ("payload", payload),
+  ]
+}
+
+let createFormStatusPayload = (~status) => {
+  let payload = PaymentEventData.formStatusEventToJson(~status)
+  [
+    ("elementType", "payment"->JSON.Encode.string),
+    ("eventName", FormStatus->eventToString->JSON.Encode.string),
+    ("payload", payload),
+  ]
+}
+
+let createPaymentMethodStatusPayload = (
+  ~paymentMethod,
+  ~paymentMethodType,
+  ~isSavedPaymentMethod,
+  ~isOneClickWallet=false,
+) => {
+  let payload = PaymentEventData.paymentMethodStatusEventToJson(
+    ~paymentMethod,
+    ~paymentMethodType,
+    ~isSavedPaymentMethod,
+    ~isOneClickWallet,
+  )
+
+  [
+    ("elementType", "payment"->JSON.Encode.string),
+    ("eventName", PaymentMethodStatus->eventToString->JSON.Encode.string),
+    ("payload", payload),
+  ]
+}
+
+let createBillingAddressPayload = (~country, ~state, ~postalCode) => {
+  let payload = PaymentEventData.paymentMethodInfoAddressToJson(~country, ~state, ~postalCode)
+
+  [
+    ("elementType", "payment"->JSON.Encode.string),
+    ("eventName", PaymentMethodInfoBillingAddress->eventToString->JSON.Encode.string),
+    ("payload", payload),
+  ]
+}
+
+let createCvcStatusPayload = (~iframeId, ~isCvcEmpty, ~isCvcComplete) => {
+  let event = PaymentEventData.buildCvcStatusEvent(~isCvcEmpty, ~isCvcComplete)
+  let payload = PaymentEventData.cvcStatusEventToJson(event)
+  [
+    ("elementType", "cardCvc"->JSON.Encode.string),
+    ("iframeId", iframeId->JSON.Encode.string),
+    ("eventName", CvcStatus->PaymentEventTypes.eventToString->JSON.Encode.string),
+    ("payload", payload),
+  ]
+}
+
+let createSurchargePayload = (
+  ~surchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+) => {
+  let event = switch surchargeDetails {
+  | Some(details) =>
+    PaymentEventData.buildSurchargeEvent(
+      ~surcharge={
+        \"type": details.surcharge.\"type",
+        value: details.surcharge.value,
+      },
+      ~taxOnSurcharge=details.taxOnSurcharge,
+      ~displaySurchargeAmount=details.displaySurchargeAmount,
+      ~displayTaxOnSurchargeAmount=details.displayTaxOnSurchargeAmount,
+      ~displayTotalSurchargeAmount=details.displayTotalSurchargeAmount,
+    )
+  | None => PaymentEventData.buildSurchargeEvent(~surcharge={\"type": "", value: 0.0})
+  }
+  let payload = PaymentEventData.surchargeEventToJson(event)
+  [
+    ("elementType", "payment"->JSON.Encode.string),
+    ("eventName", Surcharge->eventToString->JSON.Encode.string),
+    ("payload", payload),
+  ]
+}

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -769,7 +769,6 @@ let useEmitPaymentMethodInfo = (
   ~cardProps: CardUtils.cardProps,
   ~expiryProps: CardUtils.expiryProps,
   ~cvcProps: CardUtils.cvcProps,
-  ~isLegacy: bool,
 ) => {
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
   let {country, state, pinCode} = useNonPiiAddressData()
@@ -785,24 +784,22 @@ let useEmitPaymentMethodInfo = (
   let shouldEmitCardInfo = isCardValid && isExpiryValid && paymentMethodName == "card"
 
   let emitPaymentMethodInfoWrapper = (~paymentMethod, ~paymentMethodType) => {
-    if isLegacy {
-      if shouldEmitCardInfo {
-        emitPaymentMethodInfo(
-          ~paymentMethod=paymentMethodName,
-          ~paymentMethodType,
-          ~cardBrand=cardBrand->CardUtils.getCardType,
-          ~cardLast4,
-          ~cardBin,
-          ~cardExpiryMonth,
-          ~cardExpiryYear,
-          ~country,
-          ~state,
-          ~pinCode,
-          ~isCvcEmpty,
-        )
-      } else {
-        emitPaymentMethodInfo(~paymentMethod, ~paymentMethodType, ~country, ~state, ~pinCode)
-      }
+    if shouldEmitCardInfo {
+      emitPaymentMethodInfo(
+        ~paymentMethod=paymentMethodName,
+        ~paymentMethodType,
+        ~cardBrand=cardBrand->CardUtils.getCardType,
+        ~cardLast4,
+        ~cardBin,
+        ~cardExpiryMonth,
+        ~cardExpiryYear,
+        ~country,
+        ~state,
+        ~pinCode,
+        ~isCvcEmpty,
+      )
+    } else {
+      emitPaymentMethodInfo(~paymentMethod, ~paymentMethodType, ~country, ~state, ~pinCode)
     }
   }
 
@@ -856,7 +853,6 @@ let useEmitPaymentMethodInfo = (
     country,
     state,
     pinCode,
-    isLegacy,
   ))
 }
 

--- a/src/Utilities/PaymentUtils.res
+++ b/src/Utilities/PaymentUtils.res
@@ -769,6 +769,7 @@ let useEmitPaymentMethodInfo = (
   ~cardProps: CardUtils.cardProps,
   ~expiryProps: CardUtils.expiryProps,
   ~cvcProps: CardUtils.cvcProps,
+  ~isLegacy: bool,
 ) => {
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
   let {country, state, pinCode} = useNonPiiAddressData()
@@ -784,22 +785,24 @@ let useEmitPaymentMethodInfo = (
   let shouldEmitCardInfo = isCardValid && isExpiryValid && paymentMethodName == "card"
 
   let emitPaymentMethodInfoWrapper = (~paymentMethod, ~paymentMethodType) => {
-    if shouldEmitCardInfo {
-      emitPaymentMethodInfo(
-        ~paymentMethod=paymentMethodName,
-        ~paymentMethodType,
-        ~cardBrand=cardBrand->CardUtils.getCardType,
-        ~cardLast4,
-        ~cardBin,
-        ~cardExpiryMonth,
-        ~cardExpiryYear,
-        ~country,
-        ~state,
-        ~pinCode,
-        ~isCvcEmpty,
-      )
-    } else {
-      emitPaymentMethodInfo(~paymentMethod, ~paymentMethodType, ~country, ~state, ~pinCode)
+    if isLegacy {
+      if shouldEmitCardInfo {
+        emitPaymentMethodInfo(
+          ~paymentMethod=paymentMethodName,
+          ~paymentMethodType,
+          ~cardBrand=cardBrand->CardUtils.getCardType,
+          ~cardLast4,
+          ~cardBin,
+          ~cardExpiryMonth,
+          ~cardExpiryYear,
+          ~country,
+          ~state,
+          ~pinCode,
+          ~isCvcEmpty,
+        )
+      } else {
+        emitPaymentMethodInfo(~paymentMethod, ~paymentMethodType, ~country, ~state, ~pinCode)
+      }
     }
   }
 
@@ -853,6 +856,7 @@ let useEmitPaymentMethodInfo = (
     country,
     state,
     pinCode,
+    isLegacy,
   ))
 }
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1643,7 +1643,7 @@ let expressCheckoutComponents = [
 let spmComponents = ["paymentMethodCollect"]->Array.concat(expressCheckoutComponents)
 
 let componentsForPaymentElementCreate =
-  ["payment", "paymentMethodCollect", "paymentMethodsManagement", "cardCvc"]->Array.concat(
+  ["payment", "paymentMethodCollect", "paymentMethodsManagement"]->Array.concat(
     expressCheckoutComponents,
   )
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1644,7 +1644,7 @@ let expressCheckoutComponents = [
 let spmComponents = ["paymentMethodCollect"]->Array.concat(expressCheckoutComponents)
 
 let componentsForPaymentElementCreate =
-  ["payment", "paymentMethodCollect", "paymentMethodsManagement"]->Array.concat(
+  ["payment", "paymentMethodCollect", "paymentMethodsManagement", "cardCvc"]->Array.concat(
     expressCheckoutComponents,
   )
 

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -809,7 +809,6 @@ let handlePostMessageEvents = (
   }
   messageParentWindow([
     ("elementType", "payment"->JSON.Encode.string),
-    ("iframeId", iframeId->JSON.Encode.string),
     ("complete", complete->JSON.Encode.bool),
     ("empty", empty->JSON.Encode.bool),
     ("value", [("type", paymentType->JSON.Encode.string)]->getJsonFromArrayOfJson),

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -43,16 +43,30 @@ let messageCurrentWindow = (~targetOrigin="*", messageArr) => {
   window->messageWindow(~targetOrigin, messageArr)
 }
 
-let handleOnFocusPostMessage = (~targetOrigin="*") => {
-  messageParentWindow([("focus", true->JSON.Encode.bool)], ~targetOrigin)
+let handleOnFocusPostMessage = (~iframeId, ~elementType, ~targetOrigin="*") => {
+  messageParentWindow(
+    [
+      ("focus", true->JSON.Encode.bool),
+      ("elementType", elementType->JSON.Encode.string),
+      ("iframeId", iframeId->JSON.Encode.string),
+    ],
+    ~targetOrigin,
+  )
 }
 
 let handleOnCompleteDoThisMessage = (~targetOrigin="*") => {
   messageParentWindow([("completeDoThis", true->JSON.Encode.bool)], ~targetOrigin)
 }
 
-let handleOnBlurPostMessage = (~targetOrigin="*") => {
-  messageParentWindow([("blur", true->JSON.Encode.bool)], ~targetOrigin)
+let handleOnBlurPostMessage = (~iframeId, ~elementType, ~targetOrigin="*") => {
+  messageParentWindow(
+    [
+      ("blur", true->JSON.Encode.bool),
+      ("elementType", elementType->JSON.Encode.string),
+      ("iframeId", iframeId->JSON.Encode.string),
+    ],
+    ~targetOrigin,
+  )
 }
 
 let handleOnClickPostMessage = (~targetOrigin="*", ev) => {
@@ -780,6 +794,7 @@ let validateRountingNumber = str => {
 }
 
 let handlePostMessageEvents = (
+  ~iframeId,
   ~complete,
   ~empty,
   ~paymentType,
@@ -794,6 +809,7 @@ let handlePostMessageEvents = (
   }
   messageParentWindow([
     ("elementType", "payment"->JSON.Encode.string),
+    ("iframeId", iframeId->JSON.Encode.string),
     ("complete", complete->JSON.Encode.bool),
     ("empty", empty->JSON.Encode.bool),
     ("value", [("type", paymentType->JSON.Encode.string)]->getJsonFromArrayOfJson),
@@ -1470,6 +1486,19 @@ let rec flatten = (obj, addIndicatorForObject) => {
   newDict
 }
 
+external eventDataFromJson: JSON.t => Types.eventData = "%identity"
+
+let sanitizeEventData = (data: Types.eventData): Types.eventData => {
+  let dict = data->anyTypeToJson->getDictFromJson
+  let isCompleteEvent = dict->Dict.get("complete")->Option.isSome
+  dict
+  ->Dict.toArray
+  ->Array.filter(((key, _)) => key !== "iframeId" && (isCompleteEvent || key !== "elementType"))
+  ->Dict.fromArray
+  ->JSON.Encode.object
+  ->eventDataFromJson
+}
+
 let eventHandlerFunc = (
   condition: Types.event => bool,
   eventHandler,
@@ -1488,7 +1517,7 @@ let eventHandlerFunc = (
       | OneClickConfirmPayment
       | Blur =>
         switch eventHandler {
-        | Some(eH) => eH(Some(ev.data))
+        | Some(eH) => eH(Some(sanitizeEventData(ev.data)))
         | None => ()
         }
       | _ => ()

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -437,16 +437,17 @@ let make = (
           ->Dict.get("subscriptionEvents")
           ->Option.getOr(JSON.Encode.null)
 
-        let widgetOptions = [
-          ("clientSecret", clientSecretRef.contents->JSON.Encode.string),
-          ("sdkAuthorization", sdkAuthorizationRef.contents->JSON.Encode.string),
-          ("appearance", appearance),
-          ("locale", locale),
-          ("loader", loader),
-          ("fonts", fonts),
-          ("redirectionFlags", redirectionFlagsDict->JSON.Encode.object),
-          ("subscriptionEvents", subscriptionEventsVal),
-        ]->getJsonFromArrayOfJson
+        let widgetOptions =
+          [
+            ("clientSecret", clientSecretRef.contents->JSON.Encode.string),
+            ("sdkAuthorization", sdkAuthorizationRef.contents->JSON.Encode.string),
+            ("appearance", appearance),
+            ("locale", locale),
+            ("loader", loader),
+            ("fonts", fonts),
+            ("redirectionFlags", redirectionFlagsDict->JSON.Encode.object),
+            ("subscriptionEvents", subscriptionEventsVal),
+          ]->getJsonFromArrayOfJson
         let message = [
           (
             "paymentElementCreate",

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -431,6 +431,12 @@ let make = (
             ),
           ]->Dict.fromArray
 
+        let subscriptionEventsVal =
+          newOptions
+          ->getDictFromJson
+          ->Dict.get("subscriptionEvents")
+          ->Option.getOr(JSON.Encode.null)
+
         let widgetOptions = [
           ("clientSecret", clientSecretRef.contents->JSON.Encode.string),
           ("sdkAuthorization", sdkAuthorizationRef.contents->JSON.Encode.string),
@@ -439,13 +445,7 @@ let make = (
           ("loader", loader),
           ("fonts", fonts),
           ("redirectionFlags", redirectionFlagsDict->JSON.Encode.object),
-          (
-            "subscriptionEvents",
-            newOptions
-            ->getDictFromJson
-            ->Dict.get("subscriptionEvents")
-            ->Option.getOr(JSON.Encode.null),
-          ),
+          ("subscriptionEvents", subscriptionEventsVal),
         ]->getJsonFromArrayOfJson
         let message = [
           (

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -431,16 +431,22 @@ let make = (
             ),
           ]->Dict.fromArray
 
-        let widgetOptions =
-          [
-            ("clientSecret", clientSecretRef.contents->JSON.Encode.string),
-            ("sdkAuthorization", sdkAuthorizationRef.contents->JSON.Encode.string),
-            ("appearance", appearance),
-            ("locale", locale),
-            ("loader", loader),
-            ("fonts", fonts),
-            ("redirectionFlags", redirectionFlagsDict->JSON.Encode.object),
-          ]->getJsonFromArrayOfJson
+        let widgetOptions = [
+          ("clientSecret", clientSecretRef.contents->JSON.Encode.string),
+          ("sdkAuthorization", sdkAuthorizationRef.contents->JSON.Encode.string),
+          ("appearance", appearance),
+          ("locale", locale),
+          ("loader", loader),
+          ("fonts", fonts),
+          ("redirectionFlags", redirectionFlagsDict->JSON.Encode.object),
+          (
+            "subscriptionEvents",
+            newOptions
+            ->getDictFromJson
+            ->Dict.get("subscriptionEvents")
+            ->Option.getOr(JSON.Encode.null),
+          ),
+        ]->getJsonFromArrayOfJson
         let message = [
           (
             "paymentElementCreate",

--- a/src/hyper-loader/LoaderPaymentElement.res
+++ b/src/hyper-loader/LoaderPaymentElement.res
@@ -254,8 +254,8 @@ let make = (
         )
       | Surcharge =>
         addSubscriptionEventListener(
-          "SURCHARGE",
-          `onSURCHARGE-${componentType}-${elementInstanceId}`,
+          "surchargeInfo",
+          `onSurchargeInfo-${componentType}-${elementInstanceId}`,
         )
       | _ => ()
       }

--- a/src/hyper-loader/LoaderPaymentElement.res
+++ b/src/hyper-loader/LoaderPaymentElement.res
@@ -22,6 +22,9 @@ let buildIframeHtmlString = (~iframeId: string, ~iframeSrc: string, ~additionalS
    style="border: 0px; ${additionalStyle} outline: none;"
    width="100%"
 ></iframe>`
+// Multi-instance support: tracks unmounted element refs so sibling mount() calls can
+// adopt handler-only instances (e.g. React wrapper) that never mount themselves.
+let unclaimedSelectorRefsByType: Dict.t<array<ref<string>>> = Dict.make()
 
 let make = (
   componentType,
@@ -37,6 +40,16 @@ let make = (
   try {
     let logger = logger->Option.getOr(LoggerUtils.defaultLoggerConfig)
     let mountId = ref("")
+    let localSelectorRef = ref("")
+    // Unique per-instance ID to scope event listener names and prevent collisions.
+    let elementInstanceId = generateRandomString(8)
+
+    // Register for sibling adoption — see unclaimedSelectorRefsByType.
+    if componentType->Utils.canHaveMultipleInstances {
+      let refs = unclaimedSelectorRefsByType->Dict.get(componentType)->Option.getOr([])
+      refs->Array.push(localSelectorRef)->ignore
+      unclaimedSelectorRefsByType->Dict.set(componentType, refs)
+    }
     let setPaymentIframeRef = ref => {
       setIframeRef(ref)
     }
@@ -110,6 +123,32 @@ let make = (
     }
 
     let on = (eventType, eventHandler) => {
+      let matchesInstance = (ev: Types.event) => {
+        // Multi-instance: match by elementType + iframeId so events route to the correct instance.
+        if componentType->Utils.canHaveMultipleInstances {
+          ev.data.elementType === componentType && ev.data.iframeId === localSelectorRef.contents
+        } else {
+          ev.data.elementType === componentType
+        }
+      }
+
+      // Subscription event helper: checks eventName in payload, then applies matchesInstance.
+      let addSubscriptionEventListener = (subscriptionEventName, activity) => {
+        addSmartEventListener(
+          "message",
+          (ev: Types.event) => {
+            let json = ev.data->anyTypeToJson
+            let name = json->getOptionalJsonFromJson("eventName")->getStringFromOptionalJson("")
+            if name === subscriptionEventName && matchesInstance(ev) {
+              switch eventHandler {
+              | Some(eH) => eH(Some(sanitizeEventData(ev.data)))
+              | None => ()
+              }
+            }
+          },
+          activity,
+        )
+      }
       switch eventType->eventTypeMapper {
       | Escape =>
         addSmartEventListener(
@@ -117,12 +156,12 @@ let make = (
           (ev: Types.event) => {
             if ev.key === "Escape" {
               switch eventHandler {
-              | Some(eH) => eH(Some(ev.data))
+              | Some(eH) => eH(Some(sanitizeEventData(ev.data)))
               | None => ()
               }
             }
           },
-          "onEscape",
+          `onEscape-${componentType}-${elementInstanceId}`,
         )
       | CompleteDoThis =>
         if eventHandler->Option.isSome {
@@ -130,33 +169,93 @@ let make = (
             ev => ev.data.completeDoThis,
             eventHandler,
             CompleteDoThis,
-            "onCompleteDoThis",
+            `onCompleteDoThis-${componentType}-${elementInstanceId}`,
           )
         }
       | Change =>
         eventHandlerFunc(
-          ev => ev.data.elementType === componentType,
+          ev =>
+            !ev.data.focus &&
+            !ev.data.blur &&
+            !ev.data.ready &&
+            !ev.data.confirmTriggered &&
+            !ev.data.oneClickConfirmTriggered &&
+            matchesInstance(ev),
           eventHandler,
           Change,
-          "onChange",
+          `onChange-${componentType}-${elementInstanceId}`,
         )
-      | Click => eventHandlerFunc(ev => ev.data.clickTriggered, eventHandler, Click, "onClick")
-      | Ready => eventHandlerFunc(ev => ev.data.ready, eventHandler, Ready, "onReady")
-      | Focus => eventHandlerFunc(ev => ev.data.focus, eventHandler, Focus, "onFocus")
-      | Blur => eventHandlerFunc(ev => ev.data.blur, eventHandler, Blur, "onBlur")
+      | Click =>
+        eventHandlerFunc(
+          ev => ev.data.clickTriggered,
+          eventHandler,
+          Click,
+          `onClick-${componentType}-${elementInstanceId}`,
+        )
+      | Ready =>
+        eventHandlerFunc(
+          ev => ev.data.ready && matchesInstance(ev),
+          eventHandler,
+          Ready,
+          `onReady-${componentType}-${elementInstanceId}`,
+        )
+      | Focus =>
+        eventHandlerFunc(
+          ev => ev.data.focus && matchesInstance(ev),
+          eventHandler,
+          Focus,
+          `onFocus-${componentType}-${elementInstanceId}`,
+        )
+      | Blur =>
+        eventHandlerFunc(
+          ev => ev.data.blur && matchesInstance(ev),
+          eventHandler,
+          Blur,
+          `onBlur-${componentType}-${elementInstanceId}`,
+        )
       | ConfirmPayment =>
         eventHandlerFunc(
           ev => ev.data.confirmTriggered,
           eventHandler,
           ConfirmPayment,
-          "onHelpConfirmPayment",
+          `onHelpConfirmPayment-${componentType}-${elementInstanceId}`,
         )
       | OneClickConfirmPayment =>
         eventHandlerFunc(
           ev => ev.data.oneClickConfirmTriggered,
           eventHandler,
           OneClickConfirmPayment,
-          "onHelpOneClickConfirmPayment",
+          `onHelpOneClickConfirmPayment-${componentType}-${elementInstanceId}`,
+        )
+      | CvcStatus =>
+        addSubscriptionEventListener(
+          "CVC_STATUS",
+          `onCVC_STATUS-${componentType}-${elementInstanceId}`,
+        )
+      | FormStatus =>
+        addSubscriptionEventListener(
+          "FORM_STATUS",
+          `onFORM_STATUS-${componentType}-${elementInstanceId}`,
+        )
+      | PaymentMethodInfoCard =>
+        addSubscriptionEventListener(
+          "PAYMENT_METHOD_INFO_CARD",
+          `onPAYMENT_METHOD_INFO_CARD-${componentType}-${elementInstanceId}`,
+        )
+      | PaymentMethodStatus =>
+        addSubscriptionEventListener(
+          "PAYMENT_METHOD_STATUS",
+          `onPAYMENT_METHOD_STATUS-${componentType}-${elementInstanceId}`,
+        )
+      | BillingAddress =>
+        addSubscriptionEventListener(
+          "PAYMENT_METHOD_INFO_BILLING_ADDRESS",
+          `onPAYMENT_METHOD_INFO_BILLING_ADDRESS-${componentType}-${elementInstanceId}`,
+        )
+      | Surcharge =>
+        addSubscriptionEventListener(
+          "SURCHARGE",
+          `onSURCHARGE-${componentType}-${elementInstanceId}`,
         )
       | _ => ()
       }
@@ -235,6 +334,16 @@ let make = (
       mountId := selector
       let localSelectorArr = selector->String.split("#")
       let localSelectorString = localSelectorArr->Array.get(1)->Option.getOr("someString")
+      localSelectorRef := localSelectorString
+
+      // Adopt oldest unmounted sibling so its .on() handlers can resolve this iframeId.
+      if componentType->Utils.canHaveMultipleInstances {
+        let refs = unclaimedSelectorRefsByType->Dict.get(componentType)->Option.getOr([])
+        switch refs->Array.find(r => r.contents === "") {
+        | Some(siblingRef) => siblingRef := localSelectorString
+        | None => ()
+        }
+      }
       let iframeHeightRef = ref(25.0)
       let currentClass = ref("base")
       let fullscreen = ref(false)
@@ -399,7 +508,7 @@ let make = (
           )
         }
       }
-      // Elements that can have multiple instances need unique event listener names per instance
+      // Multi-instance elements need unique listener names per instance.
       let eventListenerActivityName = if componentType->Utils.canHaveMultipleInstances {
         `onMount-${componentType}-${localSelectorString}`
       } else {

--- a/src/hyper-loader/Types.res
+++ b/src/hyper-loader/Types.res
@@ -10,6 +10,7 @@ type eventData = {
   clickTriggered: bool,
   completeDoThis: bool,
   elementType: string,
+  iframeId: string,
   classChange: bool,
   newClassType: string,
   confirmTriggered: bool,
@@ -228,6 +229,12 @@ type eventType =
   | CompleteDoThis
   | ConfirmPayment
   | OneClickConfirmPayment
+  | CvcStatus
+  | FormStatus
+  | PaymentMethodInfoCard
+  | PaymentMethodStatus
+  | BillingAddress
+  | Surcharge
   | None
 
 let eventTypeMapper = event => {
@@ -241,6 +248,12 @@ let eventTypeMapper = event => {
   | "blur" => Blur
   | "confirmTriggered" => ConfirmPayment
   | "oneClickConfirmTriggered" => OneClickConfirmPayment
+  | "CVC_STATUS" => CvcStatus
+  | "FORM_STATUS" => FormStatus
+  | "PAYMENT_METHOD_INFO_CARD" => PaymentMethodInfoCard
+  | "PAYMENT_METHOD_STATUS" => PaymentMethodStatus
+  | "PAYMENT_METHOD_INFO_BILLING_ADDRESS" => BillingAddress
+  | "SURCHARGE" => Surcharge
   | _ => None
   }
 }

--- a/src/hyper-loader/Types.res
+++ b/src/hyper-loader/Types.res
@@ -248,12 +248,7 @@ let eventTypeMapper = event => {
   | "blur" => Blur
   | "confirmTriggered" => ConfirmPayment
   | "oneClickConfirmTriggered" => OneClickConfirmPayment
-  | "CVC_STATUS" => CvcStatus
-  | "FORM_STATUS" => FormStatus
-  | "PAYMENT_METHOD_INFO_CARD" => PaymentMethodInfoCard
-  | "PAYMENT_METHOD_STATUS" => PaymentMethodStatus
-  | "PAYMENT_METHOD_INFO_BILLING_ADDRESS" => BillingAddress
-  | "SURCHARGE" => Surcharge
+  | "surchargeInfo" => Surcharge
   | _ => None
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Introduces a **subscription events system** that allows merchants to opt into specific events via `subscriptionEvents` config option, replacing the old unconditional event emission pattern
- Adds a new **`surchargeInfo`** subscription event that emits the full eligibility surcharge details object when surcharge data changes
- Adds **multi-instance element support** in `LoaderPaymentElement` so multiple payment elements on the same page get correct per-instance event routing
- Migrates all payment components (card, wallets, bank transfers, saved methods) to the new hook-based event emission pattern
- SharedCode Pr:  https://github.com/juspay/hyperswitch-sdk-utils/pull/75
- ##Note: only surchregeInfo is supported

## Subscription Events

Merchants configure which events they want to receive via the `subscriptionEvents` option:
```js
// react integration
export const paymentElementOptions = (layout, extraOptions) => ({
  displayDefaultSavedPaymentIcon: false,
  ...(layout && { layout }),
  subscriptionEvents: [
     "PAYMENT_METHOD_INFO_CARD",
     "PAYMENT_METHOD_STATUS",
     "FORM_STATUS",
     "PAYMENT_METHOD_INFO_BILLING_ADDRESS",
     "CVC_STATUS",
   ],
  wallets: {
    walletReturnUrl: window.location.origin,
    applePay: "auto",
    googlePay: "auto",
    style: {
      theme: "dark",
      type: "default",
      height: 55,
    },
  },
  ...(extraOptions && extraOptions),
});

...


<PaymentElement
                    id="payment-element"
                    onChange={(event) => {
                      console.log("CardElement changed:", event);
                    }}
                    onFocus={(ev) => console.log("CardElement focused", ev)}
                    options={paymentElementOptions(
                      parseLayoutParam(layoutQueryParam),
                      parseOptionsParam(optionsQueryParam),
                    )}
                  />
                  
        
```

```js
// Js integration

widgets = hyper.widgets({
    appearance,
    clientSecret: "xyz",
  });

  const unifiedCheckoutOptions = {
    // layout: {
    //   savedMethodCustomization: {
    //     groupingBehavior: "groupByPaymentMethods",
    //   },
    // },
    subscriptionEvents: ["CVC_STATUS"],
    wallets: {
      walletReturnUrl: "https://example.com/complete",
      //Mandatory parameter for Wallet Flows such as Googlepay, Paypal and Applepay
    },
  };


  const unifiedCheckout = widgets.create("cardCvc", unifiedCheckoutOptions);
  globalWidgets1 = unifiedCheckout;
  unifiedCheckout.mount("#unified-checkout");



  unifiedCheckout.on("CVC_STATUS", (event) => {
    // if (event.complete !== undefined) {
    console.log("change event is", event);
    // console.log("is complete", event.complete);
    // }
  });
```
- If `subscriptionEvents` is not set (or empty), all events are emitted (backward compatible)
- If set to a specific list, only listed events are emitted

## Events Reference

### Existing Events (migrated to subscription system)

| Event Name | `elementType` | Payload Props | Emitted When |
|---|---|---|---|
| `PAYMENT_METHOD_INFO_CARD` | `payment` | `bin` (string\|null), `last4` (string\|null), `brand` (string\|null), `expiryMonth` (string\|null), `expiryYear` (string\|null), `formattedExpiry` (string\|null), `isCardNumberComplete` (bool), `isCvcComplete` (bool), `isExpiryComplete` (bool), `isCardNumberValid` (bool), `isExpiryValid` (bool) | Card input changes (number, expiry, CVC, brand) |
| `PAYMENT_METHOD_STATUS` | `payment` | `paymentMethod` (string), `paymentMethodType` (string), `isSavedPaymentMethod` (bool), `isOneClickWallet` (bool) | Selected payment method changes or wallet button clicked |
| `FORM_STATUS` | `payment` | `status` (string: `"EMPTY"` \| `"FILLING"` \| `"COMPLETE"`) | Form completeness changes (empty/filling/complete) |
| `PAYMENT_METHOD_INFO_BILLING_ADDRESS` | `payment` | `country` (string), `state` (string), `postalCode` (string) | Billing address fields change |
| `CVC_STATUS` | `cardCvc` | `iframeId` (string), `isCvcEmpty` (bool), `isCvcComplete` (bool) | CVC field state changes |

### New Event

| Event Name | `elementType` | Payload Props | Emitted When |
|---|---|---|---|
| `SURCHARGE` | `payment` | `surcharge` (object: `{ type: string, value: number }`), `taxOnSurcharge` (number\|null), `displaySurchargeAmount` (number), `displayTaxOnSurchargeAmount` (number), `displayTotalSurchargeAmount` (number) | Eligibility surcharge details change (card payment, saved card selection) |

### Lifecycle Events (unchanged, always emitted)

| Event | Props | Emitted When |
|---|---|---|
| `ready` | `elementType` (string), `iframeId` (string) | Element iframe finishes loading |
| `focus` | `elementType` (string), `iframeId` (string) | Input field gains focus |
| `blur` | `elementType` (string), `iframeId` (string) | Input field loses focus |
| `change` | `elementType` (string), `iframeId` (string), `complete` (bool), `empty` (bool) | Form state changes (legacy, gated by `isLegacy`) |

## Multi-Instance Support

`LoaderPaymentElement` now supports multiple instances of the same element type on one page:
- Each instance gets a unique `elementInstanceId` to scope event listener activity names
- `matchesInstance` filters events by `elementType` + `iframeId` so events route to the correct instance
- Sibling adoption: handler-only instances (e.g. React wrapper) that never call `.mount()` get their `iframeId` resolved by a sibling's mount

## Backward Compatibility

- When `subscriptionEvents` is not configured, all events fire as before (legacy mode)
- `useLegacyEvents` hook gates old-style unconditional events behind `isLegacy` flag
- All existing `.on()` event types (ready, focus, blur, change, click, confirmPayment, etc.) continue to work

## Files Changed

| Area | Files | Purpose |
|---|---|---|
| Event types & payloads | `PaymentEventTypes.res`, `PaymentEventData.res`, `SubscriptionEventTypes.res` | New `Surcharge` event type, surcharge event builder, JSON encoder, payload creator |
| Event hooks | `SubscriptionEventHooks.res` | `useSubscriptionEventEmitter`, `useEmitFormStatus`, `useEmitBillingAddress`, `useEmitPaymentMethodStatus`, `useEmitSurcharge`, `useLegacyEvents` |
| Loader | `LoaderPaymentElement.res`, `Types.res`, `Elements.res` | Per-instance event routing, subscription event listeners, `subscriptionEvents` passthrough |
| Payment components | `CardPayment.res`, `ApplePay.res`, `GPay.res`, `PayPal.res`, `KlarnaSDK.res`, `SamsungPayComponent.res`, `PazeButton.res`, `PaypalSDKHelpers.res`, bank transfers, `SavedMethods.res`, etc. | Migrated to new hooks, added `useEmitFormStatus`/`useEmitSurcharge` calls |
| Utils | `Utils.res`, `PaymentUtils.res`, `UtilityHooks.res` | `sanitizeEventData`, `iframeId` in focus/blur/postMessage events, `isLegacy` gating |

## How did you test it?

case 1: if subscriptionEvents: is not  passed,
expectation: all events should emit

https://github.com/user-attachments/assets/9b06f9a9-c9e2-4e8d-83c9-24a760715692

case 2: PAYMENT_METHOD_INFO_CARD event

https://github.com/user-attachments/assets/867366ae-1095-4109-8279-8c4760237cb1

case 3: PAYMENT_METHOD_STATUS event


https://github.com/user-attachments/assets/936f38c4-8e48-47a0-8857-5780069945d0

case 4: FORM_STATUS event

https://github.com/user-attachments/assets/1aae09be-53de-4ea8-aca2-eb549006a35d

case 5: PAYMENT_METHOD_INFO_BILLING_ADDRESS event

https://github.com/user-attachments/assets/a83ddca6-dee4-4764-853b-3841346e3775

case 6a: CVC_STATUS event (only for cvc widget) -> multiple cvc widget

https://github.com/user-attachments/assets/3deefb4f-08fd-479b-a9a9-3b676383f47d

case 6b: CVC_STATUS event (only for cvc widget) -> single cvc widget

https://github.com/user-attachments/assets/5a0b478b-02ea-4336-9488-c7ebd66d323a



case 7: SURCHARGE event


https://github.com/user-attachments/assets/a3ba4127-e963-4479-b27b-c7a6dd66c4f9

case 8: payment widget + 2 cvc widget (subscribed events are FORM_STATUS, CVC_STATUS)


https://github.com/user-attachments/assets/43875406-e86e-4216-b831-5686f88fb4b1

case 9: using .on("change", ev=> ...), no subscription event passed

https://github.com/user-attachments/assets/84b6ba36-ff4c-4048-8cea-88bbb428e8c1

https://github.com/user-attachments/assets/0f08ec8c-9330-43cd-9f7c-eec7b1464634

case 10: using .on("change", ev=> ...), PAYMENT_METHOD_INFO_CARD event

https://github.com/user-attachments/assets/17452d57-acac-4b7b-bce9-1479e3a3dc20

case 11: using .on("change", ev=> ...), PAYMENT_METHOD_STATUS event

https://github.com/user-attachments/assets/de633e84-974d-4544-ab88-2bf7b59c7973


case 12: using .on("change", ev=> ...), FORM_STATUS event

https://github.com/user-attachments/assets/a39be2c8-3b0f-4db2-94fd-7239e05299a0


case 13: using .on("change", ev=> ...), PAYMENT_METHOD_INFO_BILLING_ADDRESS event


https://github.com/user-attachments/assets/16981e8f-65b0-43ed-b96c-3fb698620f29

case 14: using .on("change", ev=> ...), SURCHARGE event

https://github.com/user-attachments/assets/7a294431-8c33-4980-b905-cb2d1912c23a


case 15: using .on("change", ev=> ...), CVC_STATUS event
https://github.com/user-attachments/assets/263cd4ef-8ae2-4dcf-b080-1058b100a87d

case 16: using .on("PAYMENT_METHOD_INFO_CARD", ev=> ...)

https://github.com/user-attachments/assets/037ef887-6a51-42c4-a36b-60e2de300614

case 17: using .on("PAYMENT_METHOD_STATUS", ev=> ...)

https://github.com/user-attachments/assets/978a4b8e-ec84-4db5-9409-b6bfdb459b76


case 18: using .on("FORM_STATUS", ev=> ...)

https://github.com/user-attachments/assets/67fc7544-aa08-40e9-a174-0bfa18c1f5b7

case 19: using .on("PAYMENT_METHOD_INFO_BILLING_ADDRESS", ev=> ...)

https://github.com/user-attachments/assets/f98361e1-dc6c-49a2-9566-bd61a9699c0f


case 20: using .on("SURCHARGE", ev=> ...)


https://github.com/user-attachments/assets/d4abfd55-00b4-453b-a7bc-443128be4e54

case 21 using .on("CVC_STATUS", ev=> ...)

https://github.com/user-attachments/assets/5424cb8e-c292-43bd-8c0a-d611f1e88495

case 22 using .on("ready", ev=> ...) and onReady(ev=>...)
<img width="1691" height="897" alt="image" src="https://github.com/user-attachments/assets/58a0354c-7f1b-4624-84ac-1bf5f0c4d46a" />
<img width="1728" height="1011" alt="image" src="https://github.com/user-attachments/assets/f0566d01-b36e-479a-9ef8-9aa7f1196ed2" />

case 23a subscriptionEvents: ["CVC_STATUS"], .on("FORM_STATUS", (event)=> ...)

https://github.com/user-attachments/assets/8d7403e2-3322-4ce4-83ab-aa0dd8a62f0c

https://github.com/user-attachments/assets/1d5f5cda-a68b-433c-b3c5-5f79d63f348f

case 23b: react integration, event "FORM_STATUS" (which is only for payment element)


https://github.com/user-attachments/assets/f967a2bd-1765-4fdb-901c-5be77db35c87

case 24: subscriptionEvents: ["PAYMENT_METHOD_INFO_CARD", "FORM_STATUS"], .on("PAYMENT_METHOD_INFO_CARD", (event) => ..., .on("FORM_STATUS", (event)=> ...


https://github.com/user-attachments/assets/c33fd625-679a-44c7-83b7-104b29e44da6



case 25: multiple widget, js integration

https://github.com/user-attachments/assets/2b55271e-8cdc-4bcb-a144-8b1a05b84101






<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
