### PR TITLE
feat: improve eligibility surcharge UI

### DIFF
--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -62,6 +62,7 @@ let make = (
   ~installmentsError,
   ~setInstallmentsError,
   ~eligibilitySurchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+  ~isEligibilityPending=false,
   // Vault saved-card (return user) flow (VGS or Hyperswitch): when true, this card's
   // CVC is collected inside the nested iframe (ParentCardComponent saved-card mode)
   // instead of the plain input. `setCvcIframeRef` lifts the iframe ref to
@@ -235,11 +236,6 @@ let make = (
     ->PaymentUtils.filterInstallmentPlansByPaymentMethod(paymentItem.paymentMethod)
     ->Array.length > 0
 
-  let surchargeAmount =
-    eligibilitySurchargeDetails
-    ->Option.map(s => s.displayTotalSurchargeAmount->Float.toString)
-    ->Option.getOr("")
-
   <RenderIf condition={!hideExpiredPaymentMethods || !isCardExpired}>
     <button
       className={`PickerItem ${pickerItemClass} flex flex-row items-stretch`}
@@ -404,16 +400,10 @@ let make = (
                   paymentMethodType
                   cardBrand={cardBrand->CardUtils.getCardType}
                 />
-                <RenderIf condition={eligibilitySurchargeDetails->Option.isSome && isCard}>
-                  <div className="flex items-baseline text-xs mt-2 ml-1">
-                    <Icon name="asterisk" size=8 className="text-red-600 mr-1" />
-                    <div className="text-left text-gray-400">
-                      {localeString.surchargeMsgAmountForCard(
-                        paymentMethodListValue.currency,
-                        surchargeAmount,
-                      )}
-                    </div>
-                  </div>
+                <RenderIf condition={isCard}>
+                  <SurchargeEligibilityNotice
+                    eligibilitySurchargeDetails isEligibilityPending className="mt-3 ml-1.5"
+                  />
                 </RenderIf>
               </RenderIf>
             </div>

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -143,11 +143,18 @@ let make = (
     <div
       className="PickerItemContainer" tabIndex={0} role="region" ariaLabel="Saved payment methods">
       {visibleSavedMethods
-      ->Array.mapWithIndex((obj, i) =>
+      ->Array.mapWithIndex((obj, i) => {
+        let isActive = paymentTokenVal == obj.paymentToken
+        let (eligibilitySurchargeDetails, isEligibilityPending) = isActive
+          ? (
+              eligibilitySurchargeDetails,
+              isEligibilityPending && paymentMethodListValue.should_block_confirm,
+            )
+          : (None, false)
         <SavedCardItem
           key={i->Int.toString}
           setPaymentToken
-          isActive={paymentTokenVal == obj.paymentToken}
+          isActive
           paymentItem=obj
           brandIcon={obj->getPaymentMethodBrand}
           index=i
@@ -159,13 +166,12 @@ let make = (
           setShowInstallments
           installmentsError
           setInstallmentsError
-          eligibilitySurchargeDetails={paymentTokenVal == obj.paymentToken
-            ? eligibilitySurchargeDetails
-            : None}
+          eligibilitySurchargeDetails
+          isEligibilityPending
           isVaultCvcFlow
           setCvcIframeRef
         />
-      )
+      })
       ->React.array}
       <RenderIf condition={hasMoreSavedMethods}>
         <ShowMoreToggle isCollapsed setIsCollapsed />
@@ -610,13 +616,6 @@ let make = (
     } else {
       <RenderIf condition=showSavedCards> {bottomElement} </RenderIf>
     }}
-    <RenderIf condition={isEligibilityPending && paymentMethodListValue.should_block_confirm}>
-      <div className="flex items-baseline text-xs mt-2">
-        <div className="text-left text-gray-400">
-          {localeString.paymentDetailsBeingCheckedText->React.string}
-        </div>
-      </div>
-    </RenderIf>
     <RenderIf condition={conditionsForShowingSaveCardCheckbox && !alwaysSendCustomerAcceptance}>
       <div className="pt-4 pb-2 flex items-center justify-start">
         <SaveDetailsCheckbox isChecked=isSaveCardsChecked setIsChecked=setIsSaveCardsChecked />

--- a/src/Components/SurchargeEligibilityNotice.res
+++ b/src/Components/SurchargeEligibilityNotice.res
@@ -1,0 +1,54 @@
+@react.component
+let make = (
+  ~eligibilitySurchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+  ~isEligibilityPending=false,
+  ~className="",
+) => {
+  let {themeObj, localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
+  let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
+  let surchargeAmount =
+    eligibilitySurchargeDetails
+    ->Option.map(s => s.displayTotalSurchargeAmount->Float.toString)
+    ->Option.getOr("")
+
+  <RenderIf condition={isEligibilityPending || eligibilitySurchargeDetails->Option.isSome}>
+    <div className={`w-full ${className}`}>
+      {if isEligibilityPending {
+        <div
+          className="w-full"
+          role="status"
+          ariaLive=#polite
+          ariaAtomic=true>
+          <span className="sr-only">
+            {localeString.paymentDetailsBeingCheckedText->React.string}
+          </span>
+          <div
+            className="relative h-2.5 w-[72%] overflow-hidden rounded"
+            style={backgroundColor: themeObj.borderColor, opacity: "0.75"}
+            ariaHidden=true>
+            <div
+              className="absolute inset-0 -translate-x-full animate-[shimmer_1.4s_ease_infinite] bg-gradient-to-r from-transparent via-white/70 to-transparent"
+            />
+          </div>
+        </div>
+      } else {
+        <div className="flex items-start text-xs" role="status" ariaLive=#polite ariaAtomic=true>
+          <span ariaHidden=true>
+            <Icon name="asterisk" size=8 className="text-red-600 mr-1 mt-[3px] shrink-0" />
+          </span>
+          <div
+            className="text-left"
+            style={
+              color: themeObj.colorTextSecondary,
+              lineHeight: "1.45",
+            }>
+            {localeString.surchargeMsgAmountForCard(
+              paymentMethodListValue.currency,
+              surchargeAmount,
+            )}
+          </div>
+        </div>
+      }}
+    </div>
+  </RenderIf>
+}

--- a/src/Payments/CardPayment.res
+++ b/src/Payments/CardPayment.res
@@ -587,10 +587,6 @@ let make = (
   let compressedLayoutStyleForCvcError =
     innerLayout === Compressed && cvcError->String.length > 0 ? "!border-l-0" : ""
   let accordionMarginClass = layoutClass.\"type" === Accordion && !isInsideCardSDK ? "mt-4" : ""
-  let surchargeAmount =
-    eligibilitySurchargeDetails
-    ->Option.map(s => s.displayTotalSurchargeAmount->Float.toString)
-    ->Option.getOr("")
   <div className="animate-slowShow">
     <RenderIf condition={showPaymentMethodsScreen || isBancontact}>
       <div
@@ -729,24 +725,11 @@ let make = (
               />
             </>}
           </RenderIf>
-          <RenderIf condition={eligibilitySurchargeDetails->Option.isSome}>
-            <div className="flex items-baseline text-xs mt-2">
-              <Icon name="asterisk" size=8 className="text-red-600 mr-1" />
-              <div className="text-left text-gray-400">
-                {localeString.surchargeMsgAmountForCard(
-                  paymentMethodListValue.currency,
-                  surchargeAmount,
-                )}
-              </div>
-            </div>
-          </RenderIf>
-          <RenderIf condition={isEligibilityPending && paymentMethodListValue.should_block_confirm}>
-            <div className="flex items-baseline text-xs mt-2">
-              <div className="text-left text-gray-400">
-                {localeString.paymentDetailsBeingCheckedText->React.string}
-              </div>
-            </div>
-          </RenderIf>
+          <SurchargeEligibilityNotice
+            eligibilitySurchargeDetails
+            isEligibilityPending={isEligibilityPending &&
+            paymentMethodListValue.should_block_confirm}
+          />
         </div>
       </div>
     </RenderIf>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Closes #1664

This PR updates the SDK eligibility surcharge presentation for card form and saved-card flows.

- Adds a shared `SurchargeEligibilityNotice` component for eligibility surcharge UI.
- Shows a skeleton while eligibility surcharge checks are pending.
- Reuses the current translated surcharge copy when the eligibility surcharge resolves.
- Keeps pending and resolved eligibility surcharge states accessible with polite, atomic status announcements.
- Keeps saved-card eligibility state scoped to the active saved card.

## How did you test it?
Tested Locally

https://github.com/user-attachments/assets/2ea41fbd-4d63-4b96-af11-66e7c2877294



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
