### PR TITLE
fix: intent data bypass via dynamic fields

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -172,6 +172,10 @@ let make = (
     resolutionContext,
   ) = DynamicFieldsUtils.useSuperpositionRequiredFields(~paymentMethod, ~paymentMethodType)
   let initialValues = React.useMemo(() => superpositionInitialValues, (intentData, paymentMethodType))
+  React.useEffect(() => {
+    setRequiredFieldsBody(prev => prev->filterByActiveFields(requiredFields))
+    None
+  }, [requiredFields])
 
   let missingRequiredFieldsFiltered = React.useMemo(() => {
     let afterBillingFilter = removeBillingDetailsIfUseBillingAddress(
@@ -213,7 +217,7 @@ let make = (
     })
   }, (missingRequiredFields, billingAddress.isUseBillingAddress))
 
-  let finalInitialValues = React.useMemo(() => {
+  let initialValuesWithBillingDataOverride = React.useMemo(() => {
     DynamicFieldsUtils.applyBillingDetailsOverride(initialValues, defaultValues.billingDetails)
   }, (initialValues, defaultValues.billingDetails))
 
@@ -270,7 +274,7 @@ let make = (
     redirectionInfo === ShowRedirectionInfo
 
   let hasAnyField = missingRequiredFieldsFiltered->Array.length > 0
-  let shouldRenderForm = hasAnyField || finalInitialValues->Dict.keysToArray->Array.length > 0
+  let shouldRenderForm = hasAnyField || initialValuesWithBillingDataOverride->Dict.keysToArray->Array.length > 0
   let setAreRequiredFieldsValid = Recoil.useSetRecoilState(areRequiredFieldsValid)
   let setAreRequiredFieldsEmpty = Recoil.useSetRecoilState(areRequiredFieldsEmpty)
 
@@ -303,7 +307,7 @@ let make = (
   <>
     <RenderIf condition={!isSavedCardFlow && shouldRenderForm}>
       <ReactFinalForm.Form
-        initialValues={Some(finalInitialValues)}
+        initialValues={Some(initialValuesWithBillingDataOverride)}
         onSubmit={_values => ()}
         render={formProps =>
           <FormBody

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -163,11 +163,6 @@ let make = (
   let {billingAddress, redirectionInfo, defaultValues} = Recoil.useRecoilValueFromAtom(optionAtom)
   let syncEmitAddressAtoms = DynamicFieldsUtils.useSyncEmitAddressAtoms()
 
-  React.useEffect(() => {
-    setRequiredFieldsBody(_ => Dict.make())
-    None
-  }, [paymentMethodType])
-
   let intentData = paymentMethodListValue.intent_data.intentDataObject
 
   let (
@@ -176,7 +171,7 @@ let make = (
     superpositionInitialValues,
     resolutionContext,
   ) = DynamicFieldsUtils.useSuperpositionRequiredFields(~paymentMethod, ~paymentMethodType)
-  let initialValues = React.useMemo(() => superpositionInitialValues, [intentData])
+  let initialValues = React.useMemo(() => superpositionInitialValues, (intentData, paymentMethodType))
 
   let missingRequiredFieldsFiltered = React.useMemo(() => {
     let afterBillingFilter = removeBillingDetailsIfUseBillingAddress(
@@ -275,6 +270,7 @@ let make = (
     redirectionInfo === ShowRedirectionInfo
 
   let hasAnyField = missingRequiredFieldsFiltered->Array.length > 0
+  let shouldRenderForm = hasAnyField || finalInitialValues->Dict.keysToArray->Array.length > 0
   let setAreRequiredFieldsValid = Recoil.useSetRecoilState(areRequiredFieldsValid)
   let setAreRequiredFieldsEmpty = Recoil.useSetRecoilState(areRequiredFieldsEmpty)
 
@@ -286,6 +282,16 @@ let make = (
     None
   }, (isSavedCardFlow, hasAnyField))
 
+  // When a form renders, FormBody's onFormChange fully replaces requiredFieldsBody, so switching
+  // methods is handled automatically. When no form renders, FormBody is unmounted and nothing
+  // overwrites the body, so we clear it here to avoid leaking the previous method's values.
+  React.useEffect(() => {
+    if !shouldRenderForm {
+      setRequiredFieldsBody(_ => Dict.make())
+    }
+    None
+  }, (paymentMethodType, shouldRenderForm))
+
   // Log which dynamic fields are being rendered for the current payment method.
   DynamicFieldsUtils.useLogDynamicFieldsRendered(
     ~fields=missingRequiredFieldsFiltered,
@@ -295,7 +301,7 @@ let make = (
   )
 
   <>
-    <RenderIf condition={!isSavedCardFlow && hasAnyField}>
+    <RenderIf condition={!isSavedCardFlow && shouldRenderForm}>
       <ReactFinalForm.Form
         initialValues={Some(finalInitialValues)}
         onSubmit={_values => ()}

--- a/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
+++ b/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
@@ -31,15 +31,11 @@ let make = (~fieldConfig: fieldConfig, ~isLabelHidden=false) => {
     })
   )
 
-  let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let firstOptionValue =
     phoneNumberCodeOptions->Array.get(0)->Option.map(o => o.value)->Option.getOr("")
-  let seedCountry = defaultCountry !== "" ? defaultCountry : firstOptionValue
-  let seedIso = getCountryCode(seedCountry).isoAlpha2
-
   let defaultDropdownValue =
     countryAndCodeList
-    ->Array.find(c => c->getDictFromJson->getString("country_code", "") === seedIso)
+    ->Array.find(c => c->getDictFromJson->getString("country_code", "") === defaultCountryCode)
     ->Option.map(c => {
       let countryDict = c->getDictFromJson
       let flag = countryDict->getString("country_flag", "")

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -12,6 +12,17 @@ type superpositionResolutionContext = {
 
 let billingPrefix = "payment_method_data.billing."
 
+let filterByActiveFields = (
+  flatValues: Dict.t<JSON.t>,
+  activeFields: array<SuperpositionTypes.fieldConfig>,
+): Dict.t<JSON.t> =>
+  activeFields
+  ->Array.filterMap(field => {
+    let path = field.confirmRequestWritePath
+    flatValues->Dict.get(path)->Option.map(value => (path, value))
+  })
+  ->Dict.fromArray
+
 // Derive a stable, locale-independent test id from a field's write path,
 // e.g. "payment_method_data.billing.address.line1" -> "line1".
 let getFieldTestId = (path: string): string => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Issue reported: https://app.spaces.xyne.juspay.net/6642623f-cca7-43ad-9a6b-5e49c33226b4/chat/dir/cmp31lgbx02e4ohe7rzn4ax4g/204226aa-e854-4e3f-81b3-c0f479e46b58#origin=204226aa-e854-4e3f-81b3-c0f479e46b58&messageId=b4fe2c62-4acc-4b5f-8341-44f5d9811ce3

### Analysis
- `missingRequiredFields` from superposition were populated as expected.
- `intentData` had required values and was being parsed properly as per superposition config.
- `/confirm` call payload wasn't reflecting the intent values in payload.

### Bug
- When the `requiredFieldsToRender.length == 0`, RFF wasn't rendered and hence the initialValues weren't passed in `requiredFieldsBody` atom by `RFF.onFormChange`.

### Fix
- initialize form for components that has initial values.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```
const paymentData = {
  currency: "USD",
  amount: 299999,
  order_details: [
    {
      product_name: "Apple iPhone 15",
      quantity: 1,
      amount: 2999,
    },
  ],
  confirm: false,
  capture_method: "automatic",
  authentication_type: "no_three_ds",
  customer_id: "hyperswitch_sdk_demo_id",
  request_external_three_ds_authentication: false,
  description: "Hello this is description",
  shipping: {
    address: {
      line1: "1467",
      line2: "Harrison Street",
      line3: "Harrison Street",
      city: "San Fransico",
      state: "California",
      zip: "94122",
      country: "US",
      first_name: "joseph",
      last_name: "Doe",
    },
    phone: {
      number: "8056594427",
      country_code: "+91",
    },
  },
  metadata: {
    udf1: "value1",
    new_customer: "true",
    login_date: "2019-09-10T10:11:12Z",
  },
  billing: {
    address: {
      line1: "1467",
      line2: "Harrison Street",
      line3: "Harrison Street",
      city: "San Fransico",
      state: "California",
      zip: "94122",
      country: "US",
      first_name: "joseph",
      last_name: "Doe",
    },
    phone: {
      number: "8056594427",
      country_code: "+91",
    },
  },
};
```
<img width="1829" height="882" alt="image" src="https://github.com/user-attachments/assets/a8b7970a-3cfd-4a26-84cc-38a4c09b4327" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
