### PR TITLE
fix: paymentMethodType in DynamicFields

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -176,25 +176,30 @@ let make = (
 
   let intentData = paymentMethodListValue.intent_data.intentDataObject
 
+  let configPaymentMethodType = PaymentUtils.getPaymentMethodName(
+    ~paymentMethodType=paymentMethod,
+    ~paymentMethodName=paymentMethodType,
+  )
+
   let eligibleConnectors = React.useMemo(() => {
     SdkConfigParser.getEligibleConnectorsFromPaymentMethods(
       sdkConfigsValue.payment_methods,
       paymentMethod,
-      paymentMethodType,
+      configPaymentMethodType,
     )->Array.map(item => item->JSON.Encode.string)
-  }, (sdkConfigsValue.payment_methods, paymentMethod, paymentMethodType))
+  }, (sdkConfigsValue.payment_methods, paymentMethod, configPaymentMethodType))
 
   let superpositionBaseContext = React.useMemo(() => {
     buildSuperpositionBaseContext(
       ~paymentMethod,
-      ~paymentMethodType,
+      ~paymentMethodType=configPaymentMethodType,
       ~country,
       ~paymentMethodListValue,
       ~accountConfig=sdkConfigsValue.account_config,
     )
   }, (
     paymentMethod,
-    paymentMethodType,
+    configPaymentMethodType,
     country,
     paymentMethodListValue,
     sdkConfigsValue.account_config,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

#### Bug:
- Bank debit/transfer types come through with a suffix (`ach_debit`, `sepa_transfer`), but Superposition and the `sdk-configs` payment_methods API key on the canonical name (`ach`, `sepa`). Passing the raw suffixed value into `getEligibleConnectorsFromPaymentMethods` and `buildSuperpositionBaseContext` made those lookups miss, yielding empty/incorrect required fields.

#### Fix:
- Fixed `payment_method_type` in `DynamicFields.
- used `PaymentUtils.getPaymentMethodName` for accessing the `payment_method_type`'s name.
- affects some bank debit and bank transfer types. Cards/wallets remains unaffected.

## How did you test it?

| Before                                                                                                                              | After                                                                                                                               |
|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| `multibanco_transfer`                                                                                                               | `multibanco`                                                                                                                        |
| <img width="772" height="106" alt="image" src="https://github.com/user-attachments/assets/4993dc2b-302f-4303-bd85-11816e91ab4a" />  | <img width="772" height="106" alt="image" src="https://github.com/user-attachments/assets/af4eba3b-4685-46dd-bea9-6ca4af51235f" />  |
| <img width="1054" height="758" alt="image" src="https://github.com/user-attachments/assets/ef586a8a-a185-40d5-95b1-52f00ed6ffed" /> | <img width="1054" height="758" alt="image" src="https://github.com/user-attachments/assets/1ca9a388-032f-4b73-ae88-eb6a9120fe5c" /> |

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
