### PR TITLE
fix: changed cvc location in confirm payload for saved flow

### DIFF
--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -123,8 +123,7 @@ let make = (
               if requiresCvv && isCvcComplete {
                 setCvcError(_ => "")
 
-                let bodyWithCvc =
-                  bodyArr->Array.concat([("card_cvc", cvcNumber->JSON.Encode.string)])
+                let bodyWithCvc = bodyArr->Array.concat([PaymentBody.cardTokenCvcTuple(~cvcNumber)])
 
                 let paymentType = paymentTypeStr->PaymentHelpers.getPaymentType
 

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -126,6 +126,13 @@ let customerAcceptanceBody =
     ),
   ]->Utils.getJsonFromArrayOfJson
 
+let cardTokenCvcTuple = (~cvcNumber) => (
+  "payment_method_data",
+  [
+    ("card_token", [("card_cvc", cvcNumber->JSON.Encode.string)]->Utils.getJsonFromArrayOfJson),
+  ]->Utils.getJsonFromArrayOfJson,
+)
+
 let savedCardBody = (
   ~paymentToken,
   ~customerId,
@@ -140,7 +147,7 @@ let savedCardBody = (
   ]
 
   if requiresCvv {
-    savedCardBody->Array.push(("card_cvc", cvcNumber->JSON.Encode.string))->ignore
+    savedCardBody->Array.push(cardTokenCvcTuple(~cvcNumber))->ignore
   }
 
   if isCustomerAcceptanceRequired {

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -146,11 +146,11 @@ let savedCardBody = (
   ]
 
   if requiresCvv {
-    savedCardBody->Array.push(cardTokenCvcTuple(~cvcNumber))->ignore
+    savedCardBody->Array.push(cardTokenCvcTuple(~cvcNumber))
   }
 
   if isCustomerAcceptanceRequired {
-    savedCardBody->Array.push(("customer_acceptance", customerAcceptanceBody))->ignore
+    savedCardBody->Array.push(("customer_acceptance", customerAcceptanceBody))
   }
 
   savedCardBody

--- a/src/hyper-loader/PaymentSessionMethods.res
+++ b/src/hyper-loader/PaymentSessionMethods.res
@@ -210,7 +210,7 @@ let getCustomerSavedPaymentMethods = (
             ~errorType=cvcValidationErrorType,
           )->resolve
         } else {
-          body->Array.push(("card_cvc", cvcString->JSON.Encode.string))->ignore
+          body->Array.push(PaymentBody.cardTokenCvcTuple(~cvcNumber=cvcString))->ignore
           PaymentHelpers.paymentIntentForPaymentSession(
             ~body,
             ~paymentType,

--- a/src/hyper-loader/PaymentSessionMethods.res
+++ b/src/hyper-loader/PaymentSessionMethods.res
@@ -210,7 +210,7 @@ let getCustomerSavedPaymentMethods = (
             ~errorType=cvcValidationErrorType,
           )->resolve
         } else {
-          body->Array.push(PaymentBody.cardTokenCvcTuple(~cvcNumber=cvcString))->ignore
+          body->Array.push(PaymentBody.cardTokenCvcTuple(~cvcNumber=cvcString))
           PaymentHelpers.paymentIntentForPaymentSession(
             ~body,
             ~paymentType,


### PR DESCRIPTION
## Type of Change

  <!-- Put an `x` in the boxes that apply -->

  - [x] Bugfix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates
  - [ ] Documentation
  - [ ] CI/CD

  ## Description
#1699 
  Updates the location of the card CVC field to comply with the new API contract.

  Previously, `card_cvc` was sent as a top-level field:

  ```json
  {
    "card_cvc": "123"
  }
 ```
  It is now nested under payment_method_data.card_token:
```
  {
    "payment_method_data": {
      "card_token": {
        "card_cvc": "123"
      }
    }
  }
  ```

  This change applies to:

  - Saved-card payments that require CVC.
  - Card CVC element submissions.
  - Saved payment methods used through payment sessions.

  A shared PaymentBody.cardTokenCvcTuple helper has been introduced to ensure the updated payload structure is
  used consistently across these flows. The previous top-level CVC field is deprecated by the API.

  ## How did you test it?

  - Ran npm run re:build to verify that the ReScript code compiles successfully.
  - Manually verified the request payload for saved-card payment flows requiring CVC.
  - Confirmed that card_cvc is sent under payment_method_data.card_token and is no longer included at the top
    level.
    

https://github.com/user-attachments/assets/a396d89d-acd3-4dda-9c92-73d989981ebc



  ## Checklist
  <!-- Put an `x` in the boxes that apply -->

  - [x] I ran npm run re:build
  - [x] I reviewed submitted code
  - [ ] I added unit tests for my changes where possible