### PR TITLE
feat: added logs for dynamic fields being rendered for each payment method

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -321,6 +321,15 @@ let make = (
     None
   }, (isSavedCardFlow, hasAnyField))
 
+  // Log which dynamic fields are being rendered for the current payment method.
+  DynamicFieldsUtils.useLogDynamicFieldsRendered(
+    ~missingRequiredFieldsFiltered,
+    ~paymentMethod,
+    ~configPaymentMethodType,
+    ~rawConfigs,
+    ~isSavedCardFlow,
+  )
+
   <>
     <RenderIf condition={!isSavedCardFlow && hasAnyField}>
       <ReactFinalForm.Form

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -328,6 +328,8 @@ let make = (
     ~configPaymentMethodType,
     ~rawConfigs,
     ~isSavedCardFlow,
+    ~eligibleConnectors,
+    ~superpositionBaseContext,
   )
 
   <>

--- a/src/Components/SurchargeEligibilityNotice.res
+++ b/src/Components/SurchargeEligibilityNotice.res
@@ -14,11 +14,7 @@ let make = (
   <RenderIf condition={isEligibilityPending || eligibilitySurchargeDetails->Option.isSome}>
     <div className={`w-full ${className}`}>
       {if isEligibilityPending {
-        <div
-          className="w-full"
-          role="status"
-          ariaLive=#polite
-          ariaAtomic=true>
+        <div className="w-full" role="status" ariaLive=#polite ariaAtomic=true>
           <span className="sr-only">
             {localeString.paymentDetailsBeingCheckedText->React.string}
           </span>

--- a/src/Types/HyperLoggerTypes.res
+++ b/src/Types/HyperLoggerTypes.res
@@ -108,6 +108,7 @@ type eventName =
   | VGS_VAULT_FLOW
   | UPDATE_INTENT
   | UPDATE_SDK
+  | DYNAMIC_FIELDS_RENDERED
 
 type maskableDetails = Email | CardDetails
 type source = Loader | Elements(CardThemeType.mode) | Headless

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -502,6 +502,64 @@ let applyBillingDetailsOverride = (
   initialValues
 }
 
+let useLogDynamicFieldsRendered = (
+  ~missingRequiredFieldsFiltered: array<SuperpositionTypes.fieldConfig>,
+  ~paymentMethod: string,
+  ~configPaymentMethodType: string,
+  ~rawConfigs: option<JSON.t>,
+  ~isSavedCardFlow: bool,
+) => {
+  let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
+  let lastLoggedKey = React.useRef("")
+
+  // Log which dynamic fields are being rendered for the current payment method.
+  // Fires once per (paymentMethod, configPaymentMethodType) combination; the
+  // dedupeKey guard prevents re-logging when unrelated state (e.g. billingAddress
+  // toggle) causes missingRequiredFieldsFiltered to change identity.
+  React.useEffect(() => {
+    if !isSavedCardFlow && rawConfigs->Option.isSome {
+      let dedupeKey = paymentMethod ++ "|" ++ configPaymentMethodType
+      if lastLoggedKey.current !== dedupeKey {
+        lastLoggedKey.current = dedupeKey
+        let fieldsJson =
+          missingRequiredFieldsFiltered
+          ->Array.map(field =>
+            [
+              ("field_type", (field.fieldRenderType :> string)->JSON.Encode.string),
+              ("write_path", field.confirmRequestWritePath->JSON.Encode.string),
+            ]
+            ->Dict.fromArray
+            ->JSON.Encode.object
+          )
+          ->JSON.Encode.array
+        let payload =
+          [
+            ("payment_method", paymentMethod->JSON.Encode.string),
+            ("payment_method_type", configPaymentMethodType->JSON.Encode.string),
+            ("field_count", missingRequiredFieldsFiltered->Array.length->JSON.Encode.int),
+            ("fields", fieldsJson),
+          ]
+          ->Dict.fromArray
+          ->JSON.Encode.object
+          ->JSON.stringify
+        loggerState.setLogInfo(
+          ~value=payload,
+          ~eventName=HyperLoggerTypes.DYNAMIC_FIELDS_RENDERED,
+          ~paymentMethod,
+        )
+      }
+    }
+    None
+  }, (
+    missingRequiredFieldsFiltered,
+    paymentMethod,
+    configPaymentMethodType,
+    rawConfigs,
+    isSavedCardFlow,
+    loggerState,
+  ))
+}
+
 // TODO: refactor event emitters to use react-final-forms
 let useSyncEmitAddressAtoms = () => {
   let country = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -508,6 +508,8 @@ let useLogDynamicFieldsRendered = (
   ~configPaymentMethodType: string,
   ~rawConfigs: option<JSON.t>,
   ~isSavedCardFlow: bool,
+  ~eligibleConnectors,
+  ~superpositionBaseContext: SuperpositionTypes.superpositionBaseContext,
 ) => {
   let loggerState = Recoil.useRecoilValueFromAtom(RecoilAtoms.loggerAtom)
   let lastLoggedKey = React.useRef("")
@@ -527,6 +529,23 @@ let useLogDynamicFieldsRendered = (
             [
               ("field_type", (field.fieldRenderType :> string)->JSON.Encode.string),
               ("write_path", field.confirmRequestWritePath->JSON.Encode.string),
+              (
+                "intent_data_read_path",
+                field.intentDataReadPath
+                ->Option.map(JSON.Encode.string)
+                ->Option.getOr(JSON.Null),
+              ),
+              ("is_required", field.isRequired->JSON.Encode.bool),
+              (
+                "validation_rule_type",
+                field.validationRuleType->Option.map(JSON.Encode.string)->Option.getOr(JSON.Null),
+              ),
+              (
+                "validation_regex_pattern",
+                field.validationRegexPattern
+                ->Option.map(JSON.Encode.string)
+                ->Option.getOr(JSON.Null),
+              ),
             ]
             ->Dict.fromArray
             ->JSON.Encode.object
@@ -534,8 +553,8 @@ let useLogDynamicFieldsRendered = (
           ->JSON.Encode.array
         let payload =
           [
-            ("payment_method", paymentMethod->JSON.Encode.string),
-            ("payment_method_type", configPaymentMethodType->JSON.Encode.string),
+            ("superposition_base_context", superpositionBaseContext->Identity.anyTypeToJson),
+            ("eligible_connectors", eligibleConnectors->JSON.Encode.array),
             ("field_count", missingRequiredFieldsFiltered->Array.length->JSON.Encode.int),
             ("fields", fieldsJson),
           ]
@@ -556,6 +575,8 @@ let useLogDynamicFieldsRendered = (
     configPaymentMethodType,
     rawConfigs,
     isSavedCardFlow,
+    eligibleConnectors,
+    superpositionBaseContext,
     loggerState,
   ))
 }

--- a/src/Utilities/LoggerUtils.res
+++ b/src/Utilities/LoggerUtils.res
@@ -340,6 +340,7 @@ let apiEventInitMapper = (eventName: HyperLoggerTypes.eventName): option<
   | VGS_VAULT_FLOW
   | UPDATE_INTENT
   | UPDATE_SDK
+  | DYNAMIC_FIELDS_RENDERED
   | CLIENT_LIST_CALL_INIT =>
     None
   }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a `DYNAMIC_FIELDS_RENDERED` log event to track which dynamic payment form fields are rendered to the merchant per payment method selection. This provides observability into the field-rendering pipeline following the recent refactoring of `DynamicFields.res` into a modular sub-component architecture.
## Changes
| File | Change |
|---|---|
| `src/Types/HyperLoggerTypes.res` | Registers `DYNAMIC_FIELDS_RENDERED` as a new `eventName` variant |
| `src/Utilities/LoggerUtils.res` | Adds the new variant to the exhaustive `None` branch of `apiEventInitMapper` |
| `src/Utilities/DynamicFieldsUtils.res` | New custom hook `useLogDynamicFieldsRendered` that owns all logging logic |
| `src/Components/DynamicFields.res` | Calls `DynamicFieldsUtils.useLogDynamicFieldsRendered(...)` |

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Following Dynamic Fields getting logged - 

```
{
  "superposition_base_context": {
    "payment_method": "card",
    "payment_method_type": "debit",
    "platform": "web",
    "country": "India",
    "mandate_type": "non_mandate",
    "collect_shipping_details_from_wallet_connector": "false",
    "collect_billing_details_from_wallet_connector": "false",
    "profile_id": "pro_a4ahmFAnMFwvDeQjVEos",
    "organization_id": "org_S7kONhD2T7y7IHNCA0hv"
  },
  "eligible_connectors": [
    "cybersource"
  ],
  "field_count": 7,
  "fields": [
    {
      "field_type": "Email",
      "write_path": "payment_method_data.billing.email",
      "intent_data_read_path": "billing.email",
      "is_required": true,
      "validation_rule_type": "regex",
      "validation_regex_pattern": "^(([^<>()[\\\\]\\\\\\\\.,;:\\\\s@\\\\\\\"]+(\\\\.[^<>()[\\\\]\\\\\\\\.,;:\\\\s@\\\\\\\"]+)*)|(\\\\\\\".+\\\\\\\"))@((\\\\[[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}\\\\])|(([a-zA-Z\\\\-0-9]+\\\\.)+[a-zA-Z]{2,}))$"
    },
    {
      "field_type": "CardHolderName",
      "write_path": "payment_method_data.billing.address.first_name",
      "intent_data_read_path": "billing.address.first_name",
      "is_required": true,
      "validation_rule_type": null,
      "validation_regex_pattern": null
    },
    {
      "field_type": "Generic",
      "write_path": "payment_method_data.billing.address.line1",
      "intent_data_read_path": "billing.address.line1",
      "is_required": true,
      "validation_rule_type": null,
      "validation_regex_pattern": null
    },
    {
      "field_type": "Generic",
      "write_path": "payment_method_data.billing.address.city",
      "intent_data_read_path": "billing.address.city",
      "is_required": true,
      "validation_rule_type": null,
      "validation_regex_pattern": null
    },
    {
      "field_type": "State",
      "write_path": "payment_method_data.billing.address.state",
      "intent_data_read_path": "billing.address.state",
      "is_required": true,
      "validation_rule_type": null,
      "validation_regex_pattern": null
    },
    {
      "field_type": "Country",
      "write_path": "payment_method_data.billing.address.country",
      "intent_data_read_path": "billing.address.country",
      "is_required": true,
      "validation_rule_type": null,
      "validation_regex_pattern": null
    },
    {
      "field_type": "Generic",
      "write_path": "payment_method_data.billing.address.zip",
      "intent_data_read_path": "billing.address.zip",
      "is_required": true,
      "validation_rule_type": null,
      "validation_regex_pattern": null
    }
  ]
}

```
<img width="1034" height="241" alt="image" src="https://github.com/user-attachments/assets/36480883-4676-458c-b2fa-e5c7442ddac3" />

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
