### PR TITLE
feat: add `OPPP` as dimension for dynamicFields resolution

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -193,6 +193,7 @@ let make = (
     buildSuperpositionBaseContext(
       ~paymentMethod,
       ~paymentMethodType=configPaymentMethodType,
+      ~platform="web",
       ~country,
       ~paymentMethodListValue,
       ~accountConfig=sdkConfigsValue.account_config,

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -196,6 +196,7 @@ let make = (
       ~country,
       ~paymentMethodListValue,
       ~accountConfig=sdkConfigsValue.account_config,
+      ~contextUsed=sdkConfigsValue.context_used,
     )
   }, (
     paymentMethod,
@@ -203,6 +204,7 @@ let make = (
     country,
     paymentMethodListValue,
     sdkConfigsValue.account_config,
+    sdkConfigsValue.context_used,
   ))
 
   let (requiredFields, missingRequiredFields, superpositionInitialValues) = React.useMemo(() => {

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -147,6 +147,7 @@ let buildSuperpositionBaseContext = (
   ~country: string,
   ~paymentMethodListValue: PaymentMethodsRecord.paymentMethodList,
   ~accountConfig: option<SdkConfigTypes.accountConfig>,
+  ~contextUsed: option<SdkConfigTypes.contextUsed>,
 ) => {
   let mandateType = switch paymentMethodListValue.payment_type {
   | NEW_MANDATE => "new_mandate"
@@ -162,6 +163,9 @@ let buildSuperpositionBaseContext = (
   let collectShipping = SdkConfigParser.getCollectShippingDetailsFromWalletConnector(profile)
     ? "true"
     : "false"
+  let (profileId, processorMerchantId, organizationId) = SdkConfigParser.getProfileContext(
+    contextUsed,
+  )
 
   let context: SuperpositionTypes.superpositionBaseContext = {
     payment_method: paymentMethod,
@@ -170,6 +174,9 @@ let buildSuperpositionBaseContext = (
     mandate_type: mandateType,
     collect_shipping_details_from_wallet_connector: collectShipping,
     collect_billing_details_from_wallet_connector: collectBilling,
+    profile_id: ?profileId,
+    processor_merchant_id: ?processorMerchantId,
+    organization_id: ?organizationId,
   }
   context
 }

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -144,6 +144,7 @@ let removeBillingDetailsIfUseBillingAddress = (
 let buildSuperpositionBaseContext = (
   ~paymentMethod: string,
   ~paymentMethodType: string,
+  ~platform: string,
   ~country: string,
   ~paymentMethodListValue: PaymentMethodsRecord.paymentMethodList,
   ~accountConfig: option<SdkConfigTypes.accountConfig>,
@@ -177,6 +178,7 @@ let buildSuperpositionBaseContext = (
     profile_id: ?profileId,
     processor_merchant_id: ?processorMerchantId,
     organization_id: ?organizationId,
+    platform,
   }
   context
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Added `organization_id`, `profile_id`, `processor_merchant_id `, `platform` as dimension for superposition's dynamicFields resolution.
- `organization_id`, `profile_id`, `merchant_id` are received in `sdk-configs` api response.
- corresponding shared-code PR: https://github.com/juspay/hyperswitch-sdk-utils/pull/77

## How did you test it?

- Added override on superposition integ for a `profile_id`. Got the expected resolved config for `dynamicFields` on platform `web`.

- #### Superposition dashboard (Integ)
<img width="1375" height="577" alt="image" src="https://github.com/user-attachments/assets/f9e1d99e-603b-4cb1-bbed-9abd3d350128" />

- #### Web sdk 
<img width="612" height="807" alt="image" src="https://github.com/user-attachments/assets/b33d729a-326d-40be-850d-af7ac1dbf9a1" />

<img width="786" height="205" alt="image" src="https://github.com/user-attachments/assets/11098125-b583-496b-b43d-5e2d3e98571b" />



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
