### PR TITLE
fix: address flags `usePrefilledValues` and `isUseBillingAddress`

### DIFF
--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -171,26 +171,32 @@ let make = (
     superpositionInitialValues,
     resolutionContext,
   ) = DynamicFieldsUtils.useSuperpositionRequiredFields(~paymentMethod, ~paymentMethodType)
-  let initialValues = React.useMemo(() => superpositionInitialValues, (intentData, paymentMethodType))
+  let initialValues = React.useMemo(
+    () => superpositionInitialValues,
+    (
+      intentData,
+      paymentMethodType,
+      billingAddress.isUseBillingAddress,
+      billingAddress.usePrefilledValues,
+    ),
+  )
+  let setFilteredRequiredFieldsBody = setter =>
+    setRequiredFieldsBody(prev => setter(prev)->filterByActiveFields(requiredFields))
+
   React.useEffect(() => {
     setRequiredFieldsBody(prev => prev->filterByActiveFields(requiredFields))
     None
   }, [requiredFields])
 
   let missingRequiredFieldsFiltered = React.useMemo(() => {
-    let afterBillingFilter = removeBillingDetailsIfUseBillingAddress(
-      missingRequiredFields,
-      billingAddress,
-    )
-
     let firstEmailPath =
-      afterBillingFilter
+      missingRequiredFields
       ->Array.filter(fieldConfig => fieldConfig.fieldRenderType === Email)
       ->Array.get(0)
       ->Option.map(fieldConfig => fieldConfig.confirmRequestWritePath)
 
     let firstCardHolderNamePath =
-      afterBillingFilter
+      missingRequiredFields
       ->Array.filter(fieldConfig => fieldConfig.fieldRenderType === CardHolderName)
       ->Array.get(0)
       ->Option.map(fieldConfig => fieldConfig.confirmRequestWritePath)
@@ -199,7 +205,7 @@ let make = (
     //   - Any card-data fields (card_exp_month, card_exp_year, card_network, etc.)
     //   - Duplicate Email / CardHolderName fields (only the first path is rendered)
     //   - Dropdown fields with no options (would render React.null anyway)
-    afterBillingFilter->Array.filter(field => {
+    missingRequiredFields->Array.filter(field => {
       switch field.fieldRenderType {
       | CardNumber
       | Cvc
@@ -215,7 +221,7 @@ let make = (
       | _ => true
       }
     })
-  }, (missingRequiredFields, billingAddress.isUseBillingAddress))
+  }, [missingRequiredFields])
 
   let initialValuesWithBillingDataOverride = React.useMemo(() => {
     DynamicFieldsUtils.applyBillingDetailsOverride(initialValues, defaultValues.billingDetails)

--- a/src/Components/DynamicFields.res
+++ b/src/Components/DynamicFields.res
@@ -180,8 +180,6 @@ let make = (
       billingAddress.usePrefilledValues,
     ),
   )
-  let setFilteredRequiredFieldsBody = setter =>
-    setRequiredFieldsBody(prev => setter(prev)->filterByActiveFields(requiredFields))
 
   React.useEffect(() => {
     setRequiredFieldsBody(prev => prev->filterByActiveFields(requiredFields))
@@ -280,7 +278,8 @@ let make = (
     redirectionInfo === ShowRedirectionInfo
 
   let hasAnyField = missingRequiredFieldsFiltered->Array.length > 0
-  let shouldRenderForm = hasAnyField || initialValuesWithBillingDataOverride->Dict.keysToArray->Array.length > 0
+  let shouldRenderForm =
+    hasAnyField || initialValuesWithBillingDataOverride->Dict.keysToArray->Array.length > 0
   let setAreRequiredFieldsValid = Recoil.useSetRecoilState(areRequiredFieldsValid)
   let setAreRequiredFieldsEmpty = Recoil.useSetRecoilState(areRequiredFieldsEmpty)
 

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -153,19 +153,6 @@ let extractValuesFromPMLRequiredFields = (
   })
 }
 
-let removeBillingDetailsIfUseBillingAddress = (
-  missingRequiredFields: array<SuperpositionTypes.fieldConfig>,
-  billingAddress: PaymentType.billingAddress,
-) => {
-  if billingAddress.isUseBillingAddress {
-    missingRequiredFields->Array.filter(requiredField => {
-      !(requiredField.confirmRequestWritePath->String.startsWith(billingPrefix))
-    })
-  } else {
-    missingRequiredFields
-  }
-}
-
 let buildSuperpositionBaseContext = (
   ~paymentMethod: string,
   ~paymentMethodType: string,
@@ -248,6 +235,15 @@ let useSuperpositionRequiredFields = (~paymentMethod, ~paymentMethodType) => {
   let userCountryName = Recoil.useRecoilValueFromAtom(RecoilAtoms.userCountry)
   let country = Utils.getCountryCode(userCountryName).isoAlpha2
 
+  let {billingAddress} = Recoil.useRecoilValueFromAtom(RecoilAtoms.optionAtom)
+  // isUseBillingAddress force-includes the billing.address.* set into the required/render sets whenever
+  // the merchant opts in.
+  let isUseBillingAddress = billingAddress.isUseBillingAddress
+  let suppressBillingPrefill = switch billingAddress.usePrefilledValues {
+  | Never => isUseBillingAddress
+  | Auto => false
+  }
+
   let rawConfigs = sdkConfigsValue.raw_configs
   let getSuperpositionFinalFields = ConfigurationService.useConfigurationService(~rawConfigs)
 
@@ -286,8 +282,21 @@ let useSuperpositionRequiredFields = (~paymentMethod, ~paymentMethodType) => {
   ))
 
   let (requiredFields, missingRequiredFields, initialValues) = React.useMemo(() => {
-    getSuperpositionFinalFields(eligibleConnectors, superpositionBaseContext, intentData)
-  }, (getSuperpositionFinalFields, eligibleConnectors, superpositionBaseContext, intentData))
+    getSuperpositionFinalFields(
+      eligibleConnectors,
+      superpositionBaseContext,
+      intentData,
+      ~isUseBillingAddress,
+      ~suppressBillingPrefill,
+    )
+  }, (
+    getSuperpositionFinalFields,
+    eligibleConnectors,
+    superpositionBaseContext,
+    intentData,
+    isUseBillingAddress,
+    suppressBillingPrefill,
+  ))
 
   let resolutionContext = React.useMemo(() => {
     {
@@ -307,7 +316,14 @@ let useAreWalletRequiredFieldsPrefilled = (~paymentMethodType) => {
     ~paymentMethod="wallet",
     ~paymentMethodType,
   )
-  removeBillingDetailsIfUseBillingAddress(missingRequiredFields, billingAddress)->Array.length == 0
+  // Billing is collected via the wallet sheet, so it must not block the wallet prefilled-gate
+  // when isUseBillingAddress is set.
+  let relevant = billingAddress.isUseBillingAddress
+    ? missingRequiredFields->Array.filter(field =>
+        !(field.confirmRequestWritePath->String.startsWith(billingPrefix))
+      )
+    : missingRequiredFields
+  relevant->Array.length == 0
 }
 
 let splitName = (str: option<string>) => {

--- a/src/Utilities/DynamicFieldsUtils.res
+++ b/src/Utilities/DynamicFieldsUtils.res
@@ -318,11 +318,13 @@ let useAreWalletRequiredFieldsPrefilled = (~paymentMethodType) => {
   )
   // Billing is collected via the wallet sheet, so it must not block the wallet prefilled-gate
   // when isUseBillingAddress is set.
-  let relevant = billingAddress.isUseBillingAddress
-    ? missingRequiredFields->Array.filter(field =>
-        !(field.confirmRequestWritePath->String.startsWith(billingPrefix))
-      )
-    : missingRequiredFields
+  let relevant = if billingAddress.isUseBillingAddress {
+    missingRequiredFields->Array.filter(field =>
+      !(field.confirmRequestWritePath->String.startsWith(billingPrefix))
+    )
+  } else {
+    missingRequiredFields
+  }
   relevant->Array.length == 0
 }
 


### PR DESCRIPTION
## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- This PR fixes (restores) dynamic field resolution for the `isUseBillingAddress` and `usePrefilledValues` billing flags.
- Corresponding `shared-code` PR: https://github.com/juspay/hyperswitch-sdk-utils/pull/81


### Motivation

- We wanted to ensure complete backwards compatibility after the `DynamicFields` revamp (making them completely config-driven).
- These flags were used by some consumers so had to add them back to minimize any unwanted integration changes from consumer's end.
- **NOTE**: This behaviour can be controlled via superposition configs and we might even **deprecate** `isUseBillingAddress` and `usePrefilledValues` flags in future.
- REFERENCE: The PR that introduced these flags: https://github.com/juspay/hyperswitch-web/pull/109


### Expected behaviour

- `isUseBillingAddress = false` => ignore `usePrefilledValues` and renders as per the `required_fields` resolved. 
- `isUseBillingAddress = true` => always show billing fields, even when not required by the connector. 
- `usePrefilledValues`: `isUseBillingAddress = true` and `usePrefilledValues = "auto"` => prefilled from intent data.
- `usePrefilledValues`: `isUseBillingAddress = true` and `usePrefilledValues = "never"` => don't pre-fill from intent data.


### Changes

- Recompute dynamic field initial values when `billingAddress.isUseBillingAddress` or `billingAddress.usePrefilledValues` changes.
- Pass billing-address flags into superposition field resolution so required/missing fields are derived at the source instead of filtered later in the component.
- Remove the old billing-field filtering from `DynamicFields` and keep only render-level filtering for duplicate/non-rendered fields.
- Update wallet prefilled-field checks so billing fields do not block the wallet prefilled gate when billing is collected through the wallet sheet.


## How did you test it?

_// NOTE: `billing` and `shipping` is passed in `/payments` (create-intent api call) for all the cases._

|   | flags                                                                                     | pre-revamp                                                                                                                         | current                                                                                                                            |
|---|-------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
| 1 | ``` billingAddress: {   isUseBillingAddress: false,    usePrefilledValues: "auto",  } ``` | <img width="438" height="630" alt="image" src="https://github.com/user-attachments/assets/f58a54f0-1d09-43ef-86a1-78e185a35e36" /> | <img width="438" height="630" alt="image" src="https://github.com/user-attachments/assets/fc9be695-281a-4e44-8fa3-061a0d1be933" /> |
| 2 | ``` billingAddress: {   isUseBillingAddress: true,    usePrefilledValues: "auto",  } ```  | <img width="438" height="630" alt="image" src="https://github.com/user-attachments/assets/2e926fdb-744c-431b-902b-e8856dbae713" /> | <img width="438" height="630" alt="image" src="https://github.com/user-attachments/assets/aa01667f-64db-4ee9-915c-47741e6f6b1a" /> |
| 3 | ``` billingAddress: {   isUseBillingAddress: true,   usePrefilledValues: "never", }, ```  | <img width="438" height="630" alt="image" src="https://github.com/user-attachments/assets/3ed9cbd4-ce65-4ec9-8bea-9ccd01eee165" /> | <img width="438" height="630" alt="image" src="https://github.com/user-attachments/assets/3d69c280-f5cc-46b3-8635-c23843da6d0c" /> |



## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
