### PR TITLE
feat: added logging instrumentation for update intent flow

### DIFF
--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -391,6 +391,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
         } else if dict->getDictIsSome("paymentElementsUpdate") {
           updateOptions(dict)
         } else if dict->getDictIsSome("ElementsUpdate") {
+          logger.setLogInfo(~value="SDK Credentials Received from Loader", ~eventName=UPDATE_SDK)
           let optionsDict = dict->getDictFromObj("options")
           let clientSecret = dict->Dict.get("clientSecret")
           switch clientSecret {
@@ -632,7 +633,13 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
           setIsApplePayReady(prev => prev && false)
         }
         if dict->Dict.get("updateIntentLoading")->Option.isSome {
-          setIsUpdateIntentLoading(_ => dict->getBool("updateIntentLoading", false))
+          let isLoading = dict->getBool("updateIntentLoading", false)
+          setIsUpdateIntentLoading(_ => isLoading)
+          if isLoading {
+            logger.setLogInfo(~value="Update Intent Loading Started", ~eventName=UPDATE_INTENT)
+          } else {
+            logger.setLogInfo(~value="Update Intent Loading Completed", ~eventName=UPDATE_INTENT)
+          }
         }
       } catch {
       | _ => setIntegrateErrorError(_ => true)

--- a/src/Types/HyperLoggerTypes.res
+++ b/src/Types/HyperLoggerTypes.res
@@ -106,6 +106,8 @@ type eventName =
   | PAYMENT_METHOD_ELIGIBILITY_CALL_INIT
   | DDC_FLOW
   | VGS_VAULT_FLOW
+  | UPDATE_INTENT
+  | UPDATE_SDK
 
 type maskableDetails = Email | CardDetails
 type source = Loader | Elements(CardThemeType.mode) | Headless

--- a/src/Utilities/LoggerUtils.res
+++ b/src/Utilities/LoggerUtils.res
@@ -338,6 +338,8 @@ let apiEventInitMapper = (eventName: HyperLoggerTypes.eventName): option<
   | TEST_MODE
   | DDC_FLOW
   | VGS_VAULT_FLOW
+  | UPDATE_INTENT
+  | UPDATE_SDK
   | CLIENT_LIST_CALL_INIT =>
     None
   }

--- a/src/hyper-loader/Elements.res
+++ b/src/hyper-loader/Elements.res
@@ -347,6 +347,7 @@ let make = (
           ~isSdkParamsEnabled,
           ~selectorString=localSelectorString,
           ~shouldWaitForReady=paymentElementIframeRef->Array.length > 0,
+          ~logger,
         )
 
         // Only forward data and update tax calculation if updateIntent succeeded

--- a/src/hyper-loader/PaymentSession.res
+++ b/src/hyper-loader/PaymentSession.res
@@ -44,6 +44,7 @@ let make = (
       ~isSdkParamsEnabled=false,
       ~selectorString=localSelectorString,
       ~shouldWaitForReady=false,
+      ~logger,
     )
   }
 

--- a/src/hyper-loader/UpdateIntentHelpersNew.res
+++ b/src/hyper-loader/UpdateIntentHelpersNew.res
@@ -4,6 +4,7 @@
 open Utils
 open Identity
 open EventListenerManager
+open HyperLoggerTypes
 
 // --- Iframe messaging helpers ---
 
@@ -280,11 +281,14 @@ let performUpdateIntent = async (
   ~isSdkParamsEnabled,
   ~selectorString,
   ~shouldWaitForReady,
+  ~logger: HyperLoggerTypes.loggerMake,
 ) => {
   if isUpdateIntentInProgress.contents {
     updateIntentInProgressResponse()
   } else {
     isUpdateIntentInProgress.contents = true
+
+    logger.setLogInfo(~value="Update Intent Initiated", ~eventName=UPDATE_INTENT)
 
     let response = try {
       // Get new credentials from merchant callback
@@ -328,6 +332,7 @@ let performUpdateIntent = async (
           ->getDictFromJson
           ->getDictFromDict("error")
           ->getString("message", "An API call failed during updateIntent.")
+        logger.setLogError(~value=errorMessage, ~eventName=UPDATE_INTENT)
         getFailedSubmitResponse(~message=errorMessage, ~errorType="update_intent_error")
 
       | None =>
@@ -340,6 +345,7 @@ let performUpdateIntent = async (
         clientListDataPromise.contents = newClientListDataPromise
 
         // Send ElementsUpdate to all inner iframes with new credentials
+        logger.setLogInfo(~value="Update SDK Sent to Iframes", ~eventName=UPDATE_SDK)
         sendElementsUpdateToIframes(
           iframes,
           ~newSdkAuthorization,
@@ -368,19 +374,18 @@ let performUpdateIntent = async (
         | None => ()
         }
 
+        logger.setLogInfo(~value="Update Intent Completed Successfully", ~eventName=UPDATE_INTENT)
         [("status", "succeeded"->JSON.Encode.string)]->getJsonFromArrayOfJson
       }
     } catch {
     | Exn.Error(e) =>
-      getFailedSubmitResponse(
-        ~message=Exn.message(e)->Option.getOr("Something went wrong during updateIntent!"),
-        ~errorType="update_intent_error",
-      )
+      let msg = Exn.message(e)->Option.getOr("Something went wrong during updateIntent!")
+      logger.setLogError(~value=msg, ~eventName=UPDATE_INTENT)
+      getFailedSubmitResponse(~message=msg, ~errorType="update_intent_error")
     | _ =>
-      getFailedSubmitResponse(
-        ~message="An unexpected error occurred during updateIntent.",
-        ~errorType="update_intent_error",
-      )
+      let msg = "An unexpected error occurred during updateIntent."
+      logger.setLogError(~value=msg, ~eventName=UPDATE_INTENT)
+      getFailedSubmitResponse(~message=msg, ~errorType="update_intent_error")
     }
     isUpdateIntentInProgress.contents = false
     response


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
#1666
Adds end-to-end logging instrumentation for the `updateIntent` flow across both the hyper-loader and the SDK iframe.
### New event names (`HyperLoggerTypes.res`)

| Event | Purpose |
|---|---|
| `UPDATE_INTENT` | Tracks all stages of an updateIntent operation (initiated, completed, error) |
| `UPDATE_SDK` | Tracks when new SDK credentials are sent to / received by iframes |
### Loader-side logs (`UpdateIntentHelpersNew.res`)
`performUpdateIntent` now accepts a `~logger` parameter (forwarded from both `Elements.res` and `PaymentSession.res`) and emits:
- `UPDATE_INTENT` (`setLogInfo`, value: `"Update Intent Initiated"`) — when the flow begins
- `UPDATE_SDK` (`setLogInfo`, value: `"Update SDK Sent to Iframes"`) — just before `ElementsUpdate` is posted to iframes
- `UPDATE_INTENT` (`setLogInfo`, value: `"Update Intent Completed Successfully"`) — on success
- `UPDATE_INTENT` (`setLogError`, value: error message) — on API failure or exception
### Iframe-side logs (`LoaderController.res`)
- `UPDATE_SDK` (`setLogInfo`, value: `"SDK Credentials Received from Loader"`) — when `ElementsUpdate` postMessage arrives, confirming credentials reached the iframe
- `UPDATE_INTENT` (`setLogInfo`, value: `"Update Intent Loading Started"`) — when `updateIntentLoading: true` arrives (overlay raised)
- `UPDATE_INTENT` (`setLogInfo`, value: `"Update Intent Loading Completed"`) — when `updateIntentLoading: false` arrives (overlay lowered, full cycle done)

### End-to-end log sequence for a successful `updateIntent` call
| Source | Event | Value |
|---|---|---|
| Loader | `UPDATE_INTENT` | "Update Intent Initiated" |
| Iframe | `UPDATE_INTENT` | "Update Intent Loading Started" |
| Loader | `UPDATE_SDK` | "Update SDK Sent to Iframes" |
| Iframe | `UPDATE_SDK` | "SDK Credentials Received from Loader" |
| Loader | `UPDATE_INTENT` | "Update Intent Completed Successfully" |
| Iframe | `UPDATE_INTENT` | "Update Intent Loading Completed" |

## How did you test it?

Tested manually by triggering `updateIntent` from a merchant integration and verifying all log events were emitted in the correct order with expected values. Confirmed error paths (`setLogError`) fire correctly when an API call fails during the flow.

https://github.com/user-attachments/assets/cc2e232c-7d56-4f54-b6a8-08ba27b9526e



## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible