### PR TITLE
fix: sdk configs api authentication

### DIFF
--- a/src/Utilities/APIHelpers/APIUtils.res
+++ b/src/Utilities/APIHelpers/APIUtils.res
@@ -88,6 +88,7 @@ let generateApiUrlV1 = (~params: apiParamsV1, ~apiCallType: apiCallV1) => {
 
   let queryParams = switch apiCallType {
   | RetrievePaymentIntent
+  | FetchSdkConfigs
   | FetchClientList => defaultParams
   | FetchSessions
   | FetchThreeDsAuth
@@ -100,8 +101,7 @@ let generateApiUrlV1 = (~params: apiParamsV1, ~apiCallType: apiCallV1) => {
   | FetchEnabledAuthnMethodsToken
   | FetchEligibilityCheck
   | FetchAuthenticationSync
-  | FetchPaymentMethodEligibility
-  | FetchSdkConfigs =>
+  | FetchPaymentMethodEligibility =>
     list{}
   }
 

--- a/src/Utilities/PaymentHelpers.res
+++ b/src/Utilities/PaymentHelpers.res
@@ -2383,18 +2383,12 @@ let fetchSdkConfigs = async (
     },
   )
 
-  let headers = switch sdkAuthorization->Utils.getNonEmptyOption {
-  | None => [("client-secret", clientSecret)]->Dict.fromArray
-  | Some(_) => Dict.make()
-  }
-
   let onSuccess = data => data
   let onFailure = _ => JSON.Encode.null
 
   await fetchApiWithLogging(
     uri,
     ~eventName=SDK_CONFIGS_CALL,
-    ~headers,
     ~logger,
     ~method=#GET,
     ~customPodUri=Some(customPodUri),


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Fix authentication required for `/sdk/configs` api. The api now supports both `clientSecret` and `sdkAuthorization`. Corresponding BE PR (currently deployed on integ): https://github.com/juspay/hyperswitch/pull/12887

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Passed `clientSecret` in `HyperElements.options`. Got `200` api response.
<img width="990" height="340" alt="image" src="https://github.com/user-attachments/assets/8db75452-9ab0-4940-b968-837fa7397933" />

- Passed `sdkAuthorization` in `HyperElements.options`. Got `200` api response.
<img width="990" height="397" alt="image" src="https://github.com/user-attachments/assets/b7a6adc9-9aa5-48b8-b209-835e2185c6e5" />



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
