### PR TITLE
fix: filter bank list as per the config

### DIFF
--- a/src/Components/DynamicFieldInput.res
+++ b/src/Components/DynamicFieldInput.res
@@ -93,9 +93,18 @@ let renderSingleField = (
     </RenderIf>
 
   | BankNamesSelect =>
-    let options = Bank.getBanks(paymentMethodType)->Array.map(bank => {
-      DropdownField.value: bank.value,
-      label: bank.displayName,
+    let allowedValues = field.dropdownOptions->Option.getOr([])
+    let banks = Bank.getBanks(paymentMethodType)
+    let options = allowedValues->Array.map(bankValue => {
+      let label =
+        banks
+        ->Array.find(bank => bank.value == bankValue)
+        ->Option.map(bank => bank.displayName)
+        ->Option.getOr(bankValue)
+      {
+        DropdownField.value: bankValue,
+        label,
+      }
     })
     <RenderIf condition={options->Array.length > 0}>
       <BankNamesSelectField fieldConfig=field options />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- **Bug:** rendering bank select options directly as per `Bank.res` file resulted in some extra bank options being rendered.
- **Fix:** filter bank list as per the superposition config dropdown options. 
- Fallback: if the dropdown option is listed in config, but not available in `Bank.res`, then render the option code itself rather than dropping out the field.


## How did you test it?

<img width="991" height="992" alt="image" src="https://github.com/user-attachments/assets/5ea24735-0031-40a0-b998-e4bbbbaaaa18" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
