### PR TITLE
fix: expiry year parsing for vgs external vault

### DIFF
--- a/src/Utilities/VGSHelpers.res
+++ b/src/Utilities/VGSHelpers.res
@@ -22,7 +22,7 @@ let getTokenizedData = data => {
   let cardNumber = dict->getString("card_number", "")
   let cardExp = dict->getString("card_exp", "")
   let cardCvc = dict->getString("card_cvc", "")
-  let (month, year) = CardValidations.splitExpiryDates(cardExp)
+  let (month, year) = CardUtils.getExpiryDates(cardExp)
   (cardNumber, month, year, cardCvc)
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
## What

The VGS vault flow was sending a 2-digit `card_exp_year` (e.g. `"44"`) in the
`/payments/confirm` body, while every other card flow sends a 4-digit year
(e.g. `"2044"`). This aligns VGS with the rest.

## Why

`CardUtils.getExpiryDates` = `splitExpiryDates` **+** century prefix. It's what the
non-vault flow (`CardPayment.res:285`) and the Hyperswitch vault tokenizatio
(`CardPayment.res:211`) both use, so they emit `card_exp_year: "2044"`.

`VGSHelpers.getTokenizedData` was the only path calling the raw
`CardValidations.splitExpiryDates`, which returns the bare 2-digit year with
prefix. As a result the VGS confirm body (`vgsVaultCardBody`) shipped `"44"` instead
of `"2044"` — the only card flow doing so.

## Change

`src/Utilities/VGSHelpers.res` — `getTokenizedData` now parses the VGS expir
`CardUtils.getExpiryDates` instead of `CardValidations.splitExpiryDates`. Same
`(month, year)` tuple type; the year now carries the century prefix. Regener
`src/Utilities/VGSHelpers.bs.js` accordingly.

### Before
card_exp → splitExpiryDates("04 / 44")  → ("04", "44")    → card_exp_year: "
### After
card_exp → getExpiryDates("04 / 44")    → ("04", "2044")  → card_exp_year: "

## Affected flow

Only the VGS new-card vault flow (`getTokenizedData` is used solely at
`VGSVault.res:187`). The non-vault, Hyperswitch-vault, and saved-card-CVC flows are
unchanged — they already emitted a 4-digit year.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested via VGS Vault Flow in Safari

https://github.com/user-attachments/assets/bbb39584-71d5-47c2-8bd7-b43efecd7ca3



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
