### PR TITLE
fix: card and cvc iframe remount UX regression

### DIFF
--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -297,7 +297,7 @@ let make = (
     maxLength=maxCvcLength
     inputRef=cvcRef
     placeholder="123"
-    height={isSavedCardCvcFlow ? "1.8rem" : ""}
+    height={isSavedCardCvcFlow ? SavedCardCvcStyles.fieldHeight : ""}
     // The sibling cross-read in CardUtils.getCardElementValue resolves the CVC by this id; the
     // saved-card re-collect input is a different form and must not answer to it.
     id=?{isSavedCardCvcFlow ? None : Some("card-cvc")}

--- a/src/Components/SavedCardCvcFieldSkeleton.res
+++ b/src/Components/SavedCardCvcFieldSkeleton.res
@@ -1,10 +1,3 @@
-// Static stand-in for the saved-card (return user) CVC field, held over the nested
-// iframe's container while that iframe boots so the row never grows around it.
-//
-// Mirrors how PaymentInputField styles the CVC input inside that iframe: the compressed
-// layout drops the rounded corners, and the background follows the Payment payment-type
-// (the iframe renders without a PaymentTypeContext provider, so it takes the context
-// default). Geometry comes from SavedCardCvcStyles, which both frames share.
 @react.component
 let make = () => {
   let {themeObj, config} = Jotai.useAtomValue(JotaiAtoms.configAtom)

--- a/src/Components/SavedCardCvcFieldSkeleton.res
+++ b/src/Components/SavedCardCvcFieldSkeleton.res
@@ -1,0 +1,24 @@
+// Static stand-in for the saved-card (return user) CVC field, held over the nested
+// iframe's container while that iframe boots so the row never grows around it.
+//
+// Mirrors how PaymentInputField styles the CVC input inside that iframe: the compressed
+// layout drops the rounded corners, and the background follows the Payment payment-type
+// (the iframe renders without a PaymentTypeContext provider, so it takes the context
+// default). Geometry comes from SavedCardCvcStyles, which both frames share.
+@react.component
+let make = () => {
+  let {themeObj, config} = Jotai.useAtomValue(JotaiAtoms.configAtom)
+  let inputClassStyles = config.appearance.innerLayout === Spaced ? "Input" : "Input-Compressed"
+
+  <div
+    className="absolute top-0 left-0 flex w-full p-0.5 pointer-events-none" ariaHidden=true>
+    <div
+      className={`${inputClassStyles} Input--empty w-full`}
+      style={
+        height: SavedCardCvcStyles.fieldHeight,
+        padding: themeObj.spacingUnit,
+        background: themeObj.colorBackground,
+      }
+    />
+  </div>
+}

--- a/src/Components/SavedMethodItemV2.res
+++ b/src/Components/SavedMethodItemV2.res
@@ -206,7 +206,7 @@ let make = (
                         maxLength=4
                         inputRef=cvcRef
                         placeholder="123"
-                        height="1.8rem"
+                        height=SavedCardCvcStyles.fieldHeight
                         name={TestUtils.cardCVVInputTestId}
                         autocomplete="cc-csc"
                       />

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -386,8 +386,29 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     selectedOption,
   ))
 
+  // Keep the card body (and its PCI iframe) mounted after first selection so returning
+  // to Card does not reload the vault iframe or wipe typed card data. It is lazy: it only
+  // mounts once Card has been selected at least once, then stays alive and is hidden via
+  // display:none when another method is active.
+  let (cardMounted, setCardMounted) = React.useState(() => false)
+  React.useEffect(() => {
+    if !cardMounted && selectedOption->PaymentModeType.paymentMode == Card {
+      setCardMounted(_ => true)
+    }
+    None
+  }, (cardMounted, selectedOption))
+
   let paymentFormElement = {
-    <ErrorBoundary key={selectedOption} componentName="PaymentElement" publishableKey>
+    let cardIsActive = selectedOption->PaymentModeType.paymentMode == Card
+    <>
+      <RenderIf condition=cardMounted>
+        <div style={display: cardIsActive ? "" : "none"} ariaHidden={!cardIsActive}>
+          <ParentCardComponent
+            key={`card-${cardCollectionMode}`} cardCollectionMode isActive=cardIsActive
+          />
+        </div>
+      </RenderIf>
+      <ErrorBoundary key={selectedOption} componentName="PaymentElement" publishableKey>
       {switch selectedOption->PaymentModeType.paymentMode {
       | SavedMethods =>
         <SavedMethods
@@ -402,7 +423,7 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
           getVisaCards
           closeComponentIfSavedMethodsAreEmpty
         />
-      | Card => <ParentCardComponent key={`card-${cardCollectionMode}`} cardCollectionMode />
+      | Card => React.null
       | ACHTransfer =>
         <ReusableReactSuspense
           loaderComponent={<LoaderPaymentShimmer />} componentName="ACHBankTransferLazy">
@@ -512,7 +533,8 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
           <PaymentMethodsWrapperLazy paymentMethodName=selectedOption />
         </ReusableReactSuspense>
       }}
-    </ErrorBoundary>
+      </ErrorBoundary>
+    </>
   }
 
   let checkoutEle = if groupSavedMethodsWithPaymentMethods {

--- a/src/PaymentElement.res
+++ b/src/PaymentElement.res
@@ -386,10 +386,6 @@ let make = (~cardProps, ~expiryProps, ~cvcProps, ~paymentType: CardThemeType.mod
     selectedOption,
   ))
 
-  // Keep the card body (and its PCI iframe) mounted after first selection so returning
-  // to Card does not reload the vault iframe or wipe typed card data. It is lazy: it only
-  // mounts once Card has been selected at least once, then stays alive and is hidden via
-  // display:none when another method is active.
   let (cardMounted, setCardMounted) = React.useState(() => false)
   React.useEffect(() => {
     if !cardMounted && selectedOption->PaymentModeType.paymentMode == Card {

--- a/src/Payments/CardIframeProtocol.res
+++ b/src/Payments/CardIframeProtocol.res
@@ -74,6 +74,13 @@ let initialSavedCardCvcState: savedCardCvcState = {
   error: "",
 }
 
+// LoaderController reports the inner frame's measured body height + 1px. Before any field
+// renders, that body is only PaymentMethodsSDK's 2px padding, so a height at or below this
+// is the empty frame measuring itself rather than the form it is about to hold.
+let emptyFrameHeight = 5.0
+
+let decodeIframeHeight = dict => dict->getFloat("iframeHeight", 0.0)
+
 let jsonOptionString = (dict, key) => {
   let value = dict->getString(key, "")
   value === "" ? None : Some(value)

--- a/src/Payments/ParentCardComponent.res
+++ b/src/Payments/ParentCardComponent.res
@@ -34,6 +34,7 @@ let make = (
   ~cardCollectionMode="tokenise",
   ~isBancontact=false,
   ~flowType=CardThemeType.Payment,
+  ~isActive=true,
 ) => {
   let {
     clientSecret,
@@ -351,12 +352,12 @@ let make = (
     ~complete=cardFieldsComplete && isInstallmentValid && areRequiredFieldsValid,
     ~empty=cardFieldsEmpty,
     ~paymentType="card",
-    ~enabled=!isSavedCardFlow,
+    ~enabled=!isSavedCardFlow && isActive,
   )
   SubscriptionEventHooks.useEmitFormStatus(
     ~empty=cardFieldsEmpty,
     ~complete=cardFieldsComplete && isInstallmentValid && areRequiredFieldsValid,
-    ~enabled=!isSavedCardFlow,
+    ~enabled=!isSavedCardFlow && isActive,
   )
   SubscriptionEventHooks.useEmitSurchargeInfo(~surchargeDetails=eligibilitySurchargeDetails)
 
@@ -797,7 +798,7 @@ let make = (
   }
 
   let submitCallback = React.useCallback((ev: Window.event) => {
-    if !isSavedCardFlow {
+    if !isSavedCardFlow && isActive {
       let json = ev.data->safeParse
       let confirm = json->getDictFromJson->ConfirmType.itemToObjMapper
       if confirm.doSubmit && !hasCardFieldStatus {
@@ -973,6 +974,7 @@ let make = (
     }
   }, (
     iframeRef,
+    isActive,
     areRequiredFieldsValid,
     isCustomerAcceptanceRequired,
     selectedInstallmentPlan,

--- a/src/Payments/ParentCardComponent.res
+++ b/src/Payments/ParentCardComponent.res
@@ -105,6 +105,12 @@ let make = (
   let (savedCardCvcState, setSavedCardCvcState) = React.useState(_ =>
     CardIframeProtocol.initialSavedCardCvcState
   )
+  let (hasInnerIframeHeight, setHasInnerIframeHeight) = React.useState(_ => false)
+  // The CVC status is posted from CardCVCElement's mount effect, but the iframe is only
+  // sized a round trip later, once LoaderController's ResizeObserver has measured that
+  // same commit. Until then it is still `height: 0`, so the status alone is not something
+  // to hand over to.
+  let isCvcReady = savedCardCvcState.ready && hasInnerIframeHeight
   let {
     cardBrand,
     rawCardNumber,
@@ -500,6 +506,10 @@ let make = (
         ~sdkDomainUrl=ApiEndpoint.vaultSdkDomainUrl,
         ~logger=Some(loggerState),
         ~confirmPayment=(_json => Promise.resolve(JSON.Encode.null)),
+        // The saved-card CVC box is reserved by this component, so the iframe has to snap
+        // to the height it reports rather than animate into it — otherwise the field
+        // grows in over 0.35s just as the stand-in hands over.
+        ~animateResize=!isSavedCardFlow,
       )
       element.mount(`#${containerId}`)
       Some(
@@ -578,6 +588,9 @@ let make = (
           switch CardIframeProtocol.decodeSavedCardCvcState(dict) {
           | Some(status) => setSavedCardCvcState(_ => status)
           | None => ()
+          }
+          if dict->getFloat("iframeHeight", 0.0) > 0.0 {
+            setHasInnerIframeHeight(_ => true)
           }
         }
         switch CardIframeProtocol.decodeStateUpdate(
@@ -1008,8 +1021,23 @@ let make = (
   let accordionMarginClass = layoutClass.\"type" === Accordion ? "mt-4" : ""
   let showNickname = (!hideCardNicknameField && isCustomerAcceptanceRequired) || isPMMFlow
 
+  // Selecting a saved card mounts a fresh inner iframe, which takes a moment to boot and
+  // to be sized. Reserve the field's box up front and hold a static stand-in over the
+  // container until the real field is both rendered and sized — no growth, no reflow, no
+  // fade. The stand-in overlays the container rather than replacing it, so the iframe
+  // stays in normal flow and the row can never end up shorter than the field it holds.
+  // The container is hidden by opacity, not display, because CardCVCElement focuses
+  // itself on mount and an input inside a hidden iframe cannot take focus.
   isSavedCardFlow
-    ? <div id=containerId style={position: "relative"} />
+    ? <div className="relative w-full" style={minHeight: SavedCardCvcStyles.reservedBoxHeight}>
+        <div
+          id=containerId
+          className={`relative ${isCvcReady ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        />
+        <RenderIf condition={!isCvcReady}>
+          <SavedCardCvcFieldSkeleton />
+        </RenderIf>
+      </div>
     : <div
         className={`ParentCardComponent flex flex-col w-full ${accordionMarginClass} ${isRawMode
             ? "animate-slowShow"

--- a/src/Payments/ParentCardComponent.res
+++ b/src/Payments/ParentCardComponent.res
@@ -105,12 +105,12 @@ let make = (
   let (savedCardCvcState, setSavedCardCvcState) = React.useState(_ =>
     CardIframeProtocol.initialSavedCardCvcState
   )
-  let (hasInnerIframeHeight, setHasInnerIframeHeight) = React.useState(_ => false)
+  let (innerIframeHeight, setInnerIframeHeight) = React.useState(_ => 0.0)
   // The CVC status is posted from CardCVCElement's mount effect, but the iframe is only
   // sized a round trip later, once LoaderController's ResizeObserver has measured that
   // same commit. Until then it is still `height: 0`, so the status alone is not something
   // to hand over to.
-  let isCvcReady = savedCardCvcState.ready && hasInnerIframeHeight
+  let isCvcReady = savedCardCvcState.ready && innerIframeHeight > 0.0
   let {
     cardBrand,
     rawCardNumber,
@@ -127,6 +127,9 @@ let make = (
     hasCvcValidationStatus,
     cardInfo,
   } = innerCardState
+  let isCardFormReady =
+    hasCardFieldStatus &&
+    (isBancontact || innerIframeHeight > CardIframeProtocol.emptyFrameHeight)
   let setIsVgsScriptReady = Jotai.useSetAtom(JotaiAtoms.isVgsScriptReady)
 
   let mountConfigRef = React.useRef((
@@ -506,10 +509,7 @@ let make = (
         ~sdkDomainUrl=ApiEndpoint.vaultSdkDomainUrl,
         ~logger=Some(loggerState),
         ~confirmPayment=(_json => Promise.resolve(JSON.Encode.null)),
-        // The saved-card CVC box is reserved by this component, so the iframe has to snap
-        // to the height it reports rather than animate into it — otherwise the field
-        // grows in over 0.35s just as the stand-in hands over.
-        ~animateResize=!isSavedCardFlow,
+        ~animateResize=false,
       )
       element.mount(`#${containerId}`)
       Some(
@@ -584,13 +584,14 @@ let make = (
         iframeRef.current->Window.iframePostMessage(dict, ~targetOrigin=innerIframeOrigin)
       }
       if isInnerCardMessage {
+        let reportedHeight = CardIframeProtocol.decodeIframeHeight(dict)
+        if reportedHeight > 0.0 {
+          setInnerIframeHeight(_ => reportedHeight)
+        }
         if isSavedCardFlow {
           switch CardIframeProtocol.decodeSavedCardCvcState(dict) {
           | Some(status) => setSavedCardCvcState(_ => status)
           | None => ()
-          }
-          if dict->getFloat("iframeHeight", 0.0) > 0.0 {
-            setHasInnerIframeHeight(_ => true)
           }
         }
         switch CardIframeProtocol.decodeStateUpdate(
@@ -1043,10 +1044,18 @@ let make = (
             ? "animate-slowShow"
             : ""}`}
         style={gridGap: themeObj.spacingGridColumn}>
-        <div
-          id=containerId
-          style={position: "relative", visibility: hasCardFieldStatus ? "visible" : "hidden"}
-        />
+        // The container and the shimmer share one flex item so the column's grid gap never
+        // opens up between them: while the iframe is booting the container carries no
+        // height, and the shimmer standing under it is what reserves the form's box.
+        <div className="relative w-full">
+          <div
+            id=containerId
+            style={position: "relative", visibility: isCardFormReady ? "visible" : "hidden"}
+          />
+          <RenderIf condition={!isCardFormReady && !isBancontact}>
+            <PaymentElementShimmer />
+          </RenderIf>
+        </div>
         <RenderIf
           condition={hasCardFieldStatus &&
           (showPaymentMethodsScreen || isBancontact || !isRawMode)}>

--- a/src/Payments/ParentCardComponent.res
+++ b/src/Payments/ParentCardComponent.res
@@ -106,11 +106,8 @@ let make = (
     CardIframeProtocol.initialSavedCardCvcState
   )
   let (innerIframeHeight, setInnerIframeHeight) = React.useState(_ => 0.0)
-  // The CVC status is posted from CardCVCElement's mount effect, but the iframe is only
-  // sized a round trip later, once LoaderController's ResizeObserver has measured that
-  // same commit. Until then it is still `height: 0`, so the status alone is not something
-  // to hand over to.
   let isCvcReady = savedCardCvcState.ready && innerIframeHeight > 0.0
+
   let {
     cardBrand,
     rawCardNumber,
@@ -1022,13 +1019,6 @@ let make = (
   let accordionMarginClass = layoutClass.\"type" === Accordion ? "mt-4" : ""
   let showNickname = (!hideCardNicknameField && isCustomerAcceptanceRequired) || isPMMFlow
 
-  // Selecting a saved card mounts a fresh inner iframe, which takes a moment to boot and
-  // to be sized. Reserve the field's box up front and hold a static stand-in over the
-  // container until the real field is both rendered and sized — no growth, no reflow, no
-  // fade. The stand-in overlays the container rather than replacing it, so the iframe
-  // stays in normal flow and the row can never end up shorter than the field it holds.
-  // The container is hidden by opacity, not display, because CardCVCElement focuses
-  // itself on mount and an input inside a hidden iframe cannot take focus.
   isSavedCardFlow
     ? <div className="relative w-full" style={minHeight: SavedCardCvcStyles.reservedBoxHeight}>
         <div
@@ -1044,9 +1034,6 @@ let make = (
             ? "animate-slowShow"
             : ""}`}
         style={gridGap: themeObj.spacingGridColumn}>
-        // The container and the shimmer share one flex item so the column's grid gap never
-        // opens up between them: while the iframe is booting the container carries no
-        // height, and the shimmer standing under it is what reserves the form's box.
         <div className="relative w-full">
           <div
             id=containerId

--- a/src/Payments/VGSVault.res
+++ b/src/Payments/VGSVault.res
@@ -369,7 +369,7 @@ let make = (~cvcOnly=false) => {
             id="vgs-cc-cvc"
             isFocused={isCVCFocused->Option.getOr(false)}
             compact=true
-            height="1.8rem"
+            height=SavedCardCvcStyles.fieldHeight
           />
         </div>
       } else {

--- a/src/Utilities/SavedCardCvcStyles.res
+++ b/src/Utilities/SavedCardCvcStyles.res
@@ -1,16 +1,5 @@
-// Geometry of the saved-card (return user) CVC field.
-//
-// The field itself is rendered inside the nested paymentMethodsSDK iframe — by
-// CardCVCElement in the raw flow, by VGSInputComponent in the VGS vault flow — while
-// ParentCardComponent reserves the same box in the outer frame before that iframe has
-// booted. Both frames must agree on the height or the stand-in stops matching the real
-// field, so it lives here rather than as a literal on either side.
-
 // Height of the CVC input itself. Deliberately small: the saved-card row holds the CVC
 // inline next to the card details, not as a full-width new-card field.
 let fieldHeight = "1.8rem"
 
-// Box the outer frame reserves for the field. The inner iframe's body wrapper
-// (PaymentMethodsSDK) pads it by 2px on every side, so the reserved box is 4px taller
-// than the field — the stand-in insets itself by the same 2px.
 let reservedBoxHeight = `calc(${fieldHeight} + 4px)`

--- a/src/Utilities/SavedCardCvcStyles.res
+++ b/src/Utilities/SavedCardCvcStyles.res
@@ -1,0 +1,16 @@
+// Geometry of the saved-card (return user) CVC field.
+//
+// The field itself is rendered inside the nested paymentMethodsSDK iframe — by
+// CardCVCElement in the raw flow, by VGSInputComponent in the VGS vault flow — while
+// ParentCardComponent reserves the same box in the outer frame before that iframe has
+// booted. Both frames must agree on the height or the stand-in stops matching the real
+// field, so it lives here rather than as a literal on either side.
+
+// Height of the CVC input itself. Deliberately small: the saved-card row holds the CVC
+// inline next to the card details, not as a full-width new-card field.
+let fieldHeight = "1.8rem"
+
+// Box the outer frame reserves for the field. The inner iframe's body wrapper
+// (PaymentMethodsSDK) pads it by 2px on every side, so the reserved box is 4px taller
+// than the field — the stand-in insets itself by the same 2px.
+let reservedBoxHeight = `calc(${fieldHeight} + 4px)`

--- a/src/Utilities/VGSConstants.res
+++ b/src/Utilities/VGSConstants.res
@@ -36,8 +36,8 @@ let savedCardCvcCss =
   [
     ("padding", "0px"),
     ("margin", "0px"),
-    ("line-height", "1.8rem"),
-    ("height", "1.8rem"),
+    ("line-height", SavedCardCvcStyles.fieldHeight),
+    ("height", SavedCardCvcStyles.fieldHeight),
     ("box-sizing", "border-box"),
   ]
   ->Array.map(((key, value)) => (key, value->JSON.Encode.string))

--- a/src/hyper-loader/LoaderPaymentElement.res
+++ b/src/hyper-loader/LoaderPaymentElement.res
@@ -90,6 +90,7 @@ let make = (
   mountPostMessage,
   ~appearance,
   ~isPaymentManagementElement=false,
+  ~animateResize=true,
   ~redirectionFlags: JotaiAtomTypes.redirectionFlags,
   ~sdkDomainUrl=ApiEndpoint.sdkDomainUrl,
   ~logger: option<HyperLoggerTypes.loggerMake>,
@@ -548,7 +549,11 @@ let make = (
           let elem = Window.querySelector(`#${iframeElementId}`)
           switch elem->Nullable.toOption {
           | Some(ele) =>
-            ele->Window.style->Window.setTransition("height 0.35s ease 0s, opacity 0.4s ease 0.1s")
+            ele
+            ->Window.style
+            ->Window.setTransition(
+              animateResize ? "height 0.35s ease 0s, opacity 0.4s ease 0.1s" : "none",
+            )
           | None => ()
           }
         }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

1. Fixed a UX regression where the card iframe (PCI vault iframe) was remounted every time the user switched away from the Card payment method and came back. Because the card body was rendered inside an ErrorBoundary keyed by selectedOption, switching payment methods unmounted the card component entirely — causing the vault iframe to reload and wiping any card details the shopper had already typed.
Also, added a shimmer while the iframe is mounted.
https://github.com/user-attachments/assets/a1d739a4-8930-46ab-b9d4-6a0dd19cf369



2. Fixed CVC Elements weird re-render issue.

Details / Issue recording: 
Card Element: https://github.com/juspay/hyperswitch-cloud/issues/22585
CVC Element:  https://github.com/user-attachments/assets/52b735de-b757-4740-8dc0-498199cef32e



## SCREEN RECORDING (NOW)

https://github.com/user-attachments/assets/8032d146-7c86-468a-95ac-e31ae34f3c7a



<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
