### PR TITLE
fix: dynamic fields stale values cleanup

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -172,6 +172,13 @@ let make = (
     resolutionContext,
   ) = DynamicFieldsUtils.useSuperpositionRequiredFields(~paymentMethod, ~paymentMethodType)
   let initialValues = React.useMemo(() => superpositionInitialValues, (intentData, paymentMethodType))
+  let setFilteredRequiredFieldsBody = setter =>
+    setRequiredFieldsBody(prev => setter(prev)->filterByActiveFields(requiredFields))
+
+  React.useEffect(() => {
+    setFilteredRequiredFieldsBody(prev => prev)
+    None
+  }, [requiredFields])
 
   let missingRequiredFieldsFiltered = React.useMemo(() => {
     let afterBillingFilter = removeBillingDetailsIfUseBillingAddress(
@@ -316,7 +323,7 @@ let make = (
             allEmailFields
             allCardHolderNameFields
             paymentMethodType
-            setRequiredFieldsBody
+            setRequiredFieldsBody=setFilteredRequiredFieldsBody
             syncEmitAddressAtoms
           />}
       />

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -172,11 +172,8 @@ let make = (
     resolutionContext,
   ) = DynamicFieldsUtils.useSuperpositionRequiredFields(~paymentMethod, ~paymentMethodType)
   let initialValues = React.useMemo(() => superpositionInitialValues, (intentData, paymentMethodType))
-  let setFilteredRequiredFieldsBody = setter =>
-    setRequiredFieldsBody(prev => setter(prev)->filterByActiveFields(requiredFields))
-
   React.useEffect(() => {
-    setFilteredRequiredFieldsBody(prev => prev)
+    setRequiredFieldsBody(prev => prev->filterByActiveFields(requiredFields))
     None
   }, [requiredFields])
 
@@ -220,7 +217,7 @@ let make = (
     })
   }, (missingRequiredFields, billingAddress.isUseBillingAddress))
 
-  let finalInitialValues = React.useMemo(() => {
+  let initialValuesWithBillingDataOverride = React.useMemo(() => {
     DynamicFieldsUtils.applyBillingDetailsOverride(initialValues, defaultValues.billingDetails)
   }, (initialValues, defaultValues.billingDetails))
 
@@ -277,7 +274,7 @@ let make = (
     redirectionInfo === ShowRedirectionInfo
 
   let hasAnyField = missingRequiredFieldsFiltered->Array.length > 0
-  let shouldRenderForm = hasAnyField || finalInitialValues->Dict.keysToArray->Array.length > 0
+  let shouldRenderForm = hasAnyField || initialValuesWithBillingDataOverride->Dict.keysToArray->Array.length > 0
   let setAreRequiredFieldsValid = Recoil.useSetRecoilState(areRequiredFieldsValid)
   let setAreRequiredFieldsEmpty = Recoil.useSetRecoilState(areRequiredFieldsEmpty)
 
@@ -310,7 +307,7 @@ let make = (
   <>
     <RenderIf condition={!isSavedCardFlow && shouldRenderForm}>
       <ReactFinalForm.Form
-        initialValues={Some(finalInitialValues)}
+        initialValues={Some(initialValuesWithBillingDataOverride)}
         onSubmit={_values => ()}
         render={formProps =>
           <FormBody
@@ -323,7 +320,7 @@ let make = (
             allEmailFields
             allCardHolderNameFields
             paymentMethodType
-            setRequiredFieldsBody=setFilteredRequiredFieldsBody
+            setRequiredFieldsBody
             syncEmitAddressAtoms
           />}
       />

--- a/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
+++ b/src/Components/DynamicFields/PhoneCountryCodeDropdownField.res
@@ -31,15 +31,11 @@ let make = (~fieldConfig: fieldConfig, ~isLabelHidden=false) => {
     })
   )
 
-  let defaultCountry = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let firstOptionValue =
     phoneNumberCodeOptions->Array.get(0)->Option.map(o => o.value)->Option.getOr("")
-  let seedCountry = defaultCountry !== "" ? defaultCountry : firstOptionValue
-  let seedIso = getCountryCode(seedCountry).isoAlpha2
-
   let defaultDropdownValue =
     countryAndCodeList
-    ->Array.find(c => c->getDictFromJson->getString("country_code", "") === seedIso)
+    ->Array.find(c => c->getDictFromJson->getString("country_code", "") === defaultCountryCode)
     ->Option.map(c => {
       let countryDict = c->getDictFromJson
       let flag = countryDict->getString("country_flag", "")

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -12,6 +12,17 @@ type superpositionResolutionContext = {
 
 let billingPrefix = "payment_method_data.billing."
 
+let filterByActiveFields = (
+  flatValues: Dict.t<JSON.t>,
+  activeFields: array<SuperpositionTypes.fieldConfig>,
+): Dict.t<JSON.t> =>
+  activeFields
+  ->Array.filterMap(field => {
+    let path = field.confirmRequestWritePath
+    flatValues->Dict.get(path)->Option.map(value => (path, value))
+  })
+  ->Dict.fromArray
+
 // Derive a stable, locale-independent test id from a field's write path,
 // e.g. "payment_method_data.billing.address.line1" -> "line1".
 let getFieldTestId = (path: string): string => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

### Summary

-  This PR tightens dynamic field state handling and fixes the default phone country code selection.

### Changes

- Filter `requiredFieldsBody` to only include currently active dynamic fields, before persisting form values.
- Re-apply that **filtering whenever the resolved `requiredFields` set changes**, so stale values are removed when the active field list updates.
- Update the phone country code dropdown to resolve its default selection from `defaultCountryCode` directly instead of deriving it from the `userCountry` / first-option fallback path.
-  minor refactor, renamed `finalInitialValues` -> `initialValuesWithBillingDataOverride` 


### Why

- Dynamic fields can change based on payment method resolution and billing context. Without filtering, previously entered values for now-inactive fields can remain in `requiredFieldsBody` and leak into the `'/confirm'` payload. This change keeps the payload aligned with the fields that are actually active.
- The phone country code change makes the default dropdown value deterministic and aligned with the configured default country code.

## How did you test it?

- Selected country where state selection isn't required.
- Changed country selection and phoneCountry selection. Both work properly.
- No stale value of 'state' field selection found in '/confirm' call payload.


https://github.com/user-attachments/assets/a20eeb97-ca79-4efb-af7f-ad1d72d4c0bb



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
