### PR TITLE
fix: change country to country iso2 codes for superposition config param

### DIFF
--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -238,7 +238,8 @@ let usePaymentMethodTypeFromList = (
 let useSuperpositionRequiredFields = (~paymentMethod, ~paymentMethodType) => {
   let sdkConfigsValue = Recoil.useRecoilValueFromAtom(PaymentUtils.sdkConfigsValue)
   let paymentMethodListValue = Recoil.useRecoilValueFromAtom(PaymentUtils.paymentMethodListValue)
-  let country = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
+  let userCountryName = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
+  let country = Utils.getCountryCode(userCountryName).isoAlpha2
 
   let rawConfigs = sdkConfigsValue.raw_configs
   let getSuperpositionFinalFields = ConfigurationService.useConfigurationService(~rawConfigs)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Fixed country dimension being sent as countryName, while the expected value was corresponding ISO2 code. This parameter is required while resolving `required_fields` from superposition.

## How did you test it?

- Added console.log to log the config-parameters (`dimensions`) being sent for config resolution.

| Before                                                                                                                             | After                                                                                                                              |
|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
| <img width="600" height="220" alt="image" src="https://github.com/user-attachments/assets/bd643237-983d-45b8-8342-2adeb16557d4" /> | <img width="600" height="220" alt="image" src="https://github.com/user-attachments/assets/88631169-b97a-43cc-a4a8-50e76a109f0e" /> |

- Checked by toggling `userCountry` selection.

<img width="594" height="88" alt="image" src="https://github.com/user-attachments/assets/f2a68ece-5242-4147-a723-9a9ad753ffda" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
