### PR TITLE
fix: sdk config client secret in query param

### DIFF
--- a/src/Utilities/APIHelpers/APIUtils.res
+++ b/src/Utilities/APIHelpers/APIUtils.res
@@ -88,7 +88,8 @@ let generateApiUrlV1 = (~params: apiParamsV1, ~apiCallType: apiCallV1) => {
 
   let queryParams = switch apiCallType {
   | RetrievePaymentIntent
-  | FetchClientList => defaultParams
+  | FetchClientList
+  | FetchSdkConfigs => defaultParams
   | FetchSessions
   | FetchThreeDsAuth
   | CalculateTax
@@ -100,8 +101,7 @@ let generateApiUrlV1 = (~params: apiParamsV1, ~apiCallType: apiCallV1) => {
   | FetchEnabledAuthnMethodsToken
   | FetchEligibilityCheck
   | FetchAuthenticationSync
-  | FetchPaymentMethodEligibility
-  | FetchSdkConfigs =>
+  | FetchPaymentMethodEligibility =>
     list{}
   }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Client Secret was being sent in headers instead of being passed as query param for sdk_config API call because of which it was throwing 400

```
{
    "error": {
        "type": "invalid_request",
        "message": "Missing required param: client_secret",
        "code": "IR_04"
    }
}
```

## How did you test it?

Tested SDK Config API call - 
<img width="1143" height="604" alt="Screenshot 2026-06-24 at 8 26 22 PM" src="https://github.com/user-attachments/assets/b0ad03ba-1ce7-43aa-8906-7a42061d659a" />

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
