### PR TITLE
feat(a11y): input and form-control accessibility

### DIFF
--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -249,5 +249,7 @@ let make = (
     height={isVaultCvcFlow ? "1.8rem" : ""}
     name=TestUtils.cardCVVInputTestId
     autocomplete="cc-csc"
+    ariaLabel={localeString.cvcTextLabel}
+    ariaRequired=true
   />
 }

--- a/src/CardSchemeComponent.res
+++ b/src/CardSchemeComponent.res
@@ -2,8 +2,10 @@ module CoBadgeCardSchemeDropDown = {
   @react.component
   let make = (~eligibleCardSchemes, ~setCardBrand) => {
     let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
+    let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
     <select
       className="w-4"
+      ariaLabel={localeString.cardNetworkLabel}
       onClick={_ =>
         loggerState.setLogInfo(~value="CardSchemeMenu expanded", ~eventName=CARD_SCHEME_SELECTION)}
       onChange={ev => {

--- a/src/Components/BillingNamePaymentInput.res
+++ b/src/Components/BillingNamePaymentInput.res
@@ -69,6 +69,7 @@ let make = (~customFieldName=None, ~requiredFields as optionalRequiredFields=?) 
       placeholder
       className={config.appearance.innerLayout === Spaced ? "" : "!border-b-0"}
       name=TestUtils.cardHolderNameInputTestId
+      ariaRequired=true
     />
   </RenderIf>
 }

--- a/src/Components/BlikCodePaymentInput.res
+++ b/src/Components/BlikCodePaymentInput.res
@@ -65,6 +65,7 @@ let make = () => {
       inputRef=blikCodeRef
       placeholder="000 000"
       maxLength=7
+      ariaRequired=true
     />
   </RenderIf>
 }

--- a/src/Components/ClickToPayNotYou.res
+++ b/src/Components/ClickToPayNotYou.res
@@ -3,7 +3,7 @@ open Utils
 
 @react.component
 let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVisaCards) => {
-  let {themeObj} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let (clickToPayConfig, setClickToPayConfig) = Recoil.useRecoilState(RecoilAtoms.clickToPayConfig)
 
   let (identifier, setIdentifier) = React.useState(_ => "")
@@ -189,6 +189,8 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
         <div className="w-full flex space-x-2">
           <div className="relative w-1/3">
             <select
+              id="ctp-identifier-type"
+              ariaLabel={`${localeString.emailLabel} / ${localeString.formFieldPhoneNumberLabel}`}
               value={identifierType->getIdentityType}
               onChange={handleTypeChange}
               className="w-full p-3 pr-10 border border-gray-300 rounded-md appearance-none">
@@ -207,6 +209,10 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
           {identifierType === EMAIL_ADDRESS
             ? <input
                 type_="text"
+                id="ctp-email"
+                ariaLabel={localeString.emailLabel}
+                ariaRequired=true
+                autoComplete="email"
                 value={identifier}
                 onChange={handleInputChange}
                 placeholder="Enter email"
@@ -216,6 +222,8 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
             : <div className="w-2/3 flex border border-gray-300 rounded-md overflow-hidden">
                 <div className="relative">
                   <select
+                    id="ctp-country-code"
+                    ariaLabel={localeString.formFieldCountryCodeRequiredLabel}
                     value={countryCode}
                     onChange={handleCountryCodeChange}
                     className="h-full p-3 appearance-none focus:outline-none">
@@ -239,6 +247,10 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
                 </div>
                 <input
                   type_="tel"
+                  id="ctp-phone"
+                  ariaLabel={localeString.formFieldPhoneNumberLabel}
+                  ariaRequired=true
+                  autoComplete="tel-national"
                   value={identifier}
                   onChange={handlePhoneInputChange}
                   placeholder="Mobile number"

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -79,6 +79,7 @@ module FullNameFieldInput = {
       placeholder
       inputRef
       ?autocomplete
+      ariaRequired={firstNameFieldConfig.isRequired || lastNameFieldConfig.isRequired}
     />
   }
 }

--- a/src/Components/DynamicFields/EmailField.res
+++ b/src/Components/DynamicFields/EmailField.res
@@ -43,6 +43,7 @@ module EmailInput = {
       placeholder
       inputRef={fieldRef}
       autocomplete
+      ariaRequired={primaryFieldConfig.isRequired}
     />
   }
 }

--- a/src/Components/DynamicFields/GenericInputField.res
+++ b/src/Components/DynamicFields/GenericInputField.res
@@ -33,5 +33,6 @@ let make = (~fieldConfig: fieldConfig) => {
     inputRef={fieldRef}
     ?autocomplete
     maxLength=?{fieldConfig.maxInputLength}
+    ariaRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/DynamicFields/PhoneField.res
+++ b/src/Components/DynamicFields/PhoneField.res
@@ -42,5 +42,6 @@ let make = (~fieldConfig: fieldConfig, ~isLabelHidden=false) => {
     inputRef={fieldRef}
     autocomplete
     ?maxLength
+    ariaRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/EmailPaymentInput.res
+++ b/src/Components/EmailPaymentInput.res
@@ -64,6 +64,7 @@ let make = () => {
       inputRef=emailRef
       placeholder="Eg: johndoe@gmail.com"
       name=TestUtils.emailInputTestId
+      ariaRequired=true
     />
   </RenderIf>
 }

--- a/src/Components/FullNamePaymentInput.res
+++ b/src/Components/FullNamePaymentInput.res
@@ -71,6 +71,7 @@ let make = (~customFieldName=None, ~optionalRequiredFields=None) => {
       inputRef=nameRef
       placeholder
       name=TestUtils.fullNameInputTestId
+      ariaRequired=true
     />
   </RenderIf>
 }

--- a/src/Components/GiftCardNumberInput.res
+++ b/src/Components/GiftCardNumberInput.res
@@ -52,5 +52,6 @@ let make = () => {
     placeholder={localeString.giftCardNumberPlaceholder}
     maxLength=32
     paymentType=Payment
+    ariaRequired=true
   />
 }

--- a/src/Components/GiftCardPinInput.res
+++ b/src/Components/GiftCardPinInput.res
@@ -52,5 +52,6 @@ let make = () => {
     placeholder={localeString.giftCardPinPlaceholder}
     maxLength=12
     paymentType=Payment
+    ariaRequired=true
   />
 }

--- a/src/Components/Input.res
+++ b/src/Components/Input.res
@@ -18,6 +18,9 @@ let make = (
   ~placeholder="",
   ~className="",
   ~inputRef,
+  ~ariaRequired=false,
+  ~ariaLabel=?,
+  ~fieldId=?,
 ) => {
   let options = Recoil.useRecoilValueFromAtom(elementOptions)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
@@ -59,13 +62,30 @@ let make = (
     ""
   }
 
+  let generatedId = React.useId()
+  let inputId = AccessibilityUtils.getControlId(~fieldId, ~preferredId=id, ~generatedId)
+  let hasError = errorString->AccessibilityUtils.hasOptionalText
+  let (
+    accessibleLabel,
+    errorId,
+    describedById,
+    ariaInvalid,
+  ) = AccessibilityUtils.getFieldAccessibility(
+    ~controlId=inputId,
+    ~fieldName,
+    ~placeholder,
+    ~ariaLabel,
+    ~hasError,
+    ~isValid,
+  )
+
   <div className={` flex flex-col w-full`} style={color: themeObj.colorText}>
     <RenderIf condition={fieldName->String.length > 0}>
-      <div> {React.string(fieldName)} </div>
+      <label htmlFor={inputId}> {React.string(fieldName)} </label>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <input
-        id
+        id={inputId}
         style={
           background: themeObj.colorBackground,
           padding: themeObj.spacingUnit,
@@ -83,17 +103,21 @@ let make = (
         onChange
         onBlur=handleBlur
         onFocus=handleFocus
-        ariaLabel={`Type to fill ${fieldName} input`}
+        ariaLabel={accessibleLabel}
+        ariaInvalid
+        ariaRequired
+        ariaDescribedby=?describedById
       />
       <div className={`flex -ml-10  items-center`}> {rightIcon} </div>
     </div>
     {switch errorString {
     | Some(val) =>
       <RenderIf condition={val->String.length > 0}>
-        <div
-          className="py-1 text-xs text-red-600 transition-colors transition-border ease-out duration-200">
-          {React.string(val)}
-        </div>
+        <LiveError
+          text={val}
+          className="py-1 text-xs text-red-600 transition-colors transition-border ease-out duration-200"
+          id={errorId}
+        />
       </RenderIf>
     | None => React.null
     }}

--- a/src/Components/InputField.res
+++ b/src/Components/InputField.res
@@ -25,6 +25,9 @@ let make = (
   ~labelClassName="",
   ~paymentType: option<CardThemeType.mode>=?,
   ~autocomplete="on",
+  ~ariaRequired=false,
+  ~ariaLabel=?,
+  ~fieldId=?,
 ) => {
   open ElementType
   let (eleClassName, setEleClassName) = React.useState(_ => "input-base")
@@ -96,6 +99,23 @@ let make = (
     ""
   }
 
+  let generatedId = React.useId()
+  let inputId = AccessibilityUtils.getControlId(~fieldId, ~preferredId=id, ~generatedId)
+  let hasError = errorString->AccessibilityUtils.hasOptionalText
+  let (
+    accessibleLabel,
+    errorId,
+    describedById,
+    ariaInvalid,
+  ) = AccessibilityUtils.getFieldAccessibility(
+    ~controlId=inputId,
+    ~fieldName,
+    ~placeholder,
+    ~ariaLabel,
+    ~hasError,
+    ~isValid,
+  )
+
   let isValidValue = CardUtils.getBoolOptionVal(isValid)
 
   let (cardEmpty, cardComplete, cardInvalid, cardFocused) = React.useMemo(() => {
@@ -125,11 +145,11 @@ let make = (
 
   <div className={` flex flex-col w-full`}>
     <RenderIf condition={fieldName->String.length > 0}>
-      <div className={`${labelClassName}`}> {React.string(fieldName)} </div>
+      <label htmlFor={inputId} className={`${labelClassName}`}> {React.string(fieldName)} </label>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <input
-        id
+        id={inputId}
         style={
           background: "transparent",
           width: "-webkit-fill-available",
@@ -148,7 +168,10 @@ let make = (
         onBlur=handleBlur
         onFocus=handleFocus
         autoComplete={autocomplete}
-        ariaLabel={`Type to fill ${fieldName} input`}
+        ariaLabel={accessibleLabel}
+        ariaInvalid
+        ariaRequired
+        ariaDescribedby=?describedById
       />
       <div className={`flex -ml-10  items-center`}> {rightIcon} </div>
     </div>
@@ -157,7 +180,7 @@ let make = (
       switch errorString {
       | Some(val) =>
         <RenderIf condition={val->String.length > 0}>
-          <div className={`py-1 ${errorClases}`}> {React.string(val)} </div>
+          <LiveError text={val} className={`py-1 ${errorClases}`} id={errorId} />
         </RenderIf>
       | None => React.null
       }

--- a/src/Components/LiveError.res
+++ b/src/Components/LiveError.res
@@ -1,0 +1,15 @@
+// A field/validation error that is both visually rendered and announced to
+// screen readers (role="alert" + assertive, atomic live region).
+//
+// Renders only the inner alert <div>: callers keep their own conditional-render
+// wrapper (the render condition is not always text-based), and pass the matching
+// `id` (for aria-describedby linkage from the input), `className`, and `style`.
+// `id` defaults to "" → the id attribute is omitted (byte-identical to a div with
+// no id); `style` is optional and omitted when not provided.
+@react.component
+let make = (~text: string, ~className: string, ~style: option<JsxDOM.style>=?, ~id: string="") => {
+  let elementId = id == "" ? None : Some(id)
+  <div id=?elementId role="alert" ariaLive={#assertive} ariaAtomic=true className ?style>
+    {React.string(text)}
+  </div>
+}

--- a/src/Components/PaymentDropDownField.res
+++ b/src/Components/PaymentDropDownField.res
@@ -72,6 +72,9 @@ let make = (
     themeObj.colorBackground
   }, [themeObj])
   let cursorClass = !disabled ? "cursor-pointer" : "cursor-not-allowed"
+  let selectId = `dropdown-${fieldName->String.trim->String.replaceRegExp(%re("/\s+/g"), "-")}`
+  let hasError = value.errorString->String.length > 0
+  let ariaInvalid = AccessibilityUtils.ariaInvalid(~hasError, ~isValid=value.isValid)
   <RenderIf condition={options->Array.length > 0}>
     <div className="flex flex-col w-full" style={color: themeObj.colorText}>
       <RenderIf
@@ -93,6 +96,7 @@ let make = (
       <div className="relative">
         <select
           ref={dropdownRef->ReactDOM.Ref.domRef}
+          id={selectId}
           style={
             background: disabled ? disbaledBG : themeObj.colorBackground,
             opacity: disabled ? "35%" : "",
@@ -105,7 +109,9 @@ let make = (
           onFocus={handleFocus}
           onChange=handleChange
           className={`${inputClassStyles} ${inputClass} ${className} w-full appearance-none outline-none overflow-hidden whitespace-nowrap text-ellipsis ${cursorClass}`}
-          ariaLabel={`${fieldName} option tab`}>
+          ariaLabel={localeString.optionTabLabel(fieldName)}
+          ariaInvalid
+          ariaDescribedby=?{hasError ? Some(selectId ++ "-error") : None}>
           {options
           ->Array.mapWithIndex((item: string, i) => {
             <option key={Int.toString(i)} value=item> {React.string(item)} </option>
@@ -139,17 +145,18 @@ let make = (
           }>
           <Icon size=10 name={"arrow-down"} />
         </div>
-        <RenderIf condition={value.errorString->String.length > 0}>
-          <div
+        <RenderIf condition={hasError}>
+          <LiveError
+            text={value.errorString}
             className="Error pt-1"
-            style={
+            style={{
               color: themeObj.colorDangerText,
               fontSize: themeObj.fontSizeSm,
               alignSelf: "start",
               textAlign: "left",
-            }>
-            {React.string(value.errorString)}
-          </div>
+            }}
+            id={selectId ++ "-error"}
+          />
         </RenderIf>
       </div>
     </div>

--- a/src/Components/PaymentField.res
+++ b/src/Components/PaymentField.res
@@ -24,6 +24,8 @@ let make = (
   ~inputRef,
   ~displayValue=?,
   ~setDisplayValue=?,
+  ~ariaRequired=false,
+  ~fieldId=?,
 ) => {
   let {config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
@@ -93,6 +95,23 @@ let make = (
   let inputLogoClass = getClassName("InputLogo")
   let inputClassStyles = isSpacedInnerLayout ? "Input" : "Input-Compressed"
 
+  let generatedId = React.useId()
+  let inputId = AccessibilityUtils.getControlId(~fieldId, ~preferredId=name, ~generatedId)
+  let hasError = value.errorString->String.length > 0
+  let (
+    accessibleLabel,
+    errorId,
+    describedById,
+    ariaInvalid,
+  ) = AccessibilityUtils.getFieldAccessibility(
+    ~controlId=inputId,
+    ~fieldName,
+    ~placeholder,
+    ~ariaLabel=None,
+    ~hasError,
+    ~isValid=value.isValid,
+  )
+
   let flexDirectionBasedOnType = type_ === "tel" ? "flex-row" : "flex-col"
 
   // Wrap onChange to include logging
@@ -111,17 +130,17 @@ let make = (
       fieldName->String.length > 0 &&
       config.appearance.labels == Above &&
       isSpacedInnerLayout}>
-      <div
+      <label
+        htmlFor={inputId}
         className={`Label ${labelClass}`}
         style={
           fontWeight: themeObj.fontWeightNormal,
           fontSize: themeObj.fontSizeLg,
           marginBottom: "5px",
           opacity: "0.6",
-        }
-        ariaHidden=true>
+        }>
         {React.string(fieldName)}
-      </div>
+      </label>
     </RenderIf>
     <div className={`flex ${flexDirectionBasedOnType} w-full`} style={color: themeObj.colorText}>
       <RenderIf condition={type_ === "tel"}>
@@ -142,17 +161,17 @@ let make = (
         fieldName->String.length > 0 &&
         config.appearance.labels == Above &&
         isSpacedInnerLayout}>
-        <div
+        <label
+          htmlFor={inputId}
           className={`Label ${labelClass}`}
           style={
             fontWeight: themeObj.fontWeightNormal,
             fontSize: themeObj.fontSizeLg,
             marginBottom: "5px",
             opacity: "0.6",
-          }
-          ariaHidden=true>
+          }>
           {React.string(fieldName)}
-        </div>
+        </label>
       </RenderIf>
       <div className="flex flex-row w-full" style={direction: direction}>
         <div className="relative w-full">
@@ -162,6 +181,7 @@ let make = (
               padding: themeObj.spacingUnit,
               width: "100%",
             }
+            id={inputId}
             disabled=readOnly
             ref={inputRef->ReactDOM.Ref.domRef}
             type_
@@ -177,7 +197,10 @@ let make = (
             onChange=wrappedOnChange
             onBlur=handleBlur
             onFocus=handleFocus
-            ariaLabel={`Type to fill ${fieldName->String.length > 0 ? fieldName : name} input`}
+            ariaLabel={accessibleLabel}
+            ariaInvalid
+            ariaRequired
+            ariaDescribedby=?describedById
           />
           <RenderIf condition={config.appearance.labels == Floating}>
             <div
@@ -201,17 +224,17 @@ let make = (
         </div>
       </div>
       <RenderIf condition={value.errorString->String.length > 0}>
-        <div
+        <LiveError
+          text={value.errorString}
           className="Error pt-1"
-          style={
+          style={{
             color: themeObj.colorDangerText,
             fontSize: themeObj.fontSizeSm,
             alignSelf: "start",
             textAlign: "left",
-          }
-          ariaHidden=true>
-          {React.string(value.errorString)}
-        </div>
+          }}
+          id={errorId}
+        />
       </RenderIf>
     </div>
   </div>

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -26,6 +26,9 @@ let make = (
   ~paymentType=?,
   ~isDisabled=false,
   ~autocomplete="on",
+  ~ariaRequired=false,
+  ~ariaLabel=?,
+  ~fieldId=?,
 ) => {
   let {themeObj, config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {innerLayout} = config.appearance
@@ -93,23 +96,52 @@ let make = (
   let inputLogoClass = getClassName("InputLogo")
   let inputClassStyles = innerLayout === Spaced ? "Input" : "Input-Compressed"
 
+  let generatedId = React.useId()
+  let inputId = AccessibilityUtils.getControlId(~fieldId, ~preferredId=name, ~generatedId)
+  let errorText = errorString->Option.getOr("")
+  let hasError = errorText->String.length > 0
+  let (
+    accessibleLabel,
+    errorId,
+    describedById,
+    ariaInvalid,
+  ) = AccessibilityUtils.getFieldAccessibility(
+    ~controlId=inputId,
+    ~fieldName,
+    ~placeholder,
+    ~ariaLabel,
+    ~hasError,
+    ~isValid,
+  )
+  let errorClassName =
+    innerLayout === Spaced ? "Error pt-1" : AccessibilityUtils.visuallyHiddenClass
+  let errorStyle: option<JsxDOM.style> =
+    innerLayout === Spaced
+      ? Some({
+          color: themeObj.colorDangerText,
+          fontSize: themeObj.fontSizeSm,
+          alignSelf: "start",
+          textAlign: "left",
+        })
+      : None
+
   <div className="flex flex-col w-full" style={color: themeObj.colorText}>
     <RenderIf
       condition={!isLabelHidden &&
       fieldName->String.length > 0 &&
       config.appearance.labels == Above &&
       innerLayout === Spaced}>
-      <div
+      <label
+        htmlFor={inputId}
         className={`Label ${labelClass}`}
         style={
           fontWeight: themeObj.fontWeightNormal,
           fontSize: themeObj.fontSizeLg,
           marginBottom: "5px",
           opacity: "0.6",
-        }
-        ariaHidden=true>
+        }>
         {React.string(fieldName)}
-      </div>
+      </label>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <div className={`relative w-full ${inputFieldClassName}`}>
@@ -120,6 +152,7 @@ let make = (
             width: fieldWidth,
             height,
           }
+          id={inputId}
           dataTestId={name}
           disabled={isDisabled || readOnly}
           ref={inputRef->ReactDOM.Ref.domRef}
@@ -134,7 +167,10 @@ let make = (
           onChange
           onBlur=handleBlur
           onFocus=handleFocus
-          ariaLabel={`Type to fill ${fieldName->String.length > 0 ? fieldName : name} input`}
+          ariaLabel={accessibleLabel}
+          ariaInvalid
+          ariaRequired
+          ariaDescribedby=?describedById
         />
         <RenderIf condition={!isLabelHidden && config.appearance.labels == Floating}>
           <div
@@ -155,23 +191,8 @@ let make = (
         {rightIcon}
       </div>
     </div>
-    <RenderIf condition={innerLayout === Spaced}>
-      {switch errorString {
-      | Some(val) =>
-        <RenderIf condition={val->String.length > 0}>
-          <div
-            className="Error pt-1"
-            style={
-              color: themeObj.colorDangerText,
-              fontSize: themeObj.fontSizeSm,
-              alignSelf: "start",
-              textAlign: "left",
-            }>
-            {React.string(val)}
-          </div>
-        </RenderIf>
-      | None => React.null
-      }}
+    <RenderIf condition={hasError}>
+      <LiveError text={errorText} className=errorClassName style=?errorStyle id={errorId} />
     </RenderIf>
   </div>
 }

--- a/src/Components/PixPaymentInput.res
+++ b/src/Components/PixPaymentInput.res
@@ -146,5 +146,6 @@ let make = (~fieldType="") => {
     placeholder
     ?maxLength
     paymentType=Payment
+    ariaRequired={true}
   />
 }

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -212,6 +212,8 @@ let make = (
       height
       name={TestUtils.cardCVVInputTestId}
       autocomplete="cc-csc"
+      ariaLabel={localeString.cvcTextLabel}
+      ariaRequired=true
     />
 
   // Inner-iframe container id for the VGS saved-card CVC. Only the active card

--- a/src/Components/SavedMethodItemV2.res
+++ b/src/Components/SavedMethodItemV2.res
@@ -209,6 +209,8 @@ let make = (
                         height="1.8rem"
                         name={TestUtils.cardCVVInputTestId}
                         autocomplete="cc-csc"
+                        ariaLabel={localeString.cvcTextLabel}
+                        ariaRequired=true
                       />
                     </div>
                   </div>

--- a/src/Components/VpaIdPaymentInput.res
+++ b/src/Components/VpaIdPaymentInput.res
@@ -55,5 +55,6 @@ let make = () => {
     name="vpaId"
     inputRef=vpaIdRef
     placeholder="Eg: johndoe@upi"
+    ariaRequired=true
   />
 }

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -268,4 +268,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "عرض أقل",
   refreshingText: "جارٍ التحديث...",
   paymentDetailsBeingCheckedText: "جارٍ التحقق من تفاصيل الدفع. يرجى الانتظار",
+  // --- accessibility labels ---
+  cardNetworkLabel: "شبكة البطاقة",
+  morePaymentMethodsLabel: "طرق دفع إضافية",
+  yearLabel: "السنة",
+  monthLabel: "الشهر",
+  optionTabLabel: fieldName => `${fieldName} تبويب الخيار`,
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostra menys",
   refreshingText: "Actualitzant...",
   paymentDetailsBeingCheckedText: "S'estan comprovant els detalls del pagament. Si us plau, espereu",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Xarxa de targeta",
+  morePaymentMethodsLabel: "Més mètodes de pagament",
+  yearLabel: "Any",
+  monthLabel: "Mes",
+  optionTabLabel: fieldName => `Pestanya d'opció ${fieldName}`,
 }

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "收起",
   refreshingText: "刷新中...",
   paymentDetailsBeingCheckedText: "正在检查付款详情，请稍候",
+  // --- accessibility labels ---
+  cardNetworkLabel: "卡组织",
+  morePaymentMethodsLabel: "更多支付方式",
+  yearLabel: "年",
+  monthLabel: "月",
+  optionTabLabel: fieldName => `${fieldName} 选项标签`,
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Weniger anzeigen",
   refreshingText: "Aktualisierung...",
   paymentDetailsBeingCheckedText: "Zahlungsdetails werden geprüft. Bitte warten",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Kartennetzwerk",
+  morePaymentMethodsLabel: "Weitere Zahlungsmethoden",
+  yearLabel: "Jahr",
+  monthLabel: "Monat",
+  optionTabLabel: fieldName => `${fieldName} Optionsregisterkarte`,
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Minder tonen",
   refreshingText: "Vernieuwen...",
   paymentDetailsBeingCheckedText: "Betalingsgegevens worden gecontroleerd. Een moment geduld",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Kaartnetwerk",
+  morePaymentMethodsLabel: "Meer betaalmethoden",
+  yearLabel: "Jaar",
+  monthLabel: "Maand",
+  optionTabLabel: fieldName => `${fieldName} optietabblad`,
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Show less",
   refreshingText: "Refreshing...",
   paymentDetailsBeingCheckedText: "Payment details are being checked. Please wait",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Card network",
+  morePaymentMethodsLabel: "More payment methods",
+  yearLabel: "Year",
+  monthLabel: "Month",
+  optionTabLabel: fieldName => `${fieldName} option tab`,
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Show less",
   refreshingText: "Refreshing...",
   paymentDetailsBeingCheckedText: "Payment details are being checked. Please wait",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Card network",
+  morePaymentMethodsLabel: "More payment methods",
+  yearLabel: "Year",
+  monthLabel: "Month",
+  optionTabLabel: fieldName => `${fieldName} option tab`,
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Afficher moins",
   refreshingText: "Actualisation...",
   paymentDetailsBeingCheckedText: "Les détails du paiement sont en cours de vérification. Veuillez patienter",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Réseau de carte",
+  morePaymentMethodsLabel: "Plus de méthodes de paiement",
+  yearLabel: "Année",
+  monthLabel: "Mois",
+  optionTabLabel: fieldName => `Onglet d'option ${fieldName}`,
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Afficher moins",
   refreshingText: "Actualisation...",
   paymentDetailsBeingCheckedText: "Les détails du paiement sont en cours de vérification. Veuillez patienter",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Réseau de carte",
+  morePaymentMethodsLabel: "Plus de méthodes de paiement",
+  yearLabel: "Année",
+  monthLabel: "Mois",
+  optionTabLabel: fieldName => `Onglet d'option ${fieldName}`,
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "הצג פחות",
   refreshingText: "מרענן...",
   paymentDetailsBeingCheckedText: "פרטי התשלום נבדקים. אנא המתן",
+  // --- accessibility labels ---
+  cardNetworkLabel: "רשת כרטיסים",
+  morePaymentMethodsLabel: "אמצעי תשלום נוספים",
+  yearLabel: "שנה",
+  monthLabel: "חודש",
+  optionTabLabel: fieldName => `${fieldName} לשונית אפשרות`,
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostra meno",
   refreshingText: "Aggiornamento...",
   paymentDetailsBeingCheckedText: "I dettagli del pagamento sono in fase di verifica. Attendere prego",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Circuito della carta",
+  morePaymentMethodsLabel: "Altri metodi di pagamento",
+  yearLabel: "Anno",
+  monthLabel: "Mese",
+  optionTabLabel: fieldName => `Scheda opzione ${fieldName}`,
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "表示を減らす",
   refreshingText: "更新中...",
   paymentDetailsBeingCheckedText: "お支払い情報を確認中です。しばらくお待ちください",
+  // --- accessibility labels ---
+  cardNetworkLabel: "カードネットワーク",
+  morePaymentMethodsLabel: "他の支払い方法",
+  yearLabel: "年",
+  monthLabel: "月",
+  optionTabLabel: fieldName => `${fieldName} オプションタブ`,
 }

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -253,6 +253,12 @@ type localeStrings = {
   showLess: string,
   refreshingText: string,
   paymentDetailsBeingCheckedText: string,
+  // --- accessibility labels ---
+  cardNetworkLabel: string,
+  morePaymentMethodsLabel: string,
+  yearLabel: string,
+  monthLabel: string,
+  optionTabLabel: string => string,
 }
 
 type constantStrings = {

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Pokaż mniej",
   refreshingText: "Odświeżanie...",
   paymentDetailsBeingCheckedText: "Trwa weryfikacja szczegółów płatności. Proszę czekać",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Sieć kartowa",
+  morePaymentMethodsLabel: "Więcej metod płatności",
+  yearLabel: "Rok",
+  monthLabel: "Miesiąc",
+  optionTabLabel: fieldName => `${fieldName} karta opcji`,
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostrar menos",
   refreshingText: "Atualizando...",
   paymentDetailsBeingCheckedText: "Os detalhes do pagamento estão sendo verificados. Por favor, aguarde",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Rede do cartão",
+  morePaymentMethodsLabel: "Mais métodos de pagamento",
+  yearLabel: "Ano",
+  monthLabel: "Mês",
+  optionTabLabel: fieldName => `Aba de opção ${fieldName}`,
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -274,4 +274,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Показать меньше",
   refreshingText: "Обновление...",
   paymentDetailsBeingCheckedText: "Данные платежа проверяются. Пожалуйста, подождите",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Платёжная сеть",
+  morePaymentMethodsLabel: "Другие способы оплаты",
+  yearLabel: "Год",
+  monthLabel: "Месяц",
+  optionTabLabel: fieldName => `${fieldName} вкладка параметров`,
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostrar menos",
   refreshingText: "Actualizando...",
   paymentDetailsBeingCheckedText: "Se están verificando los detalles del pago. Por favor, espere",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Red de tarjeta",
+  morePaymentMethodsLabel: "Más métodos de pago",
+  yearLabel: "Año",
+  monthLabel: "Mes",
+  optionTabLabel: fieldName => `Pestaña de opción ${fieldName}`,
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Visa mindre",
   refreshingText: "Uppdaterar...",
   paymentDetailsBeingCheckedText: "Betalningsinformation kontrolleras. Vänligen vänta",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Kortnätverk",
+  morePaymentMethodsLabel: "Fler betalningsmetoder",
+  yearLabel: "År",
+  monthLabel: "Månad",
+  optionTabLabel: fieldName => `${fieldName} alternativflik`,
 }

--- a/src/LocaleStrings/TraditionalChineseLocale.res
+++ b/src/LocaleStrings/TraditionalChineseLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "收起",
   refreshingText: "重新整理中...",
   paymentDetailsBeingCheckedText: "正在檢查付款詳情，請稍候",
+  // --- accessibility labels ---
+  cardNetworkLabel: "卡片網路",
+  morePaymentMethodsLabel: "更多付款方式",
+  yearLabel: "年",
+  monthLabel: "月",
+  optionTabLabel: fieldName => `${fieldName} 選項標籤`,
 }

--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -190,6 +190,7 @@ let make = (
           <select
             value=selectedPaymentOption.paymentMethodName
             ref={selectRef->ReactDOM.Ref.domRef}
+            ariaLabel={localeString.morePaymentMethodsLabel}
             className={`TabMore place-items-start outline-none`}
             onChange=handleChange
             disabled=readOnly

--- a/src/Payments/BacsBankDebit.res
+++ b/src/Payments/BacsBankDebit.res
@@ -158,6 +158,7 @@ let make = () => {
             onBlur=sortcodeBlur
             inputRef=sortCodeRef
             placeholder="10-80-00"
+            ariaRequired=true
           />
           <PaymentInputField
             fieldName=localeString.accountNumberText
@@ -166,6 +167,7 @@ let make = () => {
             type_="text"
             inputRef=accNumRef
             placeholder="00012345"
+            ariaRequired=true
           />
         </div>
         <EmailPaymentInput />

--- a/src/Payments/BankDebitModal.res
+++ b/src/Payments/BankDebitModal.res
@@ -240,6 +240,7 @@ let make = (~setModalData) => {
         className={`p-2 text-base px-4`}
         maxLength=17
         placeholder="eg: John Doe"
+        ariaLabel={localeString.fullNameLabel}
         onBlur={_ => setInputFocus(_ => NONE)}
       />
       <RenderIf condition={isSepaDebit}>
@@ -260,6 +261,8 @@ let make = (~setModalData) => {
           maxLength=42
           inputRef=ibanRef
           placeholder="eg: DE00 0000 0000 0000 0000 00"
+          ariaLabel={localeString.formFieldSepaIbanLabel}
+          ariaRequired=true
         />
       </RenderIf>
       <div className="flex flex-row items-center w-full justify-between">
@@ -285,6 +288,8 @@ let make = (~setModalData) => {
               className={` p-2 text-base px-4`}
               maxLength=9
               placeholder="123456789"
+              ariaLabel={localeString.formFieldACHRoutingNumberLabel}
+              ariaRequired=true
               errorString=routingError
               onBlur=routingBlur
               onFocus={_ => setInputFocus(_ => Routing)}
@@ -311,6 +316,8 @@ let make = (~setModalData) => {
               className={`p-2 text-base px-4`}
               maxLength={isBecsDebit ? 9 : 17}
               placeholder="000123456789"
+              ariaLabel={localeString.formFieldBankAccountNumberLabel}
+              ariaRequired=true
               onFocus={_ => setInputFocus(_ => Account)}
               onBlur={_ => setInputFocus(_ => NONE)}
             />
@@ -363,6 +370,8 @@ let make = (~setModalData) => {
           className={`p-2 text-base px-4`}
           maxLength=7
           placeholder="eg: 000-000"
+          ariaLabel={localeString.sortCodeText}
+          ariaRequired=true
         />
       </RenderIf>
       <Button

--- a/src/Payments/Boleto.res
+++ b/src/Payments/Boleto.res
@@ -101,6 +101,7 @@ let make = () => {
       onBlur=socialSecurityNumberBlur
       inputRef=socialSecurityNumberRef
       placeholder="000.000.000-00"
+      ariaRequired=true
     />
     <Surcharge paymentMethod paymentMethodType />
     <InfoElement />

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -622,6 +622,7 @@ let make = (
                 : ""}
               name=TestUtils.cardNoInputTestId
               autocomplete="cc-number"
+              ariaRequired=true
             />
             <div
               className="flex flex-row w-full place-content-between"
@@ -643,6 +644,7 @@ let make = (
                   placeholder=localeString.expiryPlaceholder
                   name=TestUtils.expiryInputTestId
                   autocomplete="cc-exp"
+                  ariaRequired=true
                 />
               </div>
               <div className={innerLayout === Spaced ? "w-[47%]" : "w-[50%]"}>
@@ -668,6 +670,7 @@ let make = (
                   placeholder="123"
                   name=TestUtils.cardCVVInputTestId
                   autocomplete="cc-csc"
+                  ariaRequired=true
                 />
               </div>
             </div>
@@ -676,16 +679,16 @@ let make = (
                 (cardError->String.length > 0 ||
                 cvcError->String.length > 0 ||
                 expiryError->String.length > 0)}>
-              <div
+              <LiveError
+                text={localeString.enterValidDetailsText}
                 className="Error pt-1"
-                style={
+                style={{
                   color: themeObj.colorDangerText,
                   fontSize: themeObj.fontSizeSm,
                   alignSelf: "start",
                   textAlign: "left",
-                }>
-                {React.string("Invalid input")}
-              </div>
+                }}
+              />
             </RenderIf>
           </RenderIf>
           // Business-logic UI is hidden inside the Cards SDK iframe (those features

--- a/src/Payments/DateOfBirth.res
+++ b/src/Payments/DateOfBirth.res
@@ -35,16 +35,33 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
   let field = ReactFinalForm.useField(path, ~config={validate: validate})
   let invalid = field.meta.invalid
   let showError = field.meta.touched || field.meta.submitFailed
+  let inputId = React.useId()
+  let labelId = inputId ++ "-label"
+  let hasError = showError && invalid
+  let (
+    accessibleLabel,
+    errorId,
+    describedById,
+    ariaInvalid,
+  ) = AccessibilityUtils.getFieldAccessibility(
+    ~controlId=inputId,
+    ~fieldName=label,
+    ~placeholder,
+    ~ariaLabel=None,
+    ~hasError,
+    ~isValid=None,
+  )
 
   <div className="flex flex-col gap-1">
     <div
+      id={labelId}
       className={`Label`}
       style={
         fontWeight: themeObj.fontWeightNormal,
         fontSize: themeObj.fontSizeLg,
         opacity: "0.6",
       }>
-      {label->React.string}
+      {accessibleLabel->React.string}
     </div>
     <DatePicker
       showIcon=true
@@ -65,9 +82,16 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
       wrapperClassName="datepicker"
       shouldCloseOnSelect=true
       placeholderText={placeholder}
+      id={inputId}
+      ariaLabelledBy={labelId}
+      ariaRequired={fieldConfig.isRequired ? "true" : "false"}
+      ariaInvalid
+      ariaDescribedBy=?describedById
       renderCustomHeader={val => {
         <div className="flex gap-4 items-center justify-center m-2">
           <select
+            id="dob-year"
+            ariaLabel={localeString.yearLabel}
             className="p-1"
             value={val.date->Date.getFullYear->Int.toString}
             onChange={ev => {
@@ -83,6 +107,8 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
             ->React.array}
           </select>
           <select
+            id="dob-month"
+            ariaLabel={localeString.monthLabel}
             className="p-1"
             value={months[val.date->Date.getMonth]->Option.getOr("January")}
             onChange={ev => {
@@ -98,17 +124,18 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
         </div>
       }}
     />
-    <RenderIf condition={showError && invalid}>
-      <div
+    <RenderIf condition={hasError}>
+      <LiveError
+        text={field.meta.error->Option.getOr("")}
+        id={errorId}
         className="Error pt-1"
-        style={
+        style={{
           color: themeObj.colorDangerText,
           fontSize: themeObj.fontSizeSm,
           alignSelf: "start",
           textAlign: "left",
-        }>
-        {field.meta.error->Option.getOr("")->React.string}
-      </div>
+        }}
+      />
     </RenderIf>
   </div>
 }

--- a/src/RenderPaymentMethods.res
+++ b/src/RenderPaymentMethods.res
@@ -95,6 +95,8 @@ let make = (
             id="card-number"
             isFocus
             autocomplete="cc-number"
+            ariaLabel={localeString.cardNumberLabel}
+            ariaRequired=true
           />
         | CardExpiryElement =>
           <InputField
@@ -111,6 +113,8 @@ let make = (
             id="card-expiry"
             isFocus
             autocomplete="cc-exp"
+            ariaLabel={localeString.validThruText}
+            ariaRequired=true
           />
         | CardCVCElement => <CardCVCElement cvcProps paymentType />
         | PaymentMethodsManagement =>

--- a/src/SingleLineCardPayment.res
+++ b/src/SingleLineCardPayment.res
@@ -125,6 +125,8 @@ let make = (
             placeholder="1234 1234 1234 1234"
             isFocus
             autocomplete="cc-number"
+            ariaLabel={localeString.cardNumberLabel}
+            ariaRequired=true
           />
         </div>
       </div>}
@@ -145,6 +147,8 @@ let make = (
             placeholder=localeString.expiryPlaceholder
             isFocus
             autocomplete="cc-exp"
+            ariaLabel={localeString.validThruText}
+            ariaRequired=true
           />
         </div>
         <div className="w-1/5">
@@ -164,6 +168,8 @@ let make = (
             placeholder="123"
             isFocus
             autocomplete="cc-csc"
+            ariaLabel={localeString.cvcTextLabel}
+            ariaRequired=true
           />
         </div>
         <RenderIf condition={!options.hidePostalCode}>
@@ -181,6 +187,7 @@ let make = (
               inputRef=zipRef
               placeholder="ZIP"
               isFocus
+              ariaLabel={localeString.postalCodeLabel}
             />
           </div>
         </RenderIf>

--- a/src/Utilities/AccessibilityUtils.res
+++ b/src/Utilities/AccessibilityUtils.res
@@ -1,0 +1,41 @@
+let visuallyHiddenClass = "!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip-path:inset(50%)]"
+
+let hasText = value => value->String.length > 0
+
+let hasOptionalText = value => value->Option.map(hasText)->Option.getOr(false)
+
+let getAccessibleLabel = (~fieldName="", ~placeholder="", ~fallback) =>
+  fieldName->hasText ? fieldName : placeholder->hasText ? placeholder : fallback
+
+let getControlId = (~fieldId: option<string>, ~preferredId="", ~generatedId) =>
+  fieldId->Option.getOr(preferredId->hasText ? preferredId : generatedId)
+
+let ariaInvalid = (~hasError, ~isValid) =>
+  if (
+    hasError ||
+    switch isValid {
+    | Some(false) => true
+    | _ => false
+    }
+  ) {
+    #"true"
+  } else {
+    #"false"
+  }
+
+let getFieldAccessibility = (
+  ~controlId,
+  ~fieldName="",
+  ~placeholder="",
+  ~ariaLabel: option<string>,
+  ~hasError,
+  ~isValid,
+) => {
+  let accessibleLabel =
+    ariaLabel->Option.getOr(getAccessibleLabel(~fieldName, ~placeholder, ~fallback=controlId))
+  let errorId = controlId ++ "-error"
+  let describedById = hasError ? Some(errorId) : None
+  let invalid = ariaInvalid(~hasError, ~isValid)
+
+  (accessibleLabel, errorId, describedById, invalid)
+}

--- a/src/libraries/DatePicker.res
+++ b/src/libraries/DatePicker.res
@@ -31,6 +31,11 @@ external make: (
   ~placeholderText: string=?,
   ~className: string=?,
   ~wrapperClassName: string=?,
+  ~id: string=?,
+  ~ariaLabelledBy: string=?,
+  ~ariaDescribedBy: string=?,
+  ~ariaInvalid: [#"false" | #"true"]=?,
+  ~ariaRequired: string=?,
   ~closeOnScroll: bool=?,
   ~shouldCloseOnSelect: bool=?,
 ) => React.element = "default"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR improves the accessibility contract for payment form controls. It makes control names concise, ensures required and invalid states match the visible validation state, and keeps error messages programmatically associated with the control that needs attention.

It also introduces reusable accessibility helpers for repeated label fallback, optional error detection, visually hidden text, and invalid-state mapping, so later PRs can use the same behavior consistently instead of repeating local logic.

This is the first PR in the split accessibility stack and should be reviewed first. Later PRs build on these shared form-control semantics.

Closes #1645

## How did you test it?

Validated as part of the completed accessibility stack. The checks cover the combined flow after all stacked PRs are applied, and the form-control behavior was also checked through the local payment-element accessibility smoke flow.

- Ran `npm run re:build` on the completed accessibility stack.
- Ran `npm run test:hooks` on the completed accessibility stack.
- Ran `npm run build` on the completed accessibility stack.
- Ran committed-range whitespace validation on the completed accessibility stack.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
