### PR TITLE
fix: removed card_issuer from payment body

### DIFF
--- a/cypress-tests/cypress/js-e2e-test-cases-to-refer/api-call-test.cy.js
+++ b/cypress-tests/cypress/js-e2e-test-cases-to-refer/api-call-test.cy.js
@@ -34,7 +34,6 @@ const confirmBody = {
       card_exp_year: "28",
       card_holder_name: "",
       card_cvc: "424",
-      card_issuer: "",
       card_network: "Visa",
     },
   },

--- a/cypress-tests/cypress/js-e2e-test-cases-to-refer/bluesnap-3DS-test.cy.js
+++ b/cypress-tests/cypress/js-e2e-test-cases-to-refer/bluesnap-3DS-test.cy.js
@@ -35,7 +35,6 @@ const confirmBody = {
       card_exp_year: "28",
       card_holder_name: "",
       card_cvc: "424",
-      card_issuer: "",
       card_network: "Visa",
     },
   },

--- a/cypress-tests/cypress/js-e2e-test-cases-to-refer/confirm_payload.json
+++ b/cypress-tests/cypress/js-e2e-test-cases-to-refer/confirm_payload.json
@@ -9,7 +9,6 @@
       "card_exp_year": "2024",
       "card_holder_name": "",
       "card_cvc": "424",
-      "card_issuer": "",
       "card_network": "Visa"
     }
   },

--- a/cypress-tests/cypress/js-e2e-test-cases-to-refer/stripe-3DS-test.cy.js
+++ b/cypress-tests/cypress/js-e2e-test-cases-to-refer/stripe-3DS-test.cy.js
@@ -35,7 +35,6 @@ const confirmBody = {
       card_exp_year: "28",
       card_holder_name: "",
       card_cvc: "424",
-      card_issuer: "",
       card_network: "Visa",
     },
   },

--- a/cypress-tests/cypress/support/utils.ts
+++ b/cypress-tests/cypress/support/utils.ts
@@ -200,7 +200,6 @@ export const confirmBody = {
       card_exp_year: "28",
       card_holder_name: "",
       card_cvc: "424",
-      card_issuer: "",
       card_network: "Visa",
     },
   },

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -45,7 +45,6 @@ let cardPaymentBody = (
     ("card_exp_month", month->JSON.Encode.string),
     ("card_exp_year", year->JSON.Encode.string),
     ("card_cvc", cvcNumber->JSON.Encode.string),
-    ("card_issuer", ""->JSON.Encode.string),
   ]
 
   cardHolderName

--- a/src/Utilities/PaymentManagementBody.res
+++ b/src/Utilities/PaymentManagementBody.res
@@ -43,7 +43,6 @@ let saveCardBody = (
     ("card_exp_month", month->JSON.Encode.string),
     ("card_exp_year", year->JSON.Encode.string),
     ("card_cvc", cvcNumber->JSON.Encode.string),
-    ("card_issuer", ""->JSON.Encode.string),
   ]
 
   cardHolderName


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removes `card_issuer` from outgoing payment payloads across the web SDK and Cypress test fixtures.

Response parsing remains unchanged because the application still consumes `card_issuer` when it is returned by the API.

## Changes

- Removed `card_issuer` from payment request body construction.
- Removed `card_issuer` from payment management payload construction.
- Removed `card_issuer` from Cypress request payloads and reference fixtures.
- Verified that no authoritative source or generated ReScript file still supplies the field.
- Retained existing response parsing for `card_issuer`.

## Validation

- ReScript build passed.
- ReScript formatting checks passed.
- Prettier checks passed for affected fixtures.
- TypeScript validation passed.
- `git diff --check` passed.
- Repository-wide searches confirmed no remaining outgoing `card_issuer` usage.


## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
### Before
<img width="971" height="378" alt="Screenshot 2026-07-22 at 8 59 25 PM" src="https://github.com/user-attachments/assets/5035bf1d-90ca-4603-9dcb-ba582ebda230" />


### After
<img width="1271" height="396" alt="Screenshot 2026-07-22 at 8 57 58 PM" src="https://github.com/user-attachments/assets/b3c5af7a-0348-4d29-93a4-6508deea9e48" />

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
