### PR TITLE
fix: move makeOneClickHandlerPromise in ssn.onvalidatemerchant in ApplePay session

### DIFF
--- a/src/Payments/ApplePay.res
+++ b/src/Payments/ApplePay.res
@@ -292,30 +292,27 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
       )
       emitter.emitBillingAddress(~country, ~state, ~postalCode=pinCode)
       setApplePayClicked(_ => true)
-      makeOneClickHandlerPromise(sdkHandleIsThere)
-      ->then(result => {
-        let result = result->JSON.Decode.bool->Option.getOr(false)
-        if result {
-          if isInvokeSDKFlow {
-            if isApplePayDelayedSessionFlow {
-              setShowApplePayLoader(_ => true)
-              // New flow: send the initial session token directly to Elements (parent).
-              // Do NOT call /confirm here — the ApplePayInterceptor will trigger the
-              // confirm call from inside the iframe during onvalidatemerchant.
-              let sessionData = sessionObj->getOptionsDict->JSON.Encode.object
-              messageParentWindow([
-                ("applePayButtonClicked", true->JSON.Encode.bool),
-                ("applePayPresent", sessionData),
-                ("componentName", componentName->JSON.Encode.string),
-              ])
-            } else {
-              ApplePayHelpers.handleApplePayButtonClicked(
-                ~sessionObj,
-                ~componentName,
-                ~paymentMethodListValue,
-              )
-            }
-          } else {
+      if isInvokeSDKFlow {
+        if isApplePayDelayedSessionFlow {
+          setShowApplePayLoader(_ => true)
+          let sessionData = sessionObj->getOptionsDict->JSON.Encode.object
+          messageParentWindow([
+            ("applePayButtonClicked", true->JSON.Encode.bool),
+            ("applePayPresent", sessionData),
+            ("componentName", componentName->JSON.Encode.string),
+          ])
+        } else {
+          ApplePayHelpers.handleApplePayButtonClicked(
+            ~sessionObj,
+            ~componentName,
+            ~paymentMethodListValue,
+          )
+        }
+      } else {
+        makeOneClickHandlerPromise(sdkHandleIsThere)
+        ->then(result => {
+          let result = result->JSON.Decode.bool->Option.getOr(false)
+          if result {
             let bodyDict = PaymentBody.applePayRedirectBody(~connectors)
             ApplePayHelpers.processPayment(
               ~bodyArr=bodyDict,
@@ -326,16 +323,16 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
               ~publishableKey,
               ~isManualRetryEnabled,
             )
+          } else {
+            setApplePayClicked(_ => false)
           }
-        } else {
-          setApplePayClicked(_ => false)
-        }
-        resolve()
-      })
-      ->catch(_ => {
-        resolve()
-      })
-      ->ignore
+          resolve()
+        })
+        ->catch(_ => {
+          resolve()
+        })
+        ->ignore
+      }
     }
   }
 
@@ -343,6 +340,7 @@ let make = (~sessionObj: option<JSON.t>, ~walletOptions) => {
     ~connectors,
     ~intent,
     ~setApplePayClicked,
+    ~setShowApplePayLoader,
     ~syncPayment,
     ~isInvokeSDKFlow,
     ~isWallet,

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -110,7 +110,7 @@ let startApplePaySession = (
     ->catch(_ => {
       ssn.completeMerchantValidation(Dict.make()->JSON.Encode.object)
       handleFailureResponse(
-        ~message="ApplePay Merchant Validation Cancelled",
+        ~message="ApplePay Merchant Validation failed",
         ~errorType="apple_pay",
       )->resolvePromise
       resolve()

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -69,9 +69,9 @@ let startApplePaySession = (
   ~publishableKey,
   ~isTaxCalculationEnabled=false,
   ~sdkAuthorization=None,
-  ~sdkHandleIsThere=false,
 ) => {
   open Promise
+  let sdkHandleIsThere = LoaderPaymentElement.isPaymentButtonHandlerProvided.contents
   let ssn = applePaySession(3, paymentRequest)
   switch applePaySessionRef.contents->Nullable.toOption {
   | Some(session) =>

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -99,7 +99,7 @@ let startApplePaySession = (
           ->transformKeysWithoutModifyingValue(CamelCase)
         ssn.completeMerchantValidation(merchantSession)
       } else {
-        ssn.abort()
+        ssn.completeMerchantValidation(Dict.make()->JSON.Encode.object)
         handleFailureResponse(
           ~message="ApplePay Merchant Validation Cancelled",
           ~errorType="apple_pay",
@@ -108,7 +108,7 @@ let startApplePaySession = (
       resolve()
     })
     ->catch(_ => {
-      ssn.abort()
+      ssn.completeMerchantValidation(Dict.make()->JSON.Encode.object)
       handleFailureResponse(
         ~message="ApplePay Merchant Validation Cancelled",
         ~errorType="apple_pay",

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -86,14 +86,36 @@ let startApplePaySession = (
   applePaySessionRef := ssn->Js.Nullable.return
 
   ssn.onvalidatemerchant = _event => {
-    let merchantSession =
-      applePayPresent
-      ->Belt.Option.flatMap(JSON.Decode.object)
-      ->Option.getOr(Dict.make())
-      ->Dict.get("session_token_data")
-      ->Option.getOr(Dict.make()->JSON.Encode.object)
-      ->transformKeysWithoutModifyingValue(CamelCase)
-    ssn.completeMerchantValidation(merchantSession)
+    makeOneClickHandlerPromise(sdkHandleIsThere)
+    ->then(result => {
+      let result = result->JSON.Decode.bool->Option.getOr(false)
+      if result {
+        let merchantSession =
+          applePayPresent
+          ->Belt.Option.flatMap(JSON.Decode.object)
+          ->Option.getOr(Dict.make())
+          ->Dict.get("session_token_data")
+          ->Option.getOr(Dict.make()->JSON.Encode.object)
+          ->transformKeysWithoutModifyingValue(CamelCase)
+        ssn.completeMerchantValidation(merchantSession)
+      } else {
+        ssn.abort()
+        handleFailureResponse(
+          ~message="ApplePay Merchant Validation Cancelled",
+          ~errorType="apple_pay",
+        )->resolvePromise
+      }
+      resolve()
+    })
+    ->catch(_ => {
+      ssn.abort()
+      handleFailureResponse(
+        ~message="ApplePay Merchant Validation Cancelled",
+        ~errorType="apple_pay",
+      )->resolvePromise
+      resolve()
+    })
+    ->ignore
   }
 
   ssn.onshippingcontactselected = shippingAddressChangeEvent => {
@@ -198,27 +220,8 @@ let startApplePaySession = (
       ~errorType="apple_pay",
     )->resolvePromise
   }
-  makeOneClickHandlerPromise(sdkHandleIsThere)
-  ->then(result => {
-    let result = result->JSON.Decode.bool->Option.getOr(false)
-    if result {
-      ssn.begin()
-    } else {
-      handleFailureResponse(
-        ~message="ApplePay Session Cancelled",
-        ~errorType="apple_pay",
-      )->resolvePromise
-    }
-    resolve()
-  })
-  ->catch(_ => {
-    handleFailureResponse(
-      ~message="ApplePay Session Cancelled",
-      ~errorType="apple_pay",
-    )->resolvePromise
-    resolve()
-  })
-  ->ignore
+
+  ssn.begin()
 }
 
 let useHandleApplePayResponse = (

--- a/src/Utilities/ApplePayHelpers.res
+++ b/src/Utilities/ApplePayHelpers.res
@@ -69,6 +69,7 @@ let startApplePaySession = (
   ~publishableKey,
   ~isTaxCalculationEnabled=false,
   ~sdkAuthorization=None,
+  ~sdkHandleIsThere=false,
 ) => {
   open Promise
   let ssn = applePaySession(3, paymentRequest)
@@ -197,13 +198,34 @@ let startApplePaySession = (
       ~errorType="apple_pay",
     )->resolvePromise
   }
-  ssn.begin()
+  makeOneClickHandlerPromise(sdkHandleIsThere)
+  ->then(result => {
+    let result = result->JSON.Decode.bool->Option.getOr(false)
+    if result {
+      ssn.begin()
+    } else {
+      handleFailureResponse(
+        ~message="ApplePay Session Cancelled",
+        ~errorType="apple_pay",
+      )->resolvePromise
+    }
+    resolve()
+  })
+  ->catch(_ => {
+    handleFailureResponse(
+      ~message="ApplePay Session Cancelled",
+      ~errorType="apple_pay",
+    )->resolvePromise
+    resolve()
+  })
+  ->ignore
 }
 
 let useHandleApplePayResponse = (
   ~connectors,
   ~intent,
   ~setApplePayClicked=_ => (),
+  ~setShowApplePayLoader=_ => (),
   ~syncPayment=() => (),
   ~isInvokeSDKFlow=true,
   ~isSavedMethodsFlow=false,
@@ -268,6 +290,7 @@ let useHandleApplePayResponse = (
           )
         } else if dict->Dict.get("showApplePayButton")->Option.isSome {
           setApplePayClicked(_ => false)
+          setShowApplePayLoader(_ => false)
           if isSavedMethodsFlow || !isWallet {
             postFailedSubmitResponse(~errortype="server_error", ~message="Something went wrong")
           }

--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -132,7 +132,6 @@ let handleHyperApplePayMounted = (event: Types.event) => {
       ~isTaxCalculationEnabled,
       ~resolvePromise,
       ~sdkAuthorization=Some(sdkAuthorization),
-      ~sdkHandleIsThere=LoaderPaymentElement.isPaymentButtonHandlerProvided.contents,
     )
   }
 }

--- a/src/hyper-loader/Hyper.res
+++ b/src/hyper-loader/Hyper.res
@@ -132,6 +132,7 @@ let handleHyperApplePayMounted = (event: Types.event) => {
       ~isTaxCalculationEnabled,
       ~resolvePromise,
       ~sdkAuthorization=Some(sdkAuthorization),
+      ~sdkHandleIsThere=LoaderPaymentElement.isPaymentButtonHandlerProvided.contents,
     )
   }
 }


### PR DESCRIPTION


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The Apple Pay SDK flow creates the ApplePaySession in the loader (Hyper.res) via postMessage, not in the iframe component (ApplePay.res). Previously, makeOneClickHandlerPromise was only called in ApplePay.res before dispatching to either the SDK or redirect flow — meaning the SDK path never had the one-click handler gate.
This change:
1. ApplePay.res: Removes the one-click handler wrapper from the SDK flow path; it's now only used for the redirect (non-SDK) flow.
2. ApplePayHelpers.res: Adds ~sdkHandleIsThere to startApplePaySession and calls makeOneClickHandlerPromise right in ssn.onvalidatemerchant(). If the handler returns false, the session is aborted and a failure response is sent instead.
3. Hyper.res: Passes sdkHandleIsThere from LoaderPaymentElement.isPaymentButtonHandlerProvided into startApplePaySession.

## Note:
There is no other better way, so, currently we are using this approach for better UI.
<img width="818" height="334" alt="image" src="https://github.com/user-attachments/assets/c5541118-8995-49bf-9857-8634c2efdf97" />


<!-- Describe your changes in detail -->

## How did you test it?


```
... 
  const delay = (ms) =>
    new Promise((resolve) =>
      setTimeout(() => {
        console.log(`Resolving after ${ms}ms`, Date.now());
        resolve();
      }, ms),
    );
    
...

                  <PaymentElement
                    id="payment-element"
                    onChange={(event) => {
                      if (event?.eventName === "surchargeInfo") {
                        console.log("CardElement changed:", event);
                      }
                    }}
                    onFocus={(ev) => console.log("CardElement focused", ev)}
                    onReady={(ev) => console.log("CardElement ready", ev)}
                    onPaymentButtonClick={async () => {
                      const checkbox = document.getElementById("CheckboxID");
                      const isChecked = checkbox?.checked;
                      console.log("Payment button clicked", isChecked);

                      if (!isChecked) {
                        setCheckboxError(
                          "Please select the checkbox to continue with the payment.",
                        );
                        throw new Error("Terms and conditions not accepted");
                      } else {
                        await delay(7000);
                      }

                      // Clear error if validation passes
                      setCheckboxError("");
                    }}
                    onPaymentComplete={() => {
                      console.log("OnPaymentComplete");
                      // Add any custom post-payment logic here, such as redirection or displaying a success message
                    }}
                    options={paymentElementOptions(
                      parseLayoutParam(layoutQueryParam),
                      parseOptionsParam(optionsQueryParam),
                    )}
                  />
    
...
```


case 1: failed case(Error in makeOneClickHandlerPromise)




https://github.com/user-attachments/assets/5be89361-2b31-4ca5-b1f5-20c521ba8afe

https://github.com/user-attachments/assets/766f35dc-856c-415d-94c8-f4153142b4ee






case 2: normal flow


https://github.com/user-attachments/assets/0e12881d-1e20-4492-91f5-21f0f88ae137










<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible



