### PR TITLE
feat(a11y): keyboard navigation and focus management

### DIFF
--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -249,5 +249,6 @@ let make = (
     height={isVaultCvcFlow ? "1.8rem" : ""}
     name=TestUtils.cardCVVInputTestId
     autocomplete="cc-csc"
+    ariaRequired=true
   />
 }

--- a/src/CardSchemeComponent.res
+++ b/src/CardSchemeComponent.res
@@ -2,8 +2,10 @@ module CoBadgeCardSchemeDropDown = {
   @react.component
   let make = (~eligibleCardSchemes, ~setCardBrand) => {
     let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
+    let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
     <select
       className="w-4"
+      ariaLabel={localeString.cardNetworkLabel}
       onClick={_ =>
         loggerState.setLogInfo(~value="CardSchemeMenu expanded", ~eventName=CARD_SCHEME_SELECTION)}
       onChange={ev => {

--- a/src/Components/Accordion.res
+++ b/src/Components/Accordion.res
@@ -6,6 +6,10 @@ let make = (
   ~checkoutEle: React.element,
   ~borderBottom: bool,
   ~borderRadiusStyle,
+  ~index: int=0,
+  ~isFocused: bool=true,
+  ~registerItemRef: (int, Nullable.t<Dom.element>) => unit=(_, _) => (),
+  ~onArrowNav: (int, int) => unit=(_, _) => (),
 ) => {
   let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(configAtom)
   let {layout, customMethodNames} = Recoil.useRecoilValueFromAtom(optionAtom)
@@ -34,21 +38,40 @@ let make = (
     paymentOption.displayName,
     paymentOption.icon,
   )
+  let selected = selectedOption == paymentOption.paymentMethodName
   <div
     className={`AccordionItem flex flex-col`}
     style={
       minHeight: "60px",
       width: "-webkit-fill-available",
-      cursor: "pointer",
       marginBottom: layoutClass.spacedAccordionItems ? themeObj.spacingAccordionItem : "",
       border: `1px solid ${themeObj.borderColor}`,
       borderRadius: {borderRadiusStyle},
       borderBottomStyle: borderBottom ? "solid" : "hidden",
-    }
-    onClick={_ => setSelectedOption(_ => paymentOption.paymentMethodName)}>
+    }>
     <div
       className={`flex flex-row items-center ${accordionClass}`}
-      style={columnGap: themeObj.spacingUnit}>
+      role="radio"
+      ariaChecked={selected ? #"true" : #"false"}
+      tabIndex={isFocused ? 0 : -1}
+      ref={ReactDOM.Ref.callbackDomRef(el => registerItemRef(index, el))}
+      onKeyDown={event => {
+        let key = JsxEvent.Keyboard.key(event)
+        switch key {
+        | "ArrowDown" | "ArrowRight" =>
+          event->JsxEvent.Keyboard.preventDefault
+          onArrowNav(index, 1)
+        | "ArrowUp" | "ArrowLeft" =>
+          event->JsxEvent.Keyboard.preventDefault
+          onArrowNav(index, -1)
+        | "Enter" | " " =>
+          event->JsxEvent.Keyboard.preventDefault
+          setSelectedOption(_ => paymentOption.paymentMethodName)
+        | _ => ()
+        }
+      }}
+      style={columnGap: themeObj.spacingUnit, minHeight: "60px", cursor: "pointer"}
+      onClick={_ => setSelectedOption(_ => paymentOption.paymentMethodName)}>
       <RenderIf condition=layoutClass.radios>
         <Radio checked=radioClass />
       </RenderIf>

--- a/src/Components/AccordionContainer.res
+++ b/src/Components/AccordionContainer.res
@@ -1,4 +1,5 @@
 open RecoilAtoms
+
 module Loader = {
   @react.component
   let make = (~cardShimmerCount) => {
@@ -70,6 +71,16 @@ let make = (
   let layoutClass = CardUtils.getLayoutClass(layout)
   let (showMore, setShowMore) = React.useState(_ => false)
   let (selectedOption, setSelectedOption) = Recoil.useRecoilState(selectedOptionAtom)
+
+  // Roving-tabindex focus management for the radiogroup. The primary list and the
+  // "more" dropdown list are each treated as their own roving group: arrow keys move
+  // DOM focus within the rendered list and wrap at its ends. `-1` means "nothing has
+  // been focused yet", in which case the roving-tabbable item falls back to the
+  // selected item (else the first item).
+  let (cardFocusedIndex, setCardFocusedIndex) = React.useState(_ => -1)
+  let (dropDownFocusedIndex, setDropDownFocusedIndex) = React.useState(_ => -1)
+  let cardItemRefs = React.useRef([])
+  let dropDownItemRefs = React.useRef([])
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
   let {
     displayInSeparateScreen,
@@ -140,6 +151,44 @@ let make = (
     }
   }
 
+  // Store/clear an item's DOM element in a list's ref registry at its index.
+  let registerItemRef = (refs: React.ref<array<Nullable.t<Dom.element>>>, index, el) => {
+    while refs.current->Array.length <= index {
+      refs.current->Array.push(Nullable.null)->ignore
+    }
+    refs.current[index] = el
+  }
+
+  // The roving-tabbable index for a list: the explicitly-focused item if any,
+  // otherwise the selected item, otherwise the first item.
+  let getRovingIndex = (focusedIndex, list: array<PaymentMethodsRecord.paymentFieldsInfo>) =>
+    if focusedIndex >= 0 {
+      focusedIndex
+    } else {
+      switch list->Array.findIndex(o => o.paymentMethodName == selectedOption) {
+      | -1 => 0
+      | selectedIndex => selectedIndex
+      }
+    }
+
+  // Move DOM focus within a single list (wrapping at the ends) and update its
+  // focused-index state so the roving tabindex follows.
+  let moveFocus = (
+    refs: React.ref<array<Nullable.t<Dom.element>>>,
+    setFocusedIndex,
+    length,
+    index,
+    delta,
+  ) =>
+    if length > 0 {
+      let nextIndex = mod(mod(index + delta, length) + length, length)
+      setFocusedIndex(_ => nextIndex)
+      refs.current
+      ->Array.get(nextIndex)
+      ->Option.flatMap(Nullable.toOption)
+      ->Option.forEach(el => el->AccessibilityUtils.focus)
+    }
+
   React.useEffect0(() => {
     let shouldAutoOpenSavedMethods =
       !layoutClass.savedMethodCustomization.defaultCollapsed &&
@@ -155,6 +204,8 @@ let make = (
   <div className="w-full">
     <div
       className="AccordionContainer flex flex-col overflow-auto no-scrollbar"
+      role="radiogroup"
+      ariaLabel={localeString.paymentMethodsGroupLabel}
       style={
         marginTop: themeObj.spacingAccordionItem,
         width: "-webkit-fill-available",
@@ -173,6 +224,17 @@ let make = (
           borderBottom={(!showMore &&
           i == cardOptionDetails->Array.length - 1 &&
           !layoutClass.spacedAccordionItems) || layoutClass.spacedAccordionItems}
+          index=i
+          isFocused={i == getRovingIndex(cardFocusedIndex, cardOptionDetails)}
+          registerItemRef={registerItemRef(cardItemRefs, ...)}
+          onArrowNav={(index, delta) =>
+            moveFocus(
+              cardItemRefs,
+              setCardFocusedIndex,
+              cardOptionDetails->Array.length,
+              index,
+              delta,
+            )}
         />
       })
       ->React.array}
@@ -190,6 +252,17 @@ let make = (
             borderRadiusStyle={borderRadiusStyle}
             borderBottom={(i == dropDownOptionsDetails->Array.length - 1 &&
               !layoutClass.spacedAccordionItems) || layoutClass.spacedAccordionItems}
+            index=i
+            isFocused={i == getRovingIndex(dropDownFocusedIndex, dropDownOptionsDetails)}
+            registerItemRef={registerItemRef(dropDownItemRefs, ...)}
+            onArrowNav={(index, delta) =>
+              moveFocus(
+                dropDownItemRefs,
+                setDropDownFocusedIndex,
+                dropDownOptionsDetails->Array.length,
+                index,
+                delta,
+              )}
           />
         })
         ->React.array}
@@ -198,6 +271,9 @@ let make = (
     <RenderIf condition={!showMore && dropDownOptionsDetails->Array.length > 0}>
       <button
         className="AccordionMore flex overflow-auto no-scrollbar"
+        type_="button"
+        ariaExpanded=false
+        ariaLabel={localeString.morePaymentMethodsLabel}
         onClick={_ => setShowMore(_ => !showMore)}
         style={
           borderRadius: themeObj.borderRadius,

--- a/src/Components/Checkbox.res
+++ b/src/Components/Checkbox.res
@@ -62,6 +62,10 @@ let make = (~isChecked, ~onChange, ~label, ~ariaLabelChecked="", ~ariaLabelUnche
       let keyCode = JsxEvent.Keyboard.keyCode(event)
       if key == "Enter" || keyCode == 13 {
         onChange(!isChecked)
+      } else if key == " " {
+        // WAI-ARIA checkbox idiom: Space toggles. preventDefault stops page scroll.
+        event->JsxEvent.Keyboard.preventDefault
+        onChange(!isChecked)
       }
     }}
     role="checkbox"

--- a/src/Components/ClickToPayNotYou.res
+++ b/src/Components/ClickToPayNotYou.res
@@ -189,6 +189,8 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
         <div className="w-full flex space-x-2">
           <div className="relative w-1/3">
             <select
+              id="ctp-identifier-type"
+              ariaLabel="Identifier type"
               value={identifierType->getIdentityType}
               onChange={handleTypeChange}
               className="w-full p-3 pr-10 border border-gray-300 rounded-md appearance-none">
@@ -207,6 +209,9 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
           {identifierType === EMAIL_ADDRESS
             ? <input
                 type_="text"
+                id="ctp-email"
+                ariaLabel="Email"
+                ariaRequired=true
                 value={identifier}
                 onChange={handleInputChange}
                 placeholder="Enter email"
@@ -216,6 +221,8 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
             : <div className="w-2/3 flex border border-gray-300 rounded-md overflow-hidden">
                 <div className="relative">
                   <select
+                    id="ctp-country-code"
+                    ariaLabel="Country code"
                     value={countryCode}
                     onChange={handleCountryCodeChange}
                     className="h-full p-3 appearance-none focus:outline-none">
@@ -239,6 +246,9 @@ let make = (~setIsShowClickToPayNotYou, ~isCTPAuthenticateNotYouClicked, ~getVis
                 </div>
                 <input
                   type_="tel"
+                  id="ctp-phone"
+                  ariaLabel="Mobile number"
+                  ariaRequired=true
                   value={identifier}
                   onChange={handlePhoneInputChange}
                   placeholder="Mobile number"

--- a/src/Components/DynamicFields/CardHolderNameField.res
+++ b/src/Components/DynamicFields/CardHolderNameField.res
@@ -78,6 +78,7 @@ module FullNameFieldInput = {
       placeholder
       inputRef
       ?autocomplete
+      ariaRequired={firstNameFieldConfig.isRequired}
     />
   }
 }

--- a/src/Components/DynamicFields/EmailField.res
+++ b/src/Components/DynamicFields/EmailField.res
@@ -42,6 +42,7 @@ module EmailInput = {
       placeholder
       inputRef={fieldRef}
       autocomplete
+      ariaRequired={primaryFieldConfig.isRequired}
     />
   }
 }

--- a/src/Components/DynamicFields/GenericInputField.res
+++ b/src/Components/DynamicFields/GenericInputField.res
@@ -32,5 +32,6 @@ let make = (~fieldConfig: fieldConfig) => {
     inputRef={fieldRef}
     ?autocomplete
     maxLength=?{fieldConfig.maxInputLength}
+    ariaRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/DynamicFields/PhoneField.res
+++ b/src/Components/DynamicFields/PhoneField.res
@@ -41,5 +41,6 @@ let make = (~fieldConfig: fieldConfig) => {
     inputRef={fieldRef}
     autocomplete
     ?maxLength
+    ariaRequired={fieldConfig.isRequired}
   />
 }

--- a/src/Components/FullScreenPortal.res
+++ b/src/Components/FullScreenPortal.res
@@ -2,6 +2,27 @@ open Utils
 @val @scope(("window", "parent", "frames", `"fullscreen"`, "document"))
 external getElementById: string => Dom.element = "getElementById"
 
+/*
+ * Accessibility note (Task 12 — keyboard-navigation gap closure):
+ *
+ * This component is a thin portal: it renders `children` into the REMOTE
+ * `#fullscreen` iframe document via `ReactDOM.createPortal`. The only consumers
+ * (ACHBankDebit / BecsBankDebit) portal a `<BankDebitModal>`, whose content is
+ * the shared `Modal` component. `Modal` already provides the full dialog
+ * contract: `role="dialog"` + `ariaModal=true` + an accessible name, plus
+ * `AccessibilityHooks.useReturnFocus` / `useFocusTrap` / `useEscapeKey`
+ * (Escape -> close path that posts `("fullscreen", false)` to the parent).
+ *
+ * Therefore NO dialog semantics, focus-into-dialog, or Escape handling are added
+ * here: wrapping the portalled `Modal` in a second `role="dialog"`/`ariaModal`
+ * container would create a nested/duplicate dialog (a screen-reader regression),
+ * not an additive landmark. The genuine dismissal path lives on `Modal` and must
+ * stay the single source of truth so the bank-debit flow is not corrupted.
+ *
+ * Cross-document note: `AccessibilityHooks` derive their keydown target and
+ * active element from the rendered modal container's owner document, so the same
+ * modal contract applies when content is portalled into the fullscreen iframe.
+ */
 @react.component
 let make = (~children) => {
   let (fullScreenIframeNode, setFullScreenIframeNode) = React.useState(() => Nullable.null)

--- a/src/Components/Input.res
+++ b/src/Components/Input.res
@@ -18,6 +18,8 @@ let make = (
   ~placeholder="",
   ~className="",
   ~inputRef,
+  ~ariaRequired=false,
+  ~fieldId=?,
 ) => {
   let options = Recoil.useRecoilValueFromAtom(elementOptions)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
@@ -59,13 +61,23 @@ let make = (
     ""
   }
 
+  let inputId = fieldId->Option.getOr(id->String.length > 0 ? id : fieldName)
+  let accessibleLabel = AccessibilityUtils.getAccessibleLabel(
+    ~fieldName,
+    ~placeholder,
+    ~fallback=inputId,
+  )
+  let hasError = errorString->AccessibilityUtils.hasOptionalText
+  let describedById = hasError ? Some(inputId ++ "-error") : None
+  let ariaInvalid = AccessibilityUtils.ariaInvalid(~hasError, ~isValid)
+
   <div className={` flex flex-col w-full`} style={color: themeObj.colorText}>
     <RenderIf condition={fieldName->String.length > 0}>
-      <div> {React.string(fieldName)} </div>
+      <label htmlFor={inputId}> {React.string(fieldName)} </label>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <input
-        id
+        id={inputId}
         style={
           background: themeObj.colorBackground,
           padding: themeObj.spacingUnit,
@@ -83,17 +95,21 @@ let make = (
         onChange
         onBlur=handleBlur
         onFocus=handleFocus
-        ariaLabel={`Type to fill ${fieldName} input`}
+        ariaLabel={accessibleLabel}
+        ariaInvalid
+        ariaRequired
+        ariaDescribedby=?describedById
       />
       <div className={`flex -ml-10  items-center`}> {rightIcon} </div>
     </div>
     {switch errorString {
     | Some(val) =>
       <RenderIf condition={val->String.length > 0}>
-        <div
-          className="py-1 text-xs text-red-600 transition-colors transition-border ease-out duration-200">
-          {React.string(val)}
-        </div>
+        <LiveError
+          text={val}
+          className="py-1 text-xs text-red-600 transition-colors transition-border ease-out duration-200"
+          id={inputId ++ "-error"}
+        />
       </RenderIf>
     | None => React.null
     }}

--- a/src/Components/InputField.res
+++ b/src/Components/InputField.res
@@ -25,6 +25,8 @@ let make = (
   ~labelClassName="",
   ~paymentType: option<CardThemeType.mode>=?,
   ~autocomplete="on",
+  ~ariaRequired=false,
+  ~fieldId=?,
 ) => {
   open ElementType
   let (eleClassName, setEleClassName) = React.useState(_ => "input-base")
@@ -96,6 +98,16 @@ let make = (
     ""
   }
 
+  let inputId = fieldId->Option.getOr(id->String.length > 0 ? id : fieldName)
+  let accessibleLabel = AccessibilityUtils.getAccessibleLabel(
+    ~fieldName,
+    ~placeholder,
+    ~fallback=inputId,
+  )
+  let hasError = errorString->AccessibilityUtils.hasOptionalText
+  let describedById = hasError ? Some(inputId ++ "-error") : None
+  let ariaInvalid = AccessibilityUtils.ariaInvalid(~hasError, ~isValid)
+
   let isValidValue = CardUtils.getBoolOptionVal(isValid)
 
   let (cardEmpty, cardComplete, cardInvalid, cardFocused) = React.useMemo(() => {
@@ -125,11 +137,11 @@ let make = (
 
   <div className={` flex flex-col w-full`}>
     <RenderIf condition={fieldName->String.length > 0}>
-      <div className={`${labelClassName}`}> {React.string(fieldName)} </div>
+      <label htmlFor={inputId} className={`${labelClassName}`}> {React.string(fieldName)} </label>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <input
-        id
+        id={inputId}
         style={
           background: "transparent",
           width: "-webkit-fill-available",
@@ -148,7 +160,10 @@ let make = (
         onBlur=handleBlur
         onFocus=handleFocus
         autoComplete={autocomplete}
-        ariaLabel={`Type to fill ${fieldName} input`}
+        ariaLabel={accessibleLabel}
+        ariaInvalid
+        ariaRequired
+        ariaDescribedby=?describedById
       />
       <div className={`flex -ml-10  items-center`}> {rightIcon} </div>
     </div>
@@ -157,7 +172,7 @@ let make = (
       switch errorString {
       | Some(val) =>
         <RenderIf condition={val->String.length > 0}>
-          <div className={`py-1 ${errorClases}`}> {React.string(val)} </div>
+          <LiveError text={val} className={`py-1 ${errorClases}`} id={inputId ++ "-error"} />
         </RenderIf>
       | None => React.null
       }

--- a/src/Components/LiveError.res
+++ b/src/Components/LiveError.res
@@ -1,0 +1,15 @@
+// A field/validation error that is both visually rendered and announced to
+// screen readers (role="alert" + assertive, atomic live region).
+//
+// Renders only the inner alert <div>: callers keep their own conditional-render
+// wrapper (the render condition is not always text-based), and pass the matching
+// `id` (for aria-describedby linkage from the input), `className`, and `style`.
+// `id` defaults to "" → the id attribute is omitted (byte-identical to a div with
+// no id); `style` is optional and omitted when not provided.
+@react.component
+let make = (~text: string, ~className: string, ~style: option<JsxDOM.style>=?, ~id: string="") => {
+  let elementId = id == "" ? None : Some(id)
+  <div id=?elementId role="alert" ariaLive={#assertive} ariaAtomic=true className ?style>
+    {React.string(text)}
+  </div>
+}

--- a/src/Components/Modal.res
+++ b/src/Components/Modal.res
@@ -12,10 +12,12 @@ let make = (
   ~loader=false,
   ~showClose=true,
   ~testMode=true,
+  ~ariaLabel=?,
   ~setOpenModal,
   ~openModal,
 ) => {
-  let {themeObj} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let modalAriaLabel = ariaLabel->Option.getOr(localeString.dialogLabel)
   let closeModal = () => {
     setOpenModal(_ => false)
     switch closeCallback {
@@ -30,6 +32,27 @@ let make = (
     loader ? setOpenModal(_ => false) : setOpenModal(_ => true)
     None
   }, [loader])
+
+  // Ref on the modal content container, used for focus management (focus trap +
+  // moving focus into the dialog on open).
+  let containerRef = React.useRef(Nullable.null)
+
+  // Accessibility: return focus to the trigger on close, trap focus while open,
+  // and close on Escape — preserving all existing close behaviour.
+  AccessibilityHooks.useReturnFocus(~active=openModal, ~containerRef)
+  AccessibilityHooks.useFocusTrap(~active=openModal, ~containerRef)
+  AccessibilityHooks.useEscapeKey(~enabled=openModal, ~onEscape=closeModal, ~containerRef)
+
+  // On open, move focus to the first focusable element inside the dialog.
+  React.useEffect(() => {
+    if openModal {
+      switch AccessibilityHooks.getFocusableElements(containerRef)->Array.get(0) {
+      | Some(el) => el->AccessibilityUtils.focus
+      | None => ()
+      }
+    }
+    None
+  }, [openModal])
 
   let loaderVisibility = loader ? "visible" : "hidden"
   let contentVisibility = React.useMemo(() => {
@@ -51,6 +74,10 @@ let make = (
     }>
     {loaderUI}
     {<div
+      ref={ReactDOM.Ref.domRef(containerRef)}
+      role="dialog"
+      ariaModal=true
+      ariaLabel={modalAriaLabel}
       className={`w-full h-full sm:h-auto sm:w-[55%] md:w-[45%] lg:w-[35%] xl:w-[32%] 2xl:w-[27%]  m-auto bg-white flex flex-col justify-start sm:justify-center px-5 pb-5 md:pb-6 pt-4 md:pt-7 rounded-none sm:rounded-md relative overflow-scroll ${animate}`}
       style={
         transition: "opacity .35s ease .1s,transform .35s ease .1s,-webkit-transform .35s ease .1s",
@@ -69,11 +96,13 @@ let make = (
           </div>
         </RenderIf>
         <RenderIf condition=showClose>
-          <div
+          <button
+            type_="button"
             className="p-4 flex justify-end self-end mb-4 cursor-pointer"
-            onClick={_ => closeModal()}>
+            onClick={_ => closeModal()}
+            ariaLabel={localeString.closeLabel}>
             <Icon name="cross" size=23 />
-          </div>
+          </button>
         </RenderIf>
       </div>
       <div className={`mt-12 sm:${marginTop}`}> children </div>

--- a/src/Components/PaymentDropDownField.res
+++ b/src/Components/PaymentDropDownField.res
@@ -72,6 +72,9 @@ let make = (
     themeObj.colorBackground
   }, [themeObj])
   let cursorClass = !disabled ? "cursor-pointer" : "cursor-not-allowed"
+  let selectId = `dropdown-${fieldName->String.trim->String.replaceRegExp(%re("/\s+/g"), "-")}`
+  let hasError = value.errorString->String.length > 0
+  let ariaInvalid = AccessibilityUtils.ariaInvalid(~hasError, ~isValid=value.isValid)
   <RenderIf condition={options->Array.length > 0}>
     <div className="flex flex-col w-full" style={color: themeObj.colorText}>
       <RenderIf
@@ -93,6 +96,7 @@ let make = (
       <div className="relative">
         <select
           ref={dropdownRef->ReactDOM.Ref.domRef}
+          id={selectId}
           style={
             background: disabled ? disbaledBG : themeObj.colorBackground,
             opacity: disabled ? "35%" : "",
@@ -105,7 +109,9 @@ let make = (
           onFocus={handleFocus}
           onChange=handleChange
           className={`${inputClassStyles} ${inputClass} ${className} w-full appearance-none outline-none overflow-hidden whitespace-nowrap text-ellipsis ${cursorClass}`}
-          ariaLabel={`${fieldName} option tab`}>
+          ariaLabel={localeString.optionTabLabel(fieldName)}
+          ariaInvalid
+          ariaDescribedby=?{hasError ? Some(selectId ++ "-error") : None}>
           {options
           ->Array.mapWithIndex((item: string, i) => {
             <option key={Int.toString(i)} value=item> {React.string(item)} </option>
@@ -139,17 +145,18 @@ let make = (
           }>
           <Icon size=10 name={"arrow-down"} />
         </div>
-        <RenderIf condition={value.errorString->String.length > 0}>
-          <div
+        <RenderIf condition={hasError}>
+          <LiveError
+            text={value.errorString}
             className="Error pt-1"
-            style={
+            style={{
               color: themeObj.colorDangerText,
               fontSize: themeObj.fontSizeSm,
               alignSelf: "start",
               textAlign: "left",
-            }>
-            {React.string(value.errorString)}
-          </div>
+            }}
+            id={selectId ++ "-error"}
+          />
         </RenderIf>
       </div>
     </div>

--- a/src/Components/PaymentField.res
+++ b/src/Components/PaymentField.res
@@ -24,6 +24,8 @@ let make = (
   ~inputRef,
   ~displayValue=?,
   ~setDisplayValue=?,
+  ~ariaRequired=false,
+  ~fieldId=?,
 ) => {
   let {config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {themeObj} = Recoil.useRecoilValueFromAtom(configAtom)
@@ -93,6 +95,16 @@ let make = (
   let inputLogoClass = getClassName("InputLogo")
   let inputClassStyles = isSpacedInnerLayout ? "Input" : "Input-Compressed"
 
+  let inputId = fieldId->Option.getOr(name->String.length > 0 ? name : fieldName)
+  let accessibleLabel = AccessibilityUtils.getAccessibleLabel(
+    ~fieldName,
+    ~placeholder,
+    ~fallback=inputId,
+  )
+  let hasError = value.errorString->String.length > 0
+  let describedById = hasError ? Some(inputId ++ "-error") : None
+  let ariaInvalid = AccessibilityUtils.ariaInvalid(~hasError, ~isValid=value.isValid)
+
   let flexDirectionBasedOnType = type_ === "tel" ? "flex-row" : "flex-col"
 
   // Wrap onChange to include logging
@@ -111,17 +123,17 @@ let make = (
       fieldName->String.length > 0 &&
       config.appearance.labels == Above &&
       isSpacedInnerLayout}>
-      <div
+      <label
+        htmlFor={inputId}
         className={`Label ${labelClass}`}
         style={
           fontWeight: themeObj.fontWeightNormal,
           fontSize: themeObj.fontSizeLg,
           marginBottom: "5px",
           opacity: "0.6",
-        }
-        ariaHidden=true>
+        }>
         {React.string(fieldName)}
-      </div>
+      </label>
     </RenderIf>
     <div className={`flex ${flexDirectionBasedOnType} w-full`} style={color: themeObj.colorText}>
       <RenderIf condition={type_ === "tel"}>
@@ -142,17 +154,17 @@ let make = (
         fieldName->String.length > 0 &&
         config.appearance.labels == Above &&
         isSpacedInnerLayout}>
-        <div
+        <label
+          htmlFor={inputId}
           className={`Label ${labelClass}`}
           style={
             fontWeight: themeObj.fontWeightNormal,
             fontSize: themeObj.fontSizeLg,
             marginBottom: "5px",
             opacity: "0.6",
-          }
-          ariaHidden=true>
+          }>
           {React.string(fieldName)}
-        </div>
+        </label>
       </RenderIf>
       <div className="flex flex-row w-full" style={direction: direction}>
         <div className="relative w-full">
@@ -162,6 +174,7 @@ let make = (
               padding: themeObj.spacingUnit,
               width: "100%",
             }
+            id={inputId}
             disabled=readOnly
             ref={inputRef->ReactDOM.Ref.domRef}
             type_
@@ -177,7 +190,10 @@ let make = (
             onChange=wrappedOnChange
             onBlur=handleBlur
             onFocus=handleFocus
-            ariaLabel={`Type to fill ${fieldName->String.length > 0 ? fieldName : name} input`}
+            ariaLabel={accessibleLabel}
+            ariaInvalid
+            ariaRequired
+            ariaDescribedby=?describedById
           />
           <RenderIf condition={config.appearance.labels == Floating}>
             <div
@@ -201,17 +217,17 @@ let make = (
         </div>
       </div>
       <RenderIf condition={value.errorString->String.length > 0}>
-        <div
+        <LiveError
+          text={value.errorString}
           className="Error pt-1"
-          style={
+          style={{
             color: themeObj.colorDangerText,
             fontSize: themeObj.fontSizeSm,
             alignSelf: "start",
             textAlign: "left",
-          }
-          ariaHidden=true>
-          {React.string(value.errorString)}
-        </div>
+          }}
+          id={inputId ++ "-error"}
+        />
       </RenderIf>
     </div>
   </div>

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -25,6 +25,9 @@ let make = (
   ~paymentType=?,
   ~isDisabled=false,
   ~autocomplete="on",
+  ~ariaRequired=false,
+  ~ariaLabel=?,
+  ~fieldId=?,
 ) => {
   let {themeObj, config} = Recoil.useRecoilValueFromAtom(configAtom)
   let {innerLayout} = config.appearance
@@ -92,22 +95,44 @@ let make = (
   let inputLogoClass = getClassName("InputLogo")
   let inputClassStyles = innerLayout === Spaced ? "Input" : "Input-Compressed"
 
+  let inputId = fieldId->Option.getOr(name->String.length > 0 ? name : fieldName)
+  let fallbackAccessibleLabel = AccessibilityUtils.getAccessibleLabel(
+    ~fieldName,
+    ~placeholder,
+    ~fallback=inputId,
+  )
+  let accessibleLabel = ariaLabel->Option.getOr(fallbackAccessibleLabel)
+  let hasError = errorString->AccessibilityUtils.hasOptionalText
+  let describedById = hasError ? Some(inputId ++ "-error") : None
+  let ariaInvalid = AccessibilityUtils.ariaInvalid(~hasError, ~isValid)
+  let errorClassName =
+    innerLayout === Spaced ? "Error pt-1" : AccessibilityUtils.visuallyHiddenClass
+  let errorStyle: option<JsxDOM.style> =
+    innerLayout === Spaced
+      ? Some({
+          color: themeObj.colorDangerText,
+          fontSize: themeObj.fontSizeSm,
+          alignSelf: "start",
+          textAlign: "left",
+        })
+      : None
+
   <div className="flex flex-col w-full" style={color: themeObj.colorText}>
     <RenderIf
       condition={fieldName->String.length > 0 &&
       config.appearance.labels == Above &&
       innerLayout === Spaced}>
-      <div
+      <label
+        htmlFor={inputId}
         className={`Label ${labelClass}`}
         style={
           fontWeight: themeObj.fontWeightNormal,
           fontSize: themeObj.fontSizeLg,
           marginBottom: "5px",
           opacity: "0.6",
-        }
-        ariaHidden=true>
+        }>
         {React.string(fieldName)}
-      </div>
+      </label>
     </RenderIf>
     <div className="flex flex-row " style={direction: direction}>
       <div className={`relative w-full ${inputFieldClassName}`}>
@@ -118,6 +143,7 @@ let make = (
             width: fieldWidth,
             height,
           }
+          id={inputId}
           dataTestId={name}
           disabled={isDisabled || readOnly}
           ref={inputRef->ReactDOM.Ref.domRef}
@@ -132,7 +158,10 @@ let make = (
           onChange
           onBlur=handleBlur
           onFocus=handleFocus
-          ariaLabel={`Type to fill ${fieldName->String.length > 0 ? fieldName : name} input`}
+          ariaLabel={accessibleLabel}
+          ariaInvalid
+          ariaRequired
+          ariaDescribedby=?describedById
         />
         <RenderIf condition={config.appearance.labels == Floating}>
           <div
@@ -153,23 +182,12 @@ let make = (
         {rightIcon}
       </div>
     </div>
-    <RenderIf condition={innerLayout === Spaced}>
-      {switch errorString {
-      | Some(val) =>
-        <RenderIf condition={val->String.length > 0}>
-          <div
-            className="Error pt-1"
-            style={
-              color: themeObj.colorDangerText,
-              fontSize: themeObj.fontSizeSm,
-              alignSelf: "start",
-              textAlign: "left",
-            }>
-            {React.string(val)}
-          </div>
-        </RenderIf>
-      | None => React.null
-      }}
-    </RenderIf>
+    {switch errorString {
+    | Some(val) =>
+      <RenderIf condition={val->String.length > 0}>
+        <LiveError text={val} className=errorClassName style=?errorStyle id={inputId ++ "-error"} />
+      </RenderIf>
+    | None => React.null
+    }}
   </div>
 }

--- a/src/Hooks/AccessibilityHooks.res
+++ b/src/Hooks/AccessibilityHooks.res
@@ -1,0 +1,126 @@
+/*
+ * Reusable keyboard / focus-management hooks for accessibility.
+ *
+ * - useEscapeKey   : invoke a callback when the Escape key is pressed.
+ * - useFocusTrap   : keep keyboard focus within a container while it is active.
+ * - useReturnFocus : restore focus to the previously-focused element on close.
+ *
+ * These hooks are dependency-light and have no external deps. Each effect that
+ * registers a listener returns a cleanup that removes it.
+ */
+
+// Minimal typed view over a raw DOM keyboard event delivered to a window/document
+// "keydown" listener. `Window.addEventListener` binds the handler as `_ => unit`,
+// so we describe just the fields we read here.
+type keyboardEvent = {
+  key: string,
+  shiftKey: bool,
+}
+@send external preventDefault: keyboardEvent => unit = "preventDefault"
+type eventTarget
+type document
+@val external globalWindow: eventTarget = "window"
+@get external ownerDocument: Dom.element => Nullable.t<document> = "ownerDocument"
+@get external defaultView: document => Nullable.t<eventTarget> = "defaultView"
+@get external documentActiveElement: document => Nullable.t<Dom.element> = "activeElement"
+@send
+external addKeyDownListener: (eventTarget, @as("keydown") _, keyboardEvent => unit) => unit =
+  "addEventListener"
+@send
+external removeKeyDownListener: (eventTarget, @as("keydown") _, keyboardEvent => unit) => unit =
+  "removeEventListener"
+
+let getOwnerDocument = (containerRef: React.ref<Nullable.t<Dom.element>>) =>
+  containerRef.current
+  ->Nullable.toOption
+  ->Option.flatMap(el => el->ownerDocument->Nullable.toOption)
+
+let getEventTarget = (containerRef: React.ref<Nullable.t<Dom.element>>) =>
+  getOwnerDocument(containerRef)
+  ->Option.flatMap(doc => doc->defaultView->Nullable.toOption)
+  ->Option.getOr(globalWindow)
+
+let getActiveElement = (containerRef: React.ref<Nullable.t<Dom.element>>) =>
+  switch getOwnerDocument(containerRef) {
+  | Some(doc) => doc->documentActiveElement
+  | None => AccessibilityUtils.activeElement
+  }
+
+let getFocusableElements = (containerRef: React.ref<Nullable.t<Dom.element>>) =>
+  switch containerRef.current->Nullable.toOption {
+  | Some(container) =>
+    container->AccessibilityUtils.querySelectorAllWithin(AccessibilityUtils.focusableSelector)
+  | None => []
+  }
+
+let useEscapeKey = (
+  ~enabled: bool,
+  ~onEscape: unit => unit,
+  ~containerRef: React.ref<Nullable.t<Dom.element>>,
+) => {
+  React.useEffect(() => {
+    if enabled {
+      let handle = (ev: keyboardEvent) =>
+        if ev.key === "Escape" {
+          onEscape()
+        }
+      let target = getEventTarget(containerRef)
+      target->addKeyDownListener(handle)
+      Some(() => target->removeKeyDownListener(handle))
+    } else {
+      None
+    }
+  }, [enabled])
+}
+
+let useFocusTrap = (~active: bool, ~containerRef: React.ref<Nullable.t<Dom.element>>) => {
+  React.useEffect(() => {
+    if active {
+      let handle = (ev: keyboardEvent) =>
+        if ev.key === "Tab" {
+          let focusable = getFocusableElements(containerRef)
+          switch (focusable->Array.get(0), focusable->Array.get(focusable->Array.length - 1)) {
+          | (Some(first), Some(last)) =>
+            let current = getActiveElement(containerRef)->Nullable.toOption
+            if ev.shiftKey {
+              // Shift+Tab on the first element wraps to the last.
+              if current === Some(first) {
+                ev->preventDefault
+                last->AccessibilityUtils.focus
+              }
+            } // Tab on the last element wraps back to the first.
+            else if current === Some(last) {
+              ev->preventDefault
+              first->AccessibilityUtils.focus
+            }
+          | _ => ()
+          }
+        }
+      let target = getEventTarget(containerRef)
+      target->addKeyDownListener(handle)
+      Some(() => target->removeKeyDownListener(handle))
+    } else {
+      None
+    }
+  }, [active])
+}
+
+let useReturnFocus = (~active: bool, ~containerRef: React.ref<Nullable.t<Dom.element>>) => {
+  // Holds the element that had focus when `active` last became true.
+  let previouslyFocused = React.useRef(Nullable.null)
+
+  React.useEffect(() => {
+    if active {
+      // Capture the currently-focused element when the trap becomes active.
+      previouslyFocused.current = getActiveElement(containerRef)
+      None
+    } else {
+      // On deactivation, restore focus to the captured element (if any).
+      previouslyFocused.current
+      ->Nullable.toOption
+      ->Option.forEach(el => el->AccessibilityUtils.focus)
+      previouslyFocused.current = Nullable.null
+      None
+    }
+  }, [active])
+}

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -268,4 +268,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "عرض أقل",
   refreshingText: "جارٍ التحديث...",
   paymentDetailsBeingCheckedText: "جارٍ التحقق من تفاصيل الدفع. يرجى الانتظار",
+  // --- accessibility labels ---
+  cardNetworkLabel: "شبكة البطاقة",
+  morePaymentMethodsLabel: "طرق دفع إضافية",
+  yearLabel: "السنة",
+  monthLabel: "الشهر",
+  optionTabLabel: fieldName => `${fieldName} تبويب الخيار`,
 }

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -274,4 +274,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "السنة",
   monthLabel: "الشهر",
   optionTabLabel: fieldName => `${fieldName} تبويب الخيار`,
+  closeLabel: "إغلاق",
+  dialogLabel: "مربع حوار",
+  paymentMethodsGroupLabel: "طرق الدفع",
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostra menys",
   refreshingText: "Actualitzant...",
   paymentDetailsBeingCheckedText: "S'estan comprovant els detalls del pagament. Si us plau, espereu",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Xarxa de targeta",
+  morePaymentMethodsLabel: "Més mètodes de pagament",
+  yearLabel: "Any",
+  monthLabel: "Mes",
+  optionTabLabel: fieldName => `Pestanya d'opció ${fieldName}`,
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -273,4 +273,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Any",
   monthLabel: "Mes",
   optionTabLabel: fieldName => `Pestanya d'opció ${fieldName}`,
+  closeLabel: "Tancar",
+  dialogLabel: "Diàleg",
+  paymentMethodsGroupLabel: "Mètodes de pagament",
 }

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "收起",
   refreshingText: "刷新中...",
   paymentDetailsBeingCheckedText: "正在检查付款详情，请稍候",
+  // --- accessibility labels ---
+  cardNetworkLabel: "卡组织",
+  morePaymentMethodsLabel: "更多支付方式",
+  yearLabel: "年",
+  monthLabel: "月",
+  optionTabLabel: fieldName => `${fieldName} 选项标签`,
 }

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -271,4 +271,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "年",
   monthLabel: "月",
   optionTabLabel: fieldName => `${fieldName} 选项标签`,
+  closeLabel: "关闭",
+  dialogLabel: "对话框",
+  paymentMethodsGroupLabel: "支付方式",
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -272,4 +272,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Jahr",
   monthLabel: "Monat",
   optionTabLabel: fieldName => `${fieldName} Optionsregisterkarte`,
+  closeLabel: "Schließen",
+  dialogLabel: "Dialog",
+  paymentMethodsGroupLabel: "Zahlungsmethoden",
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Weniger anzeigen",
   refreshingText: "Aktualisierung...",
   paymentDetailsBeingCheckedText: "Zahlungsdetails werden geprüft. Bitte warten",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Kartennetzwerk",
+  morePaymentMethodsLabel: "Weitere Zahlungsmethoden",
+  yearLabel: "Jahr",
+  monthLabel: "Monat",
+  optionTabLabel: fieldName => `${fieldName} Optionsregisterkarte`,
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -271,4 +271,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Jaar",
   monthLabel: "Maand",
   optionTabLabel: fieldName => `${fieldName} optietabblad`,
+  closeLabel: "Sluiten",
+  dialogLabel: "Dialoogvenster",
+  paymentMethodsGroupLabel: "Betaalmethoden",
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Minder tonen",
   refreshingText: "Vernieuwen...",
   paymentDetailsBeingCheckedText: "Betalingsgegevens worden gecontroleerd. Een moment geduld",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Kaartnetwerk",
+  morePaymentMethodsLabel: "Meer betaalmethoden",
+  yearLabel: "Jaar",
+  monthLabel: "Maand",
+  optionTabLabel: fieldName => `${fieldName} optietabblad`,
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Show less",
   refreshingText: "Refreshing...",
   paymentDetailsBeingCheckedText: "Payment details are being checked. Please wait",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Card network",
+  morePaymentMethodsLabel: "More payment methods",
+  yearLabel: "Year",
+  monthLabel: "Month",
+  optionTabLabel: fieldName => `${fieldName} option tab`,
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -271,4 +271,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Year",
   monthLabel: "Month",
   optionTabLabel: fieldName => `${fieldName} option tab`,
+  closeLabel: "Close",
+  dialogLabel: "Dialog",
+  paymentMethodsGroupLabel: "Payment methods",
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Show less",
   refreshingText: "Refreshing...",
   paymentDetailsBeingCheckedText: "Payment details are being checked. Please wait",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Card network",
+  morePaymentMethodsLabel: "More payment methods",
+  yearLabel: "Year",
+  monthLabel: "Month",
+  optionTabLabel: fieldName => `${fieldName} option tab`,
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -271,4 +271,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Year",
   monthLabel: "Month",
   optionTabLabel: fieldName => `${fieldName} option tab`,
+  closeLabel: "Close",
+  dialogLabel: "Dialog",
+  paymentMethodsGroupLabel: "Payment methods",
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -273,4 +273,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Année",
   monthLabel: "Mois",
   optionTabLabel: fieldName => `Onglet d'option ${fieldName}`,
+  closeLabel: "Fermer",
+  dialogLabel: "Dialogue",
+  paymentMethodsGroupLabel: "Méthodes de paiement",
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Afficher moins",
   refreshingText: "Actualisation...",
   paymentDetailsBeingCheckedText: "Les détails du paiement sont en cours de vérification. Veuillez patienter",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Réseau de carte",
+  morePaymentMethodsLabel: "Plus de méthodes de paiement",
+  yearLabel: "Année",
+  monthLabel: "Mois",
+  optionTabLabel: fieldName => `Onglet d'option ${fieldName}`,
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -273,4 +273,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Année",
   monthLabel: "Mois",
   optionTabLabel: fieldName => `Onglet d'option ${fieldName}`,
+  closeLabel: "Fermer",
+  dialogLabel: "Dialogue",
+  paymentMethodsGroupLabel: "Méthodes de paiement",
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Afficher moins",
   refreshingText: "Actualisation...",
   paymentDetailsBeingCheckedText: "Les détails du paiement sont en cours de vérification. Veuillez patienter",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Réseau de carte",
+  morePaymentMethodsLabel: "Plus de méthodes de paiement",
+  yearLabel: "Année",
+  monthLabel: "Mois",
+  optionTabLabel: fieldName => `Onglet d'option ${fieldName}`,
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -272,4 +272,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "שנה",
   monthLabel: "חודש",
   optionTabLabel: fieldName => `${fieldName} לשונית אפשרות`,
+  closeLabel: "סגור",
+  dialogLabel: "תיבת דו-שיח",
+  paymentMethodsGroupLabel: "אמצעי תשלום",
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "הצג פחות",
   refreshingText: "מרענן...",
   paymentDetailsBeingCheckedText: "פרטי התשלום נבדקים. אנא המתן",
+  // --- accessibility labels ---
+  cardNetworkLabel: "רשת כרטיסים",
+  morePaymentMethodsLabel: "אמצעי תשלום נוספים",
+  yearLabel: "שנה",
+  monthLabel: "חודש",
+  optionTabLabel: fieldName => `${fieldName} לשונית אפשרות`,
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -267,4 +267,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostra meno",
   refreshingText: "Aggiornamento...",
   paymentDetailsBeingCheckedText: "I dettagli del pagamento sono in fase di verifica. Attendere prego",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Circuito della carta",
+  morePaymentMethodsLabel: "Altri metodi di pagamento",
+  yearLabel: "Anno",
+  monthLabel: "Mese",
+  optionTabLabel: fieldName => `Scheda opzione ${fieldName}`,
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -273,4 +273,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Anno",
   monthLabel: "Mese",
   optionTabLabel: fieldName => `Scheda opzione ${fieldName}`,
+  closeLabel: "Chiudi",
+  dialogLabel: "Finestra di dialogo",
+  paymentMethodsGroupLabel: "Metodi di pagamento",
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "表示を減らす",
   refreshingText: "更新中...",
   paymentDetailsBeingCheckedText: "お支払い情報を確認中です。しばらくお待ちください",
+  // --- accessibility labels ---
+  cardNetworkLabel: "カードネットワーク",
+  morePaymentMethodsLabel: "他の支払い方法",
+  yearLabel: "年",
+  monthLabel: "月",
+  optionTabLabel: fieldName => `${fieldName} オプションタブ`,
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -272,4 +272,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "年",
   monthLabel: "月",
   optionTabLabel: fieldName => `${fieldName} オプションタブ`,
+  closeLabel: "閉じる",
+  dialogLabel: "ダイアログ",
+  paymentMethodsGroupLabel: "支払い方法",
 }

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -253,6 +253,12 @@ type localeStrings = {
   showLess: string,
   refreshingText: string,
   paymentDetailsBeingCheckedText: string,
+  // --- accessibility labels ---
+  cardNetworkLabel: string,
+  morePaymentMethodsLabel: string,
+  yearLabel: string,
+  monthLabel: string,
+  optionTabLabel: string => string,
 }
 
 type constantStrings = {

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -259,6 +259,9 @@ type localeStrings = {
   yearLabel: string,
   monthLabel: string,
   optionTabLabel: string => string,
+  closeLabel: string,
+  dialogLabel: string,
+  paymentMethodsGroupLabel: string,
 }
 
 type constantStrings = {

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Pokaż mniej",
   refreshingText: "Odświeżanie...",
   paymentDetailsBeingCheckedText: "Trwa weryfikacja szczegółów płatności. Proszę czekać",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Sieć kartowa",
+  morePaymentMethodsLabel: "Więcej metod płatności",
+  yearLabel: "Rok",
+  monthLabel: "Miesiąc",
+  optionTabLabel: fieldName => `${fieldName} karta opcji`,
 }

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -272,4 +272,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Rok",
   monthLabel: "Miesiąc",
   optionTabLabel: fieldName => `${fieldName} karta opcji`,
+  closeLabel: "Zamknij",
+  dialogLabel: "Okno dialogowe",
+  paymentMethodsGroupLabel: "Metody płatności",
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostrar menos",
   refreshingText: "Atualizando...",
   paymentDetailsBeingCheckedText: "Os detalhes do pagamento estão sendo verificados. Por favor, aguarde",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Rede do cartão",
+  morePaymentMethodsLabel: "Mais métodos de pagamento",
+  yearLabel: "Ano",
+  monthLabel: "Mês",
+  optionTabLabel: fieldName => `Aba de opção ${fieldName}`,
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -272,4 +272,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Ano",
   monthLabel: "Mês",
   optionTabLabel: fieldName => `Aba de opção ${fieldName}`,
+  closeLabel: "Fechar",
+  dialogLabel: "Diálogo",
+  paymentMethodsGroupLabel: "Métodos de pagamento",
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -280,4 +280,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Год",
   monthLabel: "Месяц",
   optionTabLabel: fieldName => `${fieldName} вкладка параметров`,
+  closeLabel: "Закрыть",
+  dialogLabel: "Диалог",
+  paymentMethodsGroupLabel: "Способы оплаты",
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -274,4 +274,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Показать меньше",
   refreshingText: "Обновление...",
   paymentDetailsBeingCheckedText: "Данные платежа проверяются. Пожалуйста, подождите",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Платёжная сеть",
+  morePaymentMethodsLabel: "Другие способы оплаты",
+  yearLabel: "Год",
+  monthLabel: "Месяц",
+  optionTabLabel: fieldName => `${fieldName} вкладка параметров`,
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -266,4 +266,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostrar menos",
   refreshingText: "Actualizando...",
   paymentDetailsBeingCheckedText: "Se están verificando los detalles del pago. Por favor, espere",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Red de tarjeta",
+  morePaymentMethodsLabel: "Más métodos de pago",
+  yearLabel: "Año",
+  monthLabel: "Mes",
+  optionTabLabel: fieldName => `Pestaña de opción ${fieldName}`,
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -272,4 +272,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "Año",
   monthLabel: "Mes",
   optionTabLabel: fieldName => `Pestaña de opción ${fieldName}`,
+  closeLabel: "Cerrar",
+  dialogLabel: "Diálogo",
+  paymentMethodsGroupLabel: "Métodos de pago",
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -271,4 +271,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "År",
   monthLabel: "Månad",
   optionTabLabel: fieldName => `${fieldName} alternativflik`,
+  closeLabel: "Stäng",
+  dialogLabel: "Dialog",
+  paymentMethodsGroupLabel: "Betalningsmetoder",
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Visa mindre",
   refreshingText: "Uppdaterar...",
   paymentDetailsBeingCheckedText: "Betalningsinformation kontrolleras. Vänligen vänta",
+  // --- accessibility labels ---
+  cardNetworkLabel: "Kortnätverk",
+  morePaymentMethodsLabel: "Fler betalningsmetoder",
+  yearLabel: "År",
+  monthLabel: "Månad",
+  optionTabLabel: fieldName => `${fieldName} alternativflik`,
 }

--- a/src/LocaleStrings/TraditionalChineseLocale.res
+++ b/src/LocaleStrings/TraditionalChineseLocale.res
@@ -271,4 +271,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   yearLabel: "年",
   monthLabel: "月",
   optionTabLabel: fieldName => `${fieldName} 選項標籤`,
+  closeLabel: "關閉",
+  dialogLabel: "對話框",
+  paymentMethodsGroupLabel: "付款方式",
 }

--- a/src/LocaleStrings/TraditionalChineseLocale.res
+++ b/src/LocaleStrings/TraditionalChineseLocale.res
@@ -265,4 +265,10 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "收起",
   refreshingText: "重新整理中...",
   paymentDetailsBeingCheckedText: "正在檢查付款詳情，請稍候",
+  // --- accessibility labels ---
+  cardNetworkLabel: "卡片網路",
+  morePaymentMethodsLabel: "更多付款方式",
+  yearLabel: "年",
+  monthLabel: "月",
+  optionTabLabel: fieldName => `${fieldName} 選項標籤`,
 }

--- a/src/PaymentOptions.res
+++ b/src/PaymentOptions.res
@@ -190,6 +190,7 @@ let make = (
           <select
             value=selectedPaymentOption.paymentMethodName
             ref={selectRef->ReactDOM.Ref.domRef}
+            ariaLabel={localeString.morePaymentMethodsLabel}
             className={`TabMore place-items-start outline-none`}
             onChange=handleChange
             disabled=readOnly

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -246,28 +246,42 @@ let make = (
       // Called by both the inner-SDK path and the standard path when card
       // fields are incomplete or invalid.
       let reportCardFieldErrors = () => {
-        if cardNumber === "" {
+        let hasEmptyCardField = cardNumber === "" || cardExpiry === "" || cvcNumber === ""
+        let (cardSpecificError, hasInvalidCardField) = if cardNumber === "" {
           setCardError(_ => localeString.cardNumberEmptyText)
-          setUserError(localeString.enterFieldsText)
+          (None, false)
         } else if isCardSupported->Option.getOr(true)->not {
           if cardBrand == "" {
             setCardError(_ => localeString.enterValidCardNumberErrorText)
-            setUserError(localeString.enterValidDetailsText)
+            (None, true)
           } else {
-            setCardError(_ => localeString.cardBrandConfiguredErrorText(cardBrand))
-            setUserError(localeString.cardBrandConfiguredErrorText(cardBrand))
+            let msg = localeString.cardBrandConfiguredErrorText(cardBrand)
+            setCardError(_ => msg)
+            (Some(msg), true)
           }
+        } else {
+          (None, false)
+        }
+
+        if cardNumber === "" {
+          setCardError(_ => localeString.cardNumberEmptyText)
         }
         if cardExpiry === "" {
           setExpiryError(_ => localeString.cardExpiryDateEmptyText)
-          setUserError(localeString.enterFieldsText)
         }
         if cvcNumber === "" {
           setCvcError(_ => localeString.cvcNumberEmptyText)
-          setUserError(localeString.enterFieldsText)
         }
-        if !isCardDetailsValid {
-          setUserError(localeString.enterValidDetailsText)
+
+        let summaryMessage = switch cardSpecificError {
+        | Some(msg) => msg
+        | None if hasEmptyCardField => localeString.enterFieldsText
+        | None if hasInvalidCardField || !isCardDetailsValid => localeString.enterValidDetailsText
+        | None => ""
+        }
+
+        if summaryMessage !== "" {
+          setUserError(summaryMessage)
         }
       }
 
@@ -511,41 +525,55 @@ let make = (
         } else {
           // Card field errors (also checked via shared reportCardFieldErrors above
           // but the standard path has additional eligibility / installment checks).
-          if cardNumber === "" {
+          let hasEmptyCardField =
+            cardNumber === "" || cardExpiry === "" || (!isBancontact && cvcNumber === "")
+          let cardSpecificError = if cardNumber === "" {
             setCardError(_ => localeString.cardNumberEmptyText)
-            setUserError(localeString.enterFieldsText)
+            None
           } else if cardEligibilityError->Option.isSome {
             let msg = EligibilityHelpers.getCardEligibilityErrorText(
               ~cardEligibilityError,
               ~localeString,
             )
             setCardError(_ => msg)
-            setUserError(msg)
+            Some(msg)
           } else if isCardSupported->Option.getOr(true)->not {
             if cardBrand == "" {
               setCardError(_ => localeString.enterValidCardNumberErrorText)
-              setUserError(localeString.enterValidDetailsText)
+              None
             } else {
-              setCardError(_ => localeString.cardBrandConfiguredErrorText(cardBrand))
-              setUserError(localeString.cardBrandConfiguredErrorText(cardBrand))
+              let msg = localeString.cardBrandConfiguredErrorText(cardBrand)
+              setCardError(_ => msg)
+              Some(msg)
             }
+          } else {
+            None
           }
           if cardExpiry === "" {
             setExpiryError(_ => localeString.cardExpiryDateEmptyText)
-            setUserError(localeString.enterFieldsText)
           }
           if !isBancontact && cvcNumber === "" {
             setCvcError(_ => localeString.cvcNumberEmptyText)
-            setUserError(localeString.enterFieldsText)
           }
           if !isInstallmentValid {
-            setUserError(localeString.installmentSelectPlanError)
             setInstallmentsError(_ => localeString.installmentSelectPlanError)
           }
-          if isEligibilityPending && paymentMethodListValue.should_block_confirm {
-            setUserError(localeString.paymentDetailsBeingCheckedText)
-          } else if !validFormat {
-            setUserError(localeString.enterValidDetailsText)
+
+          let summaryMessage = if !isInstallmentValid {
+            localeString.installmentSelectPlanError
+          } else if isEligibilityPending && paymentMethodListValue.should_block_confirm {
+            localeString.paymentDetailsBeingCheckedText
+          } else {
+            switch cardSpecificError {
+            | Some(msg) => msg
+            | None if hasEmptyCardField => localeString.enterFieldsText
+            | None if !validFormat => localeString.enterValidDetailsText
+            | None => ""
+            }
+          }
+
+          if summaryMessage !== "" {
+            setUserError(summaryMessage)
           }
         }
       }
@@ -626,6 +654,7 @@ let make = (
                 : ""}
               name=TestUtils.cardNoInputTestId
               autocomplete="cc-number"
+              ariaRequired=true
             />
             <div
               className="flex flex-row w-full place-content-between"
@@ -647,6 +676,7 @@ let make = (
                   placeholder=localeString.expiryPlaceholder
                   name=TestUtils.expiryInputTestId
                   autocomplete="cc-exp"
+                  ariaRequired=true
                 />
               </div>
               <div className={innerLayout === Spaced ? "w-[47%]" : "w-[50%]"}>
@@ -672,6 +702,7 @@ let make = (
                   placeholder="123"
                   name=TestUtils.cardCVVInputTestId
                   autocomplete="cc-csc"
+                  ariaRequired=true
                 />
               </div>
             </div>
@@ -680,16 +711,16 @@ let make = (
                 (cardError->String.length > 0 ||
                 cvcError->String.length > 0 ||
                 expiryError->String.length > 0)}>
-              <div
+              <LiveError
+                text="Invalid input"
                 className="Error pt-1"
-                style={
+                style={{
                   color: themeObj.colorDangerText,
                   fontSize: themeObj.fontSizeSm,
                   alignSelf: "start",
                   textAlign: "left",
-                }>
-                {React.string("Invalid input")}
-              </div>
+                }}
+              />
             </RenderIf>
           </RenderIf>
           // Business-logic UI is hidden inside the Cards SDK iframe (those features

--- a/src/Payments/DateOfBirth.res
+++ b/src/Payments/DateOfBirth.res
@@ -68,6 +68,9 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
       renderCustomHeader={val => {
         <div className="flex gap-4 items-center justify-center m-2">
           <select
+            id="dob-year"
+            ariaLabel={localeString.yearLabel}
+            ariaRequired={fieldConfig.isRequired}
             className="p-1"
             value={val.date->Date.getFullYear->Int.toString}
             onChange={ev => {
@@ -83,6 +86,9 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
             ->React.array}
           </select>
           <select
+            id="dob-month"
+            ariaLabel={localeString.monthLabel}
+            ariaRequired={fieldConfig.isRequired}
             className="p-1"
             value={months[val.date->Date.getMonth]->Option.getOr("January")}
             onChange={ev => {
@@ -99,16 +105,16 @@ let make = (~fieldConfig: SuperpositionTypes.fieldConfig) => {
       }}
     />
     <RenderIf condition={showError && invalid}>
-      <div
+      <LiveError
+        text={field.meta.error->Option.getOr("")}
         className="Error pt-1"
-        style={
+        style={{
           color: themeObj.colorDangerText,
           fontSize: themeObj.fontSizeSm,
           alignSelf: "start",
           textAlign: "left",
-        }>
-        {field.meta.error->Option.getOr("")->React.string}
-      </div>
+        }}
+      />
     </RenderIf>
   </div>
 }

--- a/src/Utilities/AccessibilityUtils.res
+++ b/src/Utilities/AccessibilityUtils.res
@@ -1,0 +1,21 @@
+let visuallyHiddenClass = "!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]"
+
+let hasText = value => value->String.length > 0
+
+let hasOptionalText = value => value->Option.map(hasText)->Option.getOr(false)
+
+let getAccessibleLabel = (~fieldName="", ~placeholder="", ~fallback) =>
+  fieldName->hasText ? fieldName : placeholder->hasText ? placeholder : fallback
+
+let ariaInvalid = (~hasError, ~isValid) =>
+  if (
+    hasError ||
+    switch isValid {
+    | Some(false) => true
+    | _ => false
+    }
+  ) {
+    #"true"
+  } else {
+    #"false"
+  }

--- a/src/Utilities/AccessibilityUtils.res
+++ b/src/Utilities/AccessibilityUtils.res
@@ -19,3 +19,20 @@ let ariaInvalid = (~hasError, ~isValid) =>
   } else {
     #"false"
   }
+
+@send external focus: Dom.element => unit = "focus"
+
+@send
+external querySelectorAllWithin: (Dom.element, string) => array<Dom.element> = "querySelectorAll"
+
+@val @scope("document") external activeElement: Nullable.t<Dom.element> = "activeElement"
+
+let focusableSelector = "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])"
+
+let onActivateKeyDown = (~onActivate: unit => unit) => (event: JsxEvent.Keyboard.t) => {
+  let key = JsxEvent.Keyboard.key(event)
+  if key == "Enter" || JsxEvent.Keyboard.keyCode(event) == 13 || key == " " {
+    event->JsxEvent.Keyboard.preventDefault
+    onActivate()
+  }
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR improves keyboard navigation and focus management for the payment experience. It adds shared keyboard activation and focus primitives, applies clearer expanded/dialog state where relevant, and keeps non-native interactive controls operable with keyboard expectations that match native controls.

The user impact is smoother keyboard traversal, clearer assistive-technology context for dialogs and expandable controls, and fewer focus traps or dead ends during payment selection.

This PR is stacked after the form-control accessibility PR because it reuses the shared accessibility helper module introduced there.

Closes #1647

## How did you test it?

Validated as part of the completed accessibility stack. The checks cover the combined flow after all stacked PRs are applied, including keyboard and focus behavior exercised during the local accessibility smoke checks.

- Ran `npm run re:build` on the completed accessibility stack.
- Ran `npm run test:hooks` on the completed accessibility stack.
- Ran `npm run build` on the completed accessibility stack.
- Ran committed-range whitespace validation on the completed accessibility stack.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
