### PR TITLE
fix: make individual card elements confirmable

### DIFF
--- a/Hyperswitch-React-Demo-App/README.md
+++ b/Hyperswitch-React-Demo-App/README.md
@@ -35,6 +35,36 @@ SELF_SERVER_URL=http://localhost:5252                  # Your local running demo
 PROFILE_ID=""
 ```
 
+## Widgets harness
+
+The checkout page mounts the payment element only. `widgets.html` mounts any element
+`widgets.create()` accepts, one or several at a time, and tabulates every event they
+emit. It mints its own intent, so it needs no arguments:
+
+```
+http://localhost:5252/widgets.html                              # cardNumber + cardExpiry + cardCvc
+http://localhost:5252/widgets.html?element=payment              # the payment element
+http://localhost:5252/widgets.html?element=card&element=payPal  # several at once
+```
+
+Pick elements with the checkboxes, or pass `element` once per element. Override the
+keys with `?publishableKey=&clientSecret=`.
+
+`?sdk=` loads a different SDK build, so one demo app can compare two of them:
+
+```
+http://localhost:5252/widgets.html?sdk=http://localhost:9050
+http://localhost:5252/widgets.html?sdk=http://localhost:9052
+```
+
+Start the second SDK with **`ENV_SDK_URL` naming itself** — a loader creates its
+element iframes at the origin baked in at build time, so without it the second build
+serves the first build's elements and the comparison silently shows one build twice:
+
+```sh
+PORT=9052 ENV_SDK_URL=http://localhost:9052 npm run start   # in hyperswitch-web
+```
+
 ## Troubleshooting
 If your demo application is not working, you can check the following to hopefully find the issue.
 

--- a/Hyperswitch-React-Demo-App/public/widgets.html
+++ b/Hyperswitch-React-Demo-App/public/widgets.html
@@ -1,0 +1,515 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Widgets</title>
+    <style>
+      :root {
+        --border: #dcdfea;
+        --muted: #62667e;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0;
+        color: #1e2139;
+        background: #f6f7fb;
+      }
+      main {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 32px 20px 64px;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 4px;
+      }
+      h2 {
+        font-size: 13px;
+        margin: 0;
+      }
+      .sub {
+        font-size: 13px;
+        color: var(--muted);
+        margin: 0 0 8px;
+      }
+      code,
+      dd,
+      .choices label,
+      .widget > h3,
+      table {
+        font-family: ui-monospace, monospace;
+      }
+      fieldset {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: #fff;
+        margin: 0 0 20px;
+        padding: 16px;
+      }
+      legend,
+      dt {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--muted);
+        padding: 0 6px;
+      }
+      /* Configuration, elements and mounted widgets all lay out as grids. */
+      dl,
+      .choices,
+      .widgets {
+        display: grid;
+        margin: 0;
+        gap: 12px 16px;
+      }
+      dl {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+      .choices {
+        grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+        gap: 6px 12px;
+      }
+      .widgets {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        align-items: start;
+      }
+      dt {
+        padding: 0;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-weight: 400;
+      }
+      dd {
+        margin: 2px 0 0;
+        font-size: 12px;
+        word-break: break-all;
+      }
+      dd.origin {
+        font-family: inherit;
+        font-size: 11px;
+        color: var(--muted);
+      }
+      .presets,
+      .choices label,
+      .widget > h3,
+      .result {
+        font-size: 12px;
+      }
+      .presets {
+        margin: 0 0 12px;
+      }
+      .presets a {
+        margin-right: 12px;
+      }
+      .choices label {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      /* The widget cards carry the background, so their group does not. */
+      fieldset.group {
+        background: transparent;
+        border-style: dashed;
+      }
+      /* Each widget is its own card, so it is obvious where one ends. */
+      .widget {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: #fff;
+        overflow: hidden;
+      }
+      /* Only the single card fields are narrow; the rest are whole checkout
+         surfaces and get clipped in a shared column. */
+      .widget.wide {
+        grid-column: 1 / -1;
+      }
+      .widget > h3 {
+        color: var(--muted);
+        background: #fafbfe;
+        border-bottom: 1px solid var(--border);
+        margin: 0;
+        padding: 6px 10px;
+        font-weight: 500;
+      }
+      .mount {
+        padding: 10px;
+      }
+      /* The SDK sizes its own iframe, so the host must not clip it. */
+      .mount > iframe {
+        display: block;
+        width: 100%;
+        border: 0;
+      }
+      button {
+        font: inherit;
+        padding: 9px 18px;
+        border: 0;
+        border-radius: 8px;
+        background: #006df9;
+        color: #fff;
+        cursor: pointer;
+      }
+      button.secondary {
+        background: #fff;
+        color: #1e2139;
+        border: 1px solid var(--border);
+        padding: 5px 12px;
+        font-size: 12px;
+      }
+      button:disabled {
+        background: #a9aec4;
+        cursor: default;
+      }
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .result {
+        margin: 0;
+        color: var(--muted);
+      }
+      #status {
+        font-family: ui-monospace, monospace;
+        color: #1e2139;
+      }
+      /* The events are their own region, not part of the form above them. */
+      hr {
+        border: 0;
+        border-top: 1px solid var(--border);
+        margin: 36px 0 24px;
+      }
+      .events-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        line-height: 1.5;
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        overflow: hidden;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 5px 10px;
+        border-top: 1px solid var(--border);
+        vertical-align: top;
+      }
+      thead th {
+        border-top: 0;
+        background: #fafbfe;
+        font-size: 11px;
+        color: var(--muted);
+      }
+      td:nth-child(2),
+      td:nth-child(3) {
+        white-space: nowrap;
+      }
+      td:last-child {
+        color: var(--muted);
+        word-break: break-word;
+      }
+      tbody:empty::after {
+        content: "waiting for events";
+        display: block;
+        padding: 8px 10px;
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Widgets</h1>
+      <p class="sub">
+        Mounts any element <code>widgets.create()</code> accepts and records
+        every event it emits. Mints its own intent; override the keys with
+        <code>?publishableKey=&amp;clientSecret=</code>.
+      </p>
+
+      <fieldset>
+        <legend>Configuration</legend>
+        <dl id="config"></dl>
+      </fieldset>
+
+      <form method="get">
+        <fieldset>
+          <legend>Elements</legend>
+          <p class="presets" id="presets"></p>
+          <div class="choices" id="choices"></div>
+          <div class="toolbar">
+            <button class="secondary" type="submit">Mount selected</button>
+          </div>
+        </fieldset>
+      </form>
+
+      <form id="payment-form">
+        <fieldset class="group">
+          <legend>Mounted</legend>
+          <div class="widgets" id="mounts"></div>
+        </fieldset>
+        <div class="toolbar">
+          <button id="submit" type="submit" disabled>confirmPayment</button>
+          <p class="result">Result: <span id="status">not run</span></p>
+        </div>
+      </form>
+
+      <hr />
+
+      <section>
+        <div class="events-head">
+          <h2>Events</h2>
+          <button class="secondary" type="button" id="clear">Clear</button>
+        </div>
+        <p class="sub">
+          Element events, plus the <code>hyper.confirmPayment</code> lifecycle.
+          A programmatic confirm emits no element events of its own.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Time</th>
+              <th scope="col">Source</th>
+              <th scope="col">Event</th>
+              <th scope="col">Payload</th>
+            </tr>
+          </thead>
+          <tbody id="events"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script>
+      // Element types mirror CardThemeType.getPaymentMode; event names mirror
+      // Types.eventTypeMapper. Extend either list to cover a new one.
+      const ELEMENTS =
+        `payment card cardNumber cardExpiry cardCvc expressCheckout googlePay
+         applePay payPal samsungPay klarna paze paymentMethodCollect
+         paymentMethodsManagement`.split(/\s+/);
+      const EVENTS =
+        `ready change focus blur clickTriggered escape confirmTriggered
+         oneClickConfirmTriggered surchargeInfo completeDoThis`.split(/\s+/);
+      // The single card fields sit side by side; every other element needs the
+      // full row.
+      const CARD_FIELDS = ["cardNumber", "cardExpiry", "cardCvc"];
+      const NARROW = new Set(CARD_FIELDS);
+      // Named sets for combinations that only work together.
+      const PRESETS = {
+        "card fields": CARD_FIELDS,
+        card: ["card"],
+        payment: ["payment"],
+      };
+
+      const params = new URLSearchParams(location.search);
+      const selection = params.has("element")
+        ? params.getAll("element")
+        : PRESETS["card fields"];
+
+      const el = (id) => document.getElementById(id);
+      const node = (tag, text = "", className = "") =>
+        Object.assign(document.createElement(tag), {
+          textContent: text,
+          className,
+        });
+      const eventsEl = el("events");
+      const submitEl = el("submit");
+      const statusEl = el("status");
+
+      const record = (source, event, payload) => {
+        const row = eventsEl.insertRow(0);
+        [
+          new Date().toISOString().slice(11, 23),
+          source,
+          event,
+          payload ?? "",
+        ].forEach((text) => (row.insertCell().textContent = text));
+      };
+
+      el("clear").onclick = () => eventsEl.replaceChildren();
+
+      // Each row names its value's source, so it is clear which variable it is.
+      const showConfig = (rows) =>
+        el("config").replaceChildren(
+          ...rows.map(([label, value, origin]) => {
+            const group = node("div");
+            group.append(
+              node("dt", label),
+              node("dd", value),
+              node("dd", origin, "origin"),
+            );
+            return group;
+          }),
+        );
+
+      Object.entries(PRESETS).forEach(([name, elements]) => {
+        const link = node("a", name);
+        link.href = `?${elements.map((type) => `element=${type}`).join("&")}`;
+        el("presets").append(link);
+      });
+
+      // A plain GET form: the browser serialises the checked boxes into
+      // ?element=…&element=…, so there is no query-building code to maintain.
+      ELEMENTS.forEach((type) => {
+        const label = node("label");
+        const input = Object.assign(node("input"), {
+          type: "checkbox",
+          name: "element",
+          value: type,
+          checked: selection.includes(type),
+        });
+        label.append(input, document.createTextNode(type));
+        el("choices").append(label);
+      });
+
+      const loadSdk = (clientUrl) =>
+        new Promise((resolve, reject) => {
+          const script = document.createElement("script");
+          script.src = `${clientUrl}/HyperLoader.js`;
+          script.onload = () => resolve(window.Hyper);
+          script.onerror = () => reject(new Error(`cannot load ${script.src}`));
+          document.head.appendChild(script);
+        });
+
+      // server.js serves these at the root, the dev server proxies them under
+      // /payments — use whichever answers.
+      let apiBase = "";
+      const getJson = async (path) => {
+        const res = await fetch(`${apiBase}${path}`);
+        if (!res.ok) throw new Error(`${apiBase}${path} -> ${res.status}`);
+        return res.json();
+      };
+      const resolveApiBase = async () => {
+        for (const base of ["", "/payments"]) {
+          try {
+            if ((await fetch(`${base}/urls`)).ok) return base;
+          } catch (err) {
+            /* try the next one */
+          }
+        }
+        throw new Error("neither /urls nor /payments/urls answered");
+      };
+
+      const summarise = (payload) => {
+        if (payload === undefined || payload === null) return "";
+        if (typeof payload !== "object") return String(payload);
+        const text = JSON.stringify(payload);
+        return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+      };
+
+      let hyper;
+
+      const mountElement = (widgets, type) => {
+        const card = node(
+          "div",
+          "",
+          NARROW.has(type) ? "widget" : "widget wide",
+        );
+        const mount = node("div", "", "mount");
+        mount.id = `${type}-mount`;
+        card.append(node("h3", type), mount);
+        el("mounts").append(card);
+
+        const element = widgets.create(type, {});
+        // Subscribe to every known event so none is filtered out.
+        EVENTS.forEach((event) =>
+          element.on(event, (payload) =>
+            record(type, event, summarise(payload)),
+          ),
+        );
+        element.mount(`#${mount.id}`);
+      };
+
+      const init = async () => {
+        apiBase = await resolveApiBase();
+        const [config, urls] = await Promise.all([
+          getJson("/config"),
+          getJson("/urls"),
+        ]);
+        const publishableKey =
+          params.get("publishableKey") || config.publishableKey;
+        const clientSecret =
+          params.get("clientSecret") ||
+          (await getJson("/create-intent")).clientSecret;
+
+        // ?sdk= loads a different build, so two tabs can compare one against the
+        // other. Each build must have been built with ENV_SDK_URL naming itself,
+        // since that is where its loader creates the element iframes.
+        const clientUrl = params.get("sdk") || urls.clientUrl;
+
+        showConfig([
+          [
+            "SDK",
+            clientUrl,
+            params.has("sdk") ? "?sdk=" : "/urls · HYPERSWITCH_CLIENT_URL",
+          ],
+          ["Server", urls.serverUrl, "/urls · HYPERSWITCH_SERVER_URL"],
+          [
+            "Publishable key",
+            publishableKey,
+            "/config · HYPERSWITCH_PUBLISHABLE_KEY",
+          ],
+          [
+            "Payment",
+            clientSecret.split("_secret_")[0],
+            "/create-intent · clientSecret",
+          ],
+        ]);
+
+        const Hyper = await loadSdk(clientUrl);
+        hyper = Hyper(
+          { publishableKey, profileId: config.profileId },
+          { customBackendUrl: urls.serverUrl },
+        );
+        const widgets = hyper.widgets({ clientSecret });
+
+        selection.forEach((type) => {
+          try {
+            mountElement(widgets, type);
+          } catch (err) {
+            record(type, "mount failed", err.message);
+          }
+        });
+
+        submitEl.disabled = false;
+      };
+
+      el("payment-form").onsubmit = async (event) => {
+        event.preventDefault();
+        submitEl.disabled = true;
+        statusEl.textContent = "pending…";
+        record("hyper", "confirmPayment", "called");
+        const startedAt = performance.now();
+        try {
+          const { error, status, payment_id } = await hyper.confirmPayment({
+            confirmParams: { return_url: location.href },
+            redirect: "if_required",
+          });
+          const seconds = ((performance.now() - startedAt) / 1000).toFixed(1);
+          const outcome = error
+            ? [error.type, `${error.message} (${seconds}s)`]
+            : [status, `${payment_id} (${seconds}s)`];
+          statusEl.textContent = `${outcome[0]}: ${outcome[1]}`;
+          record("hyper", ...outcome);
+        } catch (err) {
+          statusEl.textContent = `threw: ${err.message}`;
+          record("hyper", "threw", err.message);
+        }
+        submitEl.disabled = false;
+      };
+
+      init().catch((err) => {
+        statusEl.textContent = `init failed: ${err.message}`;
+      });
+    </script>
+  </body>
+</html>

--- a/cypress-tests/cypress/e2e/02-cards/card-elements.cy.ts
+++ b/cypress-tests/cypress/e2e/02-cards/card-elements.cy.ts
@@ -1,0 +1,114 @@
+import {
+  CLIENT_BASE_URL,
+  createPaymentBody,
+  changeObjectKeyValue,
+} from "../../support/utils";
+import { stripeCards } from "../../support/cards";
+
+describe("Card Elements", () => {
+  let publishableKey: string;
+  let secretKey: string;
+
+  // The harness mounts each element into a <type>-mount div, and the SDK names the
+  // iframe after that div.
+  const iframeFor = (elementType: string) =>
+    `#orca-payment-element-iframeRef-${elementType}-mount`;
+
+  const visitHarness = (...elements: string[]) => {
+    const baseUrl =
+      (Cypress.env("CLIENT_BASE_URL") as string | undefined) || CLIENT_BASE_URL;
+    cy.createPaymentIntent(secretKey, createPaymentBody).then(() => {
+      cy.getGlobalState("clientSecret").then((clientSecret) => {
+        const query = new URLSearchParams({
+          publishableKey,
+          clientSecret: clientSecret as unknown as string,
+        });
+        elements.forEach((element) => query.append("element", element));
+        cy.visit(`${baseUrl}/widgets.html?${query.toString()}`);
+      });
+    });
+  };
+
+  // The harness records one row per element event.
+  const events = () => cy.get("#events");
+
+  changeObjectKeyValue(
+    createPaymentBody,
+    "customer_id",
+    "card_elements_test_user",
+  );
+
+  beforeEach(() => {
+    publishableKey = Cypress.env("HYPERSWITCH_PUBLISHABLE_KEY");
+    secretKey = Cypress.env("HYPERSWITCH_SECRET_KEY");
+  });
+
+  describe("cardNumber / cardExpiry / cardCvc", () => {
+    // Skipped: Cypress remaps `parent` inside proxied frames, so the submit path's
+    // sibling cross-read resolves to the frame itself and always reads empty.
+    it.skip("should confirm a payment from the three individual elements", () => {
+      const { cardNo, card_exp_month, card_exp_year, cvc } =
+        stripeCards.successCard;
+      visitHarness("cardNumber", "cardExpiry", "cardCvc");
+
+      cy.iframe(iframeFor("cardNumber")).find("#card-number").type(cardNo);
+      cy.iframe(iframeFor("cardExpiry"))
+        .find("#card-expiry")
+        .type(`${card_exp_month}${card_exp_year}`);
+      cy.iframe(iframeFor("cardCvc")).find("#card-cvc").type(cvc);
+
+      cy.get("#submit").click();
+
+      cy.get("#status", { timeout: 20000 }).should("contain.text", "succeeded");
+    });
+
+    it("should expose each field under the id the submit path cross-reads", () => {
+      // The cardNumber iframe reads its siblings by these ids, so losing one silently
+      // fails validation instead of erroring.
+      visitHarness("cardNumber", "cardExpiry", "cardCvc");
+
+      cy.iframe(iframeFor("cardNumber")).find("#card-number").should("exist");
+      cy.iframe(iframeFor("cardExpiry")).find("#card-expiry").should("exist");
+      cy.iframe(iframeFor("cardCvc")).find("#card-cvc").should("exist");
+    });
+
+    it("should emit ready for each element", () => {
+      // Only cardCvc used to emit it, which stalled confirmPayment's ready-gate.
+      visitHarness("cardNumber", "cardExpiry", "cardCvc");
+
+      ["cardNumber", "cardExpiry", "cardCvc"].forEach((elementType) => {
+        events()
+          .find("tr")
+          .filter(`:contains("${elementType}")`)
+          .filter(':contains("ready")')
+          .should("exist");
+      });
+    });
+  });
+
+  describe("combined card element", () => {
+    it("should emit ready and confirm a payment", () => {
+      // This element collects all three fields itself, so it exercises the confirm
+      // ready-gate rather than the sibling cross-read.
+      const { cardNo, card_exp_month, card_exp_year, cvc } =
+        stripeCards.successCard;
+      visitHarness("card");
+
+      events()
+        .find("tr")
+        .filter(':contains("ready")')
+        .should("contain.text", "card");
+
+      const cardFrame = () => cy.iframe(iframeFor("card"));
+      cardFrame().find('input[autocomplete="cc-number"]').type(cardNo);
+      cardFrame()
+        .find('input[autocomplete="cc-exp"]')
+        .type(`${card_exp_month}${card_exp_year}`);
+      cardFrame().find('input[autocomplete="cc-csc"]').type(cvc);
+
+      cy.get("#submit").click();
+
+      cy.get("#status", { timeout: 20000 }).should("contain.text", "succeeded");
+    });
+  });
+});

--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -298,6 +298,9 @@ let make = (
     inputRef=cvcRef
     placeholder="123"
     height={isSavedCardCvcFlow ? "1.8rem" : ""}
+    // The sibling cross-read in CardUtils.getCardElementValue resolves the CVC by this id; the
+    // saved-card re-collect input is a different form and must not answer to it.
+    id=?{isSavedCardCvcFlow ? None : Some("card-cvc")}
     name=TestUtils.cardCVVInputTestId
     autocomplete="cc-csc"
   />

--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -583,41 +583,39 @@ let handleInputFocus = (
 }
 
 let getCardElementValue = (iframeId, key) => {
-  let firstIframeVal = if (Window.parent->Window.frames)["0"]->Window.name !== iframeId {
-    switch (Window.parent->Window.frames)["0"]
-    ->Window.document
-    ->Window.getElementById(key)
-    ->Nullable.toOption {
-    | Some(dom) => dom->Window.value
-    | None => ""
+  // Probe every parent frame, not a hardcoded 0-2: any foreign frame (e.g. a wallet payframe)
+  // shifts sibling indices, and touching a cross-origin frame throws - guard and skip it.
+  let frames = Window.parent->Window.frames
+  let framesCount = frames->Window.framesLength
+  let rec probe = index =>
+    if index >= framesCount {
+      ""
+    } else {
+      let probed = try {
+        let frame = frames->Window.frameAt(index)
+        if frame->Window.name !== iframeId {
+          switch frame
+          ->Window.document
+          ->Window.getElementById(key)
+          ->Nullable.toOption {
+          | Some(dom) => dom->Window.value
+          | None => ""
+          }
+        } else {
+          ""
+        }
+      } catch {
+      | exn =>
+        // A cross-origin frame is the expected case here; anything else is worth surfacing.
+        switch exn {
+        | Exn.Error(obj) if obj->Exn.name == Some("SecurityError") => ()
+        | _ => Console.warn2(`Skipped frame ${index->Int.toString} while reading ${key}`, exn)
+        }
+        ""
+      }
+      probed === "" ? probe(index + 1) : probed
     }
-  } else {
-    ""
-  }
-  let secondIframeVal = if (Window.parent->Window.frames)["1"]->Window.name !== iframeId {
-    switch (Window.parent->Window.frames)["1"]
-    ->Window.document
-    ->Window.getElementById(key)
-    ->Nullable.toOption {
-    | Some(dom) => dom->Window.value
-    | None => ""
-    }
-  } else {
-    ""
-  }
-
-  let thirdIframeVal = if (Window.parent->Window.frames)["2"]->Window.name !== iframeId {
-    switch (Window.parent->Window.frames)["2"]
-    ->Window.document
-    ->Window.getElementById(key)
-    ->Nullable.toOption {
-    | Some(dom) => dom->Window.value
-    | None => ""
-    }
-  } else {
-    ""
-  }
-  thirdIframeVal === "" ? secondIframeVal === "" ? firstIframeVal : secondIframeVal : thirdIframeVal
+  probe(0)
 }
 
 let checkCardCVC = (cvcNumber, cardBrand) => {

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -16,6 +16,7 @@ let make = (
   ~onFocus=?,
   ~fieldName="",
   ~isLabelHidden=false,
+  ~id=?,
   ~name="",
   ~type_="text",
   ~maxLength=?,
@@ -120,6 +121,7 @@ let make = (
             width: fieldWidth,
             height,
           }
+          ?id
           dataTestId={name}
           disabled={isDisabled || readOnly}
           ref={inputRef->ReactDOM.Ref.domRef}

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -152,6 +152,20 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     sdkAuthorization,
   ))
 
+  React.useEffect(() => {
+    // Only the payment element and cardCvc ever emit `ready`, so confirmPayment's ready-gate
+    // stalled forever for card/cardNumber/cardExpiry mounts - emit for these modes too.
+    switch paymentMode->getPaymentMode {
+    | (Card | CardNumberElement | CardExpiryElement) as mode =>
+      SubscriptionEventHooks.emitReady(
+        ~iframeId,
+        ~elementType=CardThemeType.getPaymentModeToString(mode),
+      )
+    | _ => ()
+    }
+    None
+  }, (iframeId, paymentMode))
+
   if integrateError {
     <ErrorOccured />
   } else {

--- a/src/Window.res
+++ b/src/Window.res
@@ -75,6 +75,8 @@ external removeEventListener: (string, 'ev => unit) => unit = "removeEventListen
 @get external fullscreen: window => option<window> = "fullscreen"
 @get external frames: window => {..} = "frames"
 @get external name: window => string = "name"
+@get external framesLength: {..} => int = "length"
+@get_index external frameAt: ({..}, int) => window = ""
 @get external contentWindow: Dom.element => Dom.element = "contentWindow"
 @get external style: Dom.element => style = "style"
 @get external readyState: document => string = "readyState"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes #1704 (root causes, reproduction, and before/after screenshots there).

The individual card elements (`cardNumber` / `cardExpiry` / `cardCvc`) cannot be confirmed programmatically. Three independent causes, one commit each:

1. The CVC input lost its `#card-cvc` id in [3d89cb8](https://github.com/juspay/hyperswitch-web/commit/3d89cb8f494aaef96d07e678d3b6cd0d2812b2ca), so the sibling cross-read never resolves and validation always fails. Restored through a new optional `id` prop on `PaymentInputField`, gated to the non-vault branch so the vault CVC re-collect does not answer to the same id.
2. `getCardElementValue` hardcodes `frames[0..2]` and reads `.name` unguarded, so any foreign frame (a wallet payframe, for one) shifts the sibling indices or throws. It now walks every frame with a per-frame guard.
3. The card-family elements never emit `ready`, so `confirmPayment` waits on its ready-gate indefinitely. Now emitted for `card`, `cardNumber` and `cardExpiry`.

The full payment element is untouched.

One behavioural change: frame probing is now lowest-index-first, where the old code preferred the highest of 0-2. Only observable with multiple SDK instances on one page.

## How did you test it?

Manually against the docker stack.

Filled trio + `hyper.confirmPayment`: router-verified `status: succeeded`. Same page and inputs before the fix: `validation_error: "Please enter all fields"`. Screenshots in #1704.

Happy to add a Cypress case if you would like one.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
