### PR TITLE
fix: size and validate the CVC from the detected card brand

### DIFF
--- a/cypress-tests/cypress/e2e/02-cards/01-card-validation.cy.ts
+++ b/cypress-tests/cypress/e2e/02-cards/01-card-validation.cy.ts
@@ -227,6 +227,48 @@ describe("Card Number Validation", () => {
     });
   });
 
+  describe("CVC Validity Styling", () => {
+    // A field is marked invalid on blur and unmarked while focused, uniformly across the
+    // SDK. The second case matters because the expiry auto-advances into the CVC: focus
+    // must still land there, and must still clear the mark.
+    const typeVisaThenShortCvc = () => {
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardNoInputTestId}]`)
+        .type(stripeCards.successCard.cardNo);
+
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardCVVInputTestId}]`)
+        .type("12");
+    };
+
+    it("should mark an out-of-range CVC invalid on blur and unmark it on focus", () => {
+      typeVisaThenShortCvc();
+
+      getIframeBody().find(`[data-testid=${testIds.cardNoInputTestId}]`).click();
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardCVVInputTestId}]`)
+        .should("have.class", "Input--invalid");
+
+      getIframeBody().find(`[data-testid=${testIds.cardCVVInputTestId}]`).click();
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardCVVInputTestId}]`)
+        .should("not.have.class", "Input--invalid");
+    });
+
+    it("should focus the CVC and unmark it when the expiry auto-advances", () => {
+      typeVisaThenShortCvc();
+
+      getIframeBody()
+        .find(`[data-testid=${testIds.expiryInputTestId}]`)
+        .type("1230");
+
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardCVVInputTestId}]`)
+        .should("have.focus")
+        .and("not.have.class", "Input--invalid");
+    });
+  });
+
   describe("Card Brand Icons", () => {
     it("should display card brand icon dynamically for Visa", () => {
       getIframeBody()

--- a/cypress-tests/cypress/e2e/02-cards/01-card-validation.cy.ts
+++ b/cypress-tests/cypress/e2e/02-cards/01-card-validation.cy.ts
@@ -201,6 +201,32 @@ describe("Card Number Validation", () => {
     });
   });
 
+  describe("CVC Length by Card Brand", () => {
+    it("should size the CVC to 3 for a Visa", () => {
+      const { cardNo } = stripeCards.successCard;
+
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardNoInputTestId}]`)
+        .type(cardNo);
+
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardCVVInputTestId}]`)
+        .should("have.attr", "maxlength", "3");
+    });
+
+    it("should size the CVC to 4 for an American Express", () => {
+      const { cardNo } = stripeCards.amexCard15;
+
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardNoInputTestId}]`)
+        .type(cardNo);
+
+      getIframeBody()
+        .find(`[data-testid=${testIds.cardCVVInputTestId}]`)
+        .should("have.attr", "maxlength", "4");
+    });
+  });
+
   describe("Card Brand Icons", () => {
     it("should display card brand icon dynamically for Visa", () => {
       getIframeBody()

--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -95,6 +95,7 @@ type cvcProps = {
   onCvcKeyDown: ReactEvent.Keyboard.t => unit,
   cvcError: string,
   setCvcError: (string => string) => unit,
+  maxCVCLength: int,
 }
 
 let useDefaultCvcProps = () => {
@@ -110,6 +111,7 @@ let useDefaultCvcProps = () => {
     onCvcKeyDown: _ => (),
     cvcError: "",
     setCvcError: _ => (),
+    maxCVCLength: CardValidations.getobjFromCardPattern("").maxCVCLength,
   }
 }
 

--- a/src/Components/CardFields.res
+++ b/src/Components/CardFields.res
@@ -38,6 +38,7 @@ let make = (
     handleCVCBlur,
     cvcRef,
     cvcError,
+    maxCVCLength,
   } = cvcProps
 
   let isCvcValidValue = CardUtils.getBoolOptionVal(isCVCValid)
@@ -118,7 +119,7 @@ let make = (
             )}
             type_="tel"
             className={`tracking-widest w-full ${compressedLayoutStyleForCvcError}`}
-            maxLength=4
+            maxLength=maxCVCLength
             inputRef=cvcRef
             placeholder="123"
             name=TestUtils.cardCVVInputTestId

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -56,6 +56,7 @@ let useCardForm = (
     !showPaymentMethodsScreen && isNotBancontact ? cardScheme : detectedCardBrand
   )
 
+  let stateCardBrand = cardBrand
   let derivedCardBrand = CardUtils.getCardBrandFromStates(
     cardBrand,
     cardScheme,
@@ -63,6 +64,14 @@ let useCardForm = (
   )
   let cardBrand =
     cardBrandOverride === "" ? derivedCardBrand : cardBrandOverride->CardUtils.normalizeCardBrand
+
+  // Nothing in the card element's tree writes the scheme atom, so the brand is lost here and the CVC
+  // rules fall back to the permissive default. CVC-scoped: widening cardBrand changes the payload.
+  let cardBrandForCvc = switch (cardBrand, paymentType) {
+  | ("", CardThemeType.Card) => stateCardBrand
+  | _ => cardBrand
+  }
+  let maxCVCLength = CardValidations.getobjFromCardPattern(cardBrandForCvc).maxCVCLength
   let supportedCardBrands = React.useMemo(() => {
     switch forwardedSupportedCardBrands {
     | Some(brands) => Some(brands)
@@ -89,12 +98,26 @@ let useCardForm = (
     cardBrand->getCardType
   }, [cardBrand])
 
-  React.useEffect(() => {
-    let obj = CardValidations.getobjFromCardPattern(cardBrand)
-    let cvcLength = obj.maxCVCLength
+  // maxLength only constrains new input, so a CVC entered before the brand was known has to be
+  // re-judged against it, by the same rule as a blur: narrowing invalidates it, widening restores it.
+  React.useEffect1(() => {
     if (
-      cvcNumberInRange(cvcNumber, cardBrand)->Array.includes(true) &&
-        cvcNumber->String.length == cvcLength
+      cvcNumber->String.length > 0 &&
+        cvcNumberInRange(cvcNumber, cardBrandForCvc)->Array.includes(true)
+    ) {
+      setIsCVCValid(_ => Some(true))
+    } else if cvcNumber->String.length == 0 {
+      setIsCVCValid(_ => None)
+    } else {
+      setIsCVCValid(_ => Some(false))
+    }
+    None
+  }, [cardBrandForCvc])
+
+  React.useEffect(() => {
+    if (
+      cvcNumberInRange(cvcNumber, cardBrandForCvc)->Array.includes(true) &&
+        cvcNumber->String.length == maxCVCLength
     ) {
       blurRef(cvcRef)
     }
@@ -179,13 +202,13 @@ let useCardForm = (
   let changeCVCNumber = ev => {
     let val = ReactEvent.Form.target(ev)["value"]
     logInputChangeInfo("cardCVC", logger)
-    let cvc = val->CardValidations.formatCVCNumber(cardBrand)
+    let cvc = val->CardValidations.formatCVCNumber(cardBrandForCvc)
     setCvcNumber(_ => cvc)
-    if cvc->String.length > 0 && cvcNumberInRange(cvc, cardBrand)->Array.includes(true) {
+    if cvc->String.length > 0 && cvcNumberInRange(cvc, cardBrandForCvc)->Array.includes(true) {
       zipRef.current->Nullable.toOption->Option.forEach(input => input->focus)->ignore
     }
 
-    if cvc->String.length > 0 && cvcNumberInRange(cvc, cardBrand)->Array.includes(true) {
+    if cvc->String.length > 0 && cvcNumberInRange(cvc, cardBrandForCvc)->Array.includes(true) {
       setIsCVCValid(_ => Some(true))
     } else {
       setIsCVCValid(_ => None)
@@ -275,7 +298,8 @@ let useCardForm = (
   let handleCVCBlur = ev => {
     let cvcNumber = ReactEvent.Focus.target(ev)["value"]
     if (
-      cvcNumber->String.length > 0 && cvcNumberInRange(cvcNumber, cardBrand)->Array.includes(true)
+      cvcNumber->String.length > 0 &&
+        cvcNumberInRange(cvcNumber, cardBrandForCvc)->Array.includes(true)
     ) {
       setIsCVCValid(_ => Some(true))
     } else if cvcNumber->String.length == 0 {
@@ -390,6 +414,7 @@ let useCardForm = (
     onCvcKeyDown,
     cvcError,
     setCvcError,
+    maxCVCLength,
   }
 
   let zipProps: CardUtils.zipProps = {

--- a/src/SingleLineCardPayment.res
+++ b/src/SingleLineCardPayment.res
@@ -43,6 +43,7 @@ let make = (
     handleCVCBlur,
     cvcRef,
     onCvcKeyDown,
+    maxCVCLength,
   } = cvcProps
 
   let {
@@ -159,7 +160,7 @@ let make = (
             paymentType
             type_="tel"
             className={`tracking-widest w-auto`}
-            maxLength=4
+            maxLength=maxCVCLength
             inputRef=cvcRef
             placeholder="123"
             isFocus


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes #1706.

In a bare `card` element every CVC rule runs against an empty brand, so the rules fall back to the default card pattern, which accepts 3 or 4 digits, and the input's `maxLength` was a literal `4`. A 4-digit CVC on a Visa therefore passed the client and failed at the processor as an opaque `cvv_invalid`.

This derives a CVC-scoped brand and routes the CVC rules through it: the input's `maxLength`, the formatter, the range checks, and the CVC-to-ZIP auto-advance. A CVC already in the field when the brand arrives is re-judged against it, by the same rule a blur already uses, so narrowing invalidates it and widening makes it valid again. The value the user typed is never rewritten and never deleted.

The hook's `cardBrand` is left byte-identical to upstream. That is deliberate and is the whole reason the change is scoped this way: widening it would also put `card_network` on the wire in this mode, make `checkIsCardSupported` decline brands outside the merchant's configured `card_networks`, narrow `maxCardLength`, and wake the clear-expiry-and-CVC-on-brand-change effect. A PR about CVC length should change none of those, and this one changes none of them. `Payment.res` is untouched.

### Three things reviewers should see explicitly

- **The individual `cardCvc` element is NOT fixed.** It is a separate iframe whose local card number is always empty, so it cannot know the brand, and there is no association between a `cardNumber` and the `cardCvc` of the same form to route one to it. Its input keeps `maxLength=4`. Tightening only the submit-time gate was tried and dropped: it rejects input that the CVC iframe still shows as valid, and the error surfaces in a frame with no CVC field, which is worse than the status quo. Closing this properly looks like a design decision rather than something to invent inside a bugfix.
- **The two saved-card CVC inputs keep `maxLength=4` on purpose.** In those flows the scheme atom IS written, so the CVC brand is the saved card's scheme and the formatter already caps the value. Measured: typing `1234` into a saved Visa's CVC re-collect field yields `123`, with the attribute still reading 4. The literal never binds, so converting it would be churn.
- **In the payment element the `maxLength` attribute does change** (4 becomes 3 on a Visa), because that is where the brand was already available. The submitted value does not change, since the formatter already capped it. The only user-visible delta is that the browser now blocks a phantom 4th keystroke it previously accepted and discarded.

### One pre-existing gap this does not widen, but worth knowing

`emitIsFormReadyForSubmission` only fires when all three of `(isCardValid, isExpiryValid, isCVCValid)` are `Some`, so any transition to `None` emits nothing and a previously-emitted `true` is never retracted. Upstream already reaches that state on its own: `changeCVCNumber` sets `None` on any invalid keystroke, so deleting a digit from an accepted CVC leaves the same stale `true`. Using the blur rule for the re-judge means this change reaches `Some(false)` rather than `None` when a CVC goes stale, so the signal retracts correctly here. Making the emit total is a change to the merchant-facing event contract and belongs in its own PR.

## How did you test it?

Added two cypress assertions to `02-cards/01-card-validation.cy.ts`, next to the existing per-brand formatting tests: the CVC `maxlength` is 3 for a Visa and 4 for an American Express. The first fails on `main`. Note the `cypress` job is skipped on fork PRs, so these have not run in CI here.

Beyond that, manually against a hosted sandbox with a real connector, driving the elements in a browser. The bare `card` element is not in any demo UI, so it was mounted directly to exercise it.

CVC `maxlength`:

| | before | after |
|---|---|---|
| bare `card` element, no PAN | 4 | 4 |
| bare `card` element, Visa | 4 | 3 |
| bare `card` element, Amex | 4 | 4 |
| payment element, Visa / Amex | 4 / 4 | 3 / 4 |
| individual `cardCvc` element | 4 | 4 (by design, see above) |
| saved-card CVC re-collect | 4 | 4 (value already capped, see above) |

Validity and submit, in the bare `card` element. These matter more than the attribute, because a wrong-length CVC used to be reported as valid:

| Case | Result |
|---|---|
| Amex PAN, CVC `123`, blur | invalid, and form readiness emits `false` |
| Visa PAN, CVC `123`, blur | valid, readiness `true` |
| Amex PAN, CVC `1234`, blur | valid, readiness `true` |
| CVC `1234` typed before the PAN, then a Visa PAN | value `1234` kept, marked invalid |

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
