### PR TITLE
fix: make sdk configs api critical

### DIFF
--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -596,8 +596,9 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
           let sdkConfigsJson = dict->getJsonObjectFromDict("sdkConfigs")
           let sdkConfigsDict = sdkConfigsJson->getDictFromJson
           let isSdkConfigsError =
+            sdkConfigsJson == JSON.Encode.null ||
             sdkConfigsJson == Dict.make()->JSON.Encode.object ||
-              sdkConfigsDict->Dict.get("error")->Option.isSome
+            sdkConfigsDict->Dict.get("error")->Option.isSome
           let updatedState: PaymentType.loadType = isSdkConfigsError
             ? LoadError(sdkConfigsJson)
             : Loaded(sdkConfigsJson)

--- a/src/PaymentElementRenderer.res
+++ b/src/PaymentElementRenderer.res
@@ -11,6 +11,7 @@ let make = (
   }
   let {showLoader} = Recoil.useRecoilValueFromAtom(configAtom)
   let paymentMethodList = Recoil.useRecoilValueFromAtom(paymentMethodList)
+  let sdkConfigs = Recoil.useRecoilValueFromAtom(sdkConfigs)
   let paymentManagementList = Recoil.useRecoilValueFromAtom(RecoilAtomsV2.paymentManagementList)
   let {localeString} = Recoil.useRecoilValueFromAtom(RecoilAtoms.configAtom)
   let setFullName = Recoil.useSetRecoilState(userFullName)
@@ -25,9 +26,12 @@ let make = (
     None
   }, [])
 
-  let isLoading = switch (paymentType, paymentMethodList, paymentManagementList) {
-  | (Payment, Loading, _)
-  | (PaymentMethodsManagement, _, LoadingV2) => true
+  let divRef = React.useRef(Nullable.null)
+
+  let isLoading = switch (paymentType, paymentMethodList, sdkConfigs, paymentManagementList) {
+  | (Payment, Loading, _, _)
+  | (Payment, _, Loading, _)
+  | (PaymentMethodsManagement, _, _, LoadingV2) => true
   | _ => false
   }
 
@@ -42,7 +46,18 @@ let make = (
   } else {
     switch paymentType {
     | PaymentMethodsManagement => <PaymentElementV2 cardProps expiryProps cvcProps paymentType />
-    | _ => <PaymentElement cardProps expiryProps cvcProps paymentType />
+    | _ =>
+      // clientList and sdkConfigs are both critical APIs on this V1 payment path.
+      // If either fails, render a single error in place of PaymentElement, so the
+      // error never coexists with PaymentElement's own shimmer/form. Scoped to
+      // this branch so it can never gate the V2 (PaymentElementV2) path, which
+      // has its own critical API (paymentManagementList) and error handling.
+      switch (paymentMethodList, sdkConfigs) {
+      | (LoadError(_), _)
+      | (_, LoadError(_)) =>
+        <ErrorBoundary.ErrorTextAndImage divRef level={ErrorBoundary.Top} />
+      | _ => <PaymentElement cardProps expiryProps cvcProps paymentType />
+      }
     }
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Make `/sdk/configs` api critical.

## How did you test it?

<img width="1835" height="799" alt="image" src="https://github.com/user-attachments/assets/8fc9e562-d4a0-49ba-83e2-3bd852d9dd45" />
<img width="1852" height="792" alt="image" src="https://github.com/user-attachments/assets/27122408-4f8a-440e-9da4-e0e49e81beba" />
<img width="1848" height="813" alt="image" src="https://github.com/user-attachments/assets/5675f049-39aa-4b85-97ec-8e102ead0084" />
<img width="1843" height="786" alt="image" src="https://github.com/user-attachments/assets/83ec760c-839c-420a-bf43-9d8c6348ab06" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
