### PR TITLE
feat: add card payment eligibility check for offers

### DIFF
--- a/src/BrutalTheme.res
+++ b/src/BrutalTheme.res
@@ -23,7 +23,7 @@ let brutal = {
   fontSizeXs: "10px",
   fontSize2Xs: "8px",
   fontSize3Xs: "6px",
-  colorSuccess: "",
+  colorSuccess: "#16875B",
   colorWarning: "",
   colorPrimaryText: "#000000",
   colorBackgroundText: "#000000",

--- a/src/BubblegumTheme.res
+++ b/src/BubblegumTheme.res
@@ -23,7 +23,7 @@ let bubblegum = {
   fontSizeXs: "10px",
   fontSize2Xs: "8px",
   fontSize3Xs: "6px",
-  colorSuccess: "",
+  colorSuccess: "#16875B",
   colorWarning: "",
   colorPrimaryText: "#5469d4",
   colorBackgroundText: "",

--- a/src/CardUtils.res
+++ b/src/CardUtils.res
@@ -31,6 +31,7 @@ type cardProps = {
   cardEligibilityError: option<string>,
   updateCardEligibilityError: option<string> => unit,
   eligibilitySurchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+  eligibilityOfferDetails: option<EligibilityHelpers.eligibilityOfferDetails>,
   isEligibilityPending: bool,
 }
 
@@ -53,6 +54,7 @@ let useDefaultCardProps = () => {
     cardEligibilityError: None,
     updateCardEligibilityError: _ => (),
     eligibilitySurchargeDetails: None,
+    eligibilityOfferDetails: None,
     isEligibilityPending: false,
   }
 }

--- a/src/CharcoalTheme.res
+++ b/src/CharcoalTheme.res
@@ -23,7 +23,7 @@ let charcoal = {
   fontSizeXs: "10px",
   fontSize2Xs: "8px",
   fontSize3Xs: "6px",
-  colorSuccess: "",
+  colorSuccess: "#16875B",
   colorWarning: "",
   colorPrimaryText: "#707070",
   colorBackgroundText: "#ffffff",

--- a/src/Components/CardBusinessFields.res
+++ b/src/Components/CardBusinessFields.res
@@ -14,6 +14,8 @@ let make = (
   ~setShowInstallments,
   ~installmentsError,
   ~setInstallmentsError,
+  ~eligibilityOfferDetails,
+  ~isEligibilityPending=false,
 ) => {
   <>
     <DynamicFields
@@ -27,6 +29,7 @@ let make = (
     <RenderIf condition=showNickname>
       <NicknamePaymentInput />
     </RenderIf>
+    <EligibilityOfferNotice eligibilityOfferDetails isEligibilityPending />
     <InstallmentOptions
       setSelectedInstallmentPlan
       showInstallments

--- a/src/Components/ClickToPayAuthenticate.res
+++ b/src/Components/ClickToPayAuthenticate.res
@@ -219,6 +219,7 @@ let make = (
           installmentsError
           setInstallmentsError
           eligibilitySurchargeDetails=None
+          eligibilityOfferDetails=None
           eligibilityError=None
         />
       })

--- a/src/Components/EligibilityNotice.res
+++ b/src/Components/EligibilityNotice.res
@@ -33,7 +33,7 @@ let make = (
         </div>
       } else if eligibilityError->Option.isSome {
         <div
-          className="flex items-start text-xs"
+          className="flex items-start text-left text-xs"
           role="alert"
           ariaLive=#polite
           ariaAtomic=true

--- a/src/Components/EligibilityOfferNotice.res
+++ b/src/Components/EligibilityOfferNotice.res
@@ -1,0 +1,150 @@
+@react.component
+let make = (
+  ~eligibilityOfferDetails: option<EligibilityHelpers.eligibilityOfferDetails>,
+  ~isEligibilityPending=false,
+  ~className="",
+) => {
+  let {themeObj} = Jotai.useAtomValue(JotaiAtoms.configAtom)
+  let successColor = themeObj.colorSuccess
+
+  let appliedOffer =
+    eligibilityOfferDetails
+    ->Option.map(details => details.eligibleOffers)
+    ->Option.getOr([])
+    ->Array.get(0)
+
+  <RenderIf condition={isEligibilityPending || appliedOffer->Option.isSome}>
+    <div
+      className={`box-border flex w-full min-w-0 max-w-full flex-col overflow-hidden ${className}`}
+      style={
+        color: themeObj.colorText,
+        fontWeight: themeObj.fontWeightNormal,
+        fontSize: themeObj.fontSizeLg,
+      }
+      ariaLabel="Eligible offers"
+    >
+      {if isEligibilityPending {
+        <div
+          className="w-full rounded-md px-3 py-3 text-left"
+          style={border: `1px solid ${themeObj.borderColor}`}
+          role="status"
+          ariaLive=#polite
+        >
+          <span className="sr-only"> {"Checking eligible offers"->React.string} </span>
+          <div className="flex flex-col gap-2" ariaHidden=true>
+            <div
+              className="relative h-2.5 w-[120px] overflow-hidden rounded"
+              style={backgroundColor: themeObj.borderColor, opacity: "0.75"}
+            >
+              <div
+                className="absolute inset-0 -translate-x-full animate-[shimmer_1.4s_ease_infinite] bg-gradient-to-r from-transparent via-white/70 to-transparent"
+              />
+            </div>
+            <div
+              className="relative h-2.5 w-3/4 overflow-hidden rounded"
+              style={backgroundColor: themeObj.borderColor, opacity: "0.75"}
+            >
+              <div
+                className="absolute inset-0 -translate-x-full animate-[shimmer_1.4s_ease_infinite] bg-gradient-to-r from-transparent via-white/70 to-transparent"
+              />
+            </div>
+          </div>
+        </div>
+      } else {
+        switch appliedOffer {
+        | Some(offer) =>
+          let offerTitle = offer.title === "" ? "Card offer" : offer.title
+          <div
+            className="relative overflow-hidden"
+            style={
+              border: "1px solid transparent",
+              borderRadius: themeObj.borderRadius,
+              backgroundColor: themeObj.colorBackground,
+            }
+            role="status"
+            ariaLive=#polite
+          >
+            <div
+              className="pointer-events-none absolute inset-0"
+              style={
+                border: `1px solid ${successColor}`,
+                borderRadius: themeObj.borderRadius,
+                opacity: "0.35",
+              }
+              ariaHidden=true
+            />
+            <div
+              className="flex w-full items-center gap-2 text-left"
+              style={
+                padding: `calc(${themeObj.spacingUnit} * 0.8) ${themeObj.spacingUnit}`,
+                backgroundColor: themeObj.colorBackground,
+              }
+            >
+              <div
+                className="relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-sm font-semibold"
+                style={color: successColor}
+                ariaHidden=true
+              >
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-full"
+                  style={backgroundColor: successColor, opacity: "0.16"}
+                />
+                <span className="relative"> {"%"->React.string} </span>
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <div
+                  className="min-w-0 whitespace-normal break-words"
+                  style={minHeight: `calc(${themeObj.fontSizeLg} * 1.5)`}
+                >
+                  <span
+                    className="min-w-0" style={fontSize: themeObj.fontSizeLg, color: successColor}
+                  >
+                    {offerTitle->React.string}
+                  </span>
+                  <RenderIf condition={offer.code !== ""}>
+                    <span
+                      className="ml-2 inline-block whitespace-nowrap rounded border border-dashed px-1 py-0 font-medium"
+                      style={
+                        color: successColor,
+                        borderColor: successColor,
+                        fontSize: themeObj.fontSizeXs,
+                        verticalAlign: "text-top",
+                      }
+                    >
+                      {offer.code->React.string}
+                    </span>
+                  </RenderIf>
+                </div>
+                <RenderIf condition={offer.description !== ""}>
+                  <div
+                    className="mt-px flex min-w-0 items-center whitespace-normal break-words"
+                    style={
+                      color: themeObj.colorTextSecondary,
+                      minHeight: `calc(${themeObj.fontSizeLg} * 1.5)`,
+                    }
+                  >
+                    <span className="min-w-0" style={fontSize: themeObj.fontSizeSm}>
+                      {offer.description->React.string}
+                    </span>
+                  </div>
+                </RenderIf>
+              </div>
+              <div
+                className="ml-0.5 flex shrink-0 items-center gap-1 whitespace-nowrap"
+                style={
+                  color: successColor,
+                  fontSize: themeObj.fontSizeSm,
+                  fontWeight: themeObj.fontWeightMedium,
+                }
+              >
+                <Icon name="checkmark" size=14 />
+                <span> {"Applied"->React.string} </span>
+              </div>
+            </div>
+          </div>
+        | None => React.null
+        }
+      }}
+    </div>
+  </RenderIf>
+}

--- a/src/Components/EligibilityOfferNotice.res
+++ b/src/Components/EligibilityOfferNotice.res
@@ -4,7 +4,7 @@ let make = (
   ~isEligibilityPending=false,
   ~className="",
 ) => {
-  let {themeObj} = Jotai.useAtomValue(JotaiAtoms.configAtom)
+  let {themeObj, localeString} = Jotai.useAtomValue(JotaiAtoms.configAtom)
   let successColor = themeObj.colorSuccess
 
   let appliedOffer =
@@ -21,7 +21,7 @@ let make = (
         fontWeight: themeObj.fontWeightNormal,
         fontSize: themeObj.fontSizeLg,
       }
-      ariaLabel="Eligible offers"
+      ariaLabel=localeString.eligibleOffersText
     >
       {if isEligibilityPending {
         <div
@@ -30,7 +30,7 @@ let make = (
           role="status"
           ariaLive=#polite
         >
-          <span className="sr-only"> {"Checking eligible offers"->React.string} </span>
+          <span className="sr-only"> {localeString.checkingEligibleOffersText->React.string} </span>
           <div className="flex flex-col gap-2" ariaHidden=true>
             <div
               className="relative h-2.5 w-[120px] overflow-hidden rounded"
@@ -53,7 +53,7 @@ let make = (
       } else {
         switch appliedOffer {
         | Some(offer) =>
-          let offerTitle = offer.title === "" ? "Card offer" : offer.title
+          let offerTitle = offer.title === "" ? localeString.cardOfferText : offer.title
           <div
             className="relative overflow-hidden"
             style={
@@ -138,7 +138,7 @@ let make = (
                 }
               >
                 <Icon name="checkmark" size=14 />
-                <span> {"Applied"->React.string} </span>
+                <span> {localeString.offerAppliedText->React.string} </span>
               </div>
             </div>
           </div>

--- a/src/Components/SavedCardItem.res
+++ b/src/Components/SavedCardItem.res
@@ -101,6 +101,7 @@ let make = (
   ~installmentsError,
   ~setInstallmentsError,
   ~eligibilitySurchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+  ~eligibilityOfferDetails: option<EligibilityHelpers.eligibilityOfferDetails>,
   ~eligibilityError: option<string>,
   ~isEligibilityPending=false,
   // `isVaultCvcFlow` only selects whether the inner collector returns a vault
@@ -398,6 +399,11 @@ let make = (
                 </div>
               </RenderIf>
               <RenderIf condition={isActive}>
+                <RenderIf condition={isCard}>
+                  <EligibilityOfferNotice
+                    eligibilityOfferDetails isEligibilityPending className="mt-3"
+                  />
+                </RenderIf>
                 <RenderIf condition={isCard && hasInstallmentPlans}>
                   <div
                     style={
@@ -432,7 +438,7 @@ let make = (
                     eligibilitySurchargeDetails
                     eligibilityError
                     isEligibilityPending
-                    className="mt-3 ml-1.5"
+                    className="mt-3"
                   />
                 </RenderIf>
               </RenderIf>

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -701,7 +701,7 @@ let make = (
     (loadSavedCards === PaymentType.LoadingSavedCards || clickToPayConfig.isReady->Option.isNone)
   }, (savedCardlength, loadSavedCards, showPaymentMethodsScreen, clickToPayConfig.isReady))
 
-  <div className="flex flex-col overflow-x-hidden overflow-y-auto h-auto no-scrollbar animate-slowShow">
+  <div className="flex flex-col overflow-auto h-auto no-scrollbar animate-slowShow">
     {if enableSavedPaymentShimmer {
       <PaymentElementShimmer.SavedPaymentCardShimmer />
     } else {

--- a/src/Components/SavedMethods.res
+++ b/src/Components/SavedMethods.res
@@ -74,6 +74,7 @@ let make = (
   )
   let (isClickToPayRememberMe, setIsClickToPayRememberMe) = React.useState(_ => false)
   let (eligibilitySurchargeDetails, setEligibilitySurchargeDetails) = React.useState(_ => None)
+  let (eligibilityOfferDetails, setEligibilityOfferDetails) = React.useState(_ => None)
   let (eligibilityError, setEligibilityError) = React.useState(_ => None)
   let (isEligibilityPending, setIsEligibilityPending) = React.useState(_ => false)
   let eligibilityControllerRef = React.useRef(None)
@@ -102,6 +103,13 @@ let make = (
     clickToPayConfig.isReady == Some(true) &&
       (!groupSavedMethodsWithPaymentMethods || selectedOption == "card")
   let (installmentsError, setInstallmentsError) = React.useState(_ => "")
+
+  let selectedOfferQuoteIds =
+    eligibilityOfferDetails
+    ->Option.map((offerDetails: EligibilityHelpers.eligibilityOfferDetails) =>
+      offerDetails.offerQuoteIds
+    )
+    ->Option.getOr([])
 
   // Saved-card (return user) CVC collection always uses the nested
   // ParentCardComponent. The vault flag only selects whether submit returns a raw
@@ -163,13 +171,19 @@ let make = (
       {visibleSavedMethods
       ->Array.mapWithIndex((obj, i) => {
         let isActive = paymentTokenVal == obj.paymentToken
-        let (eligibilitySurchargeDetails, eligibilityError, isEligibilityPending) = isActive
+        let (
+          eligibilitySurchargeDetails,
+          eligibilityOfferDetails,
+          eligibilityError,
+          isEligibilityPending,
+        ) = isActive
           ? (
               eligibilitySurchargeDetails,
+              eligibilityOfferDetails,
               eligibilityError,
-              isEligibilityPending && paymentMethodListValue.should_block_confirm,
+              isEligibilityPending,
             )
-          : (None, None, false)
+          : (None, None, None, false)
         <SavedCardItem
           key={i->Int.toString}
           setPaymentToken
@@ -185,6 +199,7 @@ let make = (
           installmentsError
           setInstallmentsError
           eligibilitySurchargeDetails
+          eligibilityOfferDetails
           eligibilityError
           isEligibilityPending
           isVaultCvcFlow
@@ -253,9 +268,9 @@ let make = (
         ~bodyArr=eligibilityBody,
         ~sdkAuthorization,
         ~endpoint,
-        ~shouldBlockConfirm=paymentMethodListValue.should_block_confirm,
         ~setIsEligibilityPending,
         ~setEligibilitySurchargeDetails,
+        ~setEligibilityOfferDetails,
         ~setEligibilityError=Some(setEligibilityError),
         ~errorLogMessage="Saved card payment eligibility check failed",
         ~fetchEligibility={
@@ -284,6 +299,7 @@ let make = (
     } else {
       eligibilityControllerRef.current->Option.forEach(c => Fetch.AbortController.abort(c))
       setEligibilitySurchargeDetails(_ => None)
+      setEligibilityOfferDetails(_ => None)
       setEligibilityError(_ => None)
       setIsEligibilityPending(_ => false)
     }
@@ -309,7 +325,7 @@ let make = (
     !isUnknownPaymentMethod &&
     (!isCardPaymentMethod || isCardPaymentMethodValid) &&
     isInstallmentValid &&
-    !isEligibilityPending &&
+    !(paymentMethodListValue.should_block_confirm && isEligibilityPending) &&
     eligibilityError->Option.isNone
   // The outer iframe owns required fields, installments and eligibility; the
   // nested saved-card iframe owns CVC validation. Submit must reach the nested
@@ -318,7 +334,7 @@ let make = (
     areRequiredFieldsValid &&
     !isUnknownPaymentMethod &&
     isInstallmentValid &&
-    !isEligibilityPending &&
+    !(paymentMethodListValue.should_block_confirm && isEligibilityPending) &&
     eligibilityError->Option.isNone &&
     savedCardCvcState.ready
   } else {
@@ -331,6 +347,7 @@ let make = (
   useHandlePostMessages(~complete, ~empty, ~paymentType=paymentMethodType, ~savedMethod=true)
   SubscriptionEventHooks.useEmitFormStatus(~empty, ~complete)
   SubscriptionEventHooks.useEmitSurchargeInfo(~surchargeDetails=eligibilitySurchargeDetails)
+  SubscriptionEventHooks.useEmitAppliedOffersInfo(~offerDetails=eligibilityOfferDetails)
   let emitter = SubscriptionEventHooks.useSubscriptionEventEmitter()
 
   React.useEffect(() => {
@@ -373,6 +390,7 @@ let make = (
       !isBankRedirectPaymentMethod &&
       (alwaysSendCustomerAcceptance || customerMethod.recurringEnabled->not || isSaveCardsChecked)
     let installmentBody = selectedInstallmentPlan->PaymentBody.installmentBody
+    let offerDetailsBody = PaymentBody.offerDetailsBody(~offerQuoteIds=selectedOfferQuoteIds)
 
     let buildSavedPaymentMethodBody = cvc =>
       switch customerMethod.paymentMethod {
@@ -383,7 +401,7 @@ let make = (
           ~cvcNumber=cvc,
           ~requiresCvv=customerMethod.requiresCvv,
           ~isCustomerAcceptanceRequired,
-        )->Array.concat(installmentBody)
+        )->Array.concat(installmentBody)->Array.concat(offerDetailsBody)
       | _ => {
           let paymentMethodType = switch customerMethod.paymentMethodType {
           | Some("")
@@ -441,6 +459,7 @@ let make = (
           intent(
             ~bodyArr=clickToPayBody
             ->Array.concat(installmentBody)
+            ->Array.concat(offerDetailsBody)
             ->mergeAndFlattenToTuples(requiredFieldsBody),
             ~confirmParam=confirm.confirmParams,
             ~handleUserError=false,
@@ -557,7 +576,7 @@ let make = (
                         ~cvcToken,
                         ~isCustomerAcceptanceRequired,
                       )
-                let vaultBody = cvcConfirmBody->Array.concat(installmentBody)
+                let vaultBody = cvcConfirmBody->Array.concat(installmentBody)->Array.concat(offerDetailsBody)
                 intent(
                   ~bodyArr=vaultBody->mergeAndFlattenToTuples(requiredFieldsBody),
                   ~confirmParam=confirm.confirmParams,
@@ -652,6 +671,7 @@ let make = (
     sdkAuthorization,
     isEligibilityPending,
     eligibilityError,
+    selectedOfferQuoteIds,
     isHyperswitchVault,
     isSavedCardCvcFlow,
     isVaultCvcFlow,
@@ -681,7 +701,7 @@ let make = (
     (loadSavedCards === PaymentType.LoadingSavedCards || clickToPayConfig.isReady->Option.isNone)
   }, (savedCardlength, loadSavedCards, showPaymentMethodsScreen, clickToPayConfig.isReady))
 
-  <div className="flex flex-col overflow-auto h-auto no-scrollbar animate-slowShow">
+  <div className="flex flex-col overflow-x-hidden overflow-y-auto h-auto no-scrollbar animate-slowShow">
     {if enableSavedPaymentShimmer {
       <PaymentElementShimmer.SavedPaymentCardShimmer />
     } else {

--- a/src/DefaultTheme.res
+++ b/src/DefaultTheme.res
@@ -23,7 +23,7 @@ let default = {
   fontSizeXs: "10px",
   fontSize2Xs: "8px",
   fontSize3Xs: "6px",
-  colorSuccess: "",
+  colorSuccess: "#16875B",
   colorWarning: "",
   colorPrimaryText: "#5469d4",
   colorBackgroundText: "",

--- a/src/Hooks/CommonCardProps.res
+++ b/src/Hooks/CommonCardProps.res
@@ -22,6 +22,7 @@ let useCardForm = (
     cardEligibilityError,
     updateCardEligibilityError,
     eligibilitySurchargeDetails,
+    eligibilityOfferDetails,
     isEligibilityPending,
     triggerOnCardNumberChange,
     resetEligibilityState,
@@ -388,6 +389,7 @@ let useCardForm = (
     cardEligibilityError,
     updateCardEligibilityError,
     eligibilitySurchargeDetails,
+    eligibilityOfferDetails,
     isEligibilityPending,
   }
 

--- a/src/Hooks/SubscriptionEventHooks.res
+++ b/src/Hooks/SubscriptionEventHooks.res
@@ -21,6 +21,7 @@ type emitter = {
   emitSurcharge: (
     ~surchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
   ) => unit,
+  emitOffers: (~offerDetails: option<EligibilityHelpers.eligibilityOfferDetails>) => unit,
 }
 
 let useSubscriptionEventEmitter = (): emitter => {
@@ -95,7 +96,19 @@ let useSubscriptionEventEmitter = (): emitter => {
     }
   }
 
-  {emitCardInfo, emitPaymentMethodStatus, emitBillingAddress, emitCvcStatus, emitSurcharge}
+  let emitOffers = (~offerDetails) => {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=Offers,
+      ) &&
+      offerDetails->Option.isSome
+    ) {
+      Utils.messageParentWindow(createAppliedOffersPayload(~offerDetails))
+    }
+  }
+
+  {emitCardInfo, emitPaymentMethodStatus, emitBillingAddress, emitCvcStatus, emitSurcharge, emitOffers}
 }
 
 // ---------------------------------------------------------------------------
@@ -259,4 +272,28 @@ let useEmitSurchargeInfo = (
     }
     None
   }, (surchargeDetails, subscribedEvents))
+}
+
+// ---------------------------------------------------------------------------
+// useEmitAppliedOffersInfo
+// ---------------------------------------------------------------------------
+// Effect hook: emits the auto-applied offers when eligibility offer details change.
+let useEmitAppliedOffersInfo = (
+  ~offerDetails: option<EligibilityHelpers.eligibilityOfferDetails>,
+) => {
+  let options = Jotai.useAtomValue(JotaiAtoms.optionAtom)
+  let subscribedEvents = options.subscriptionEvents
+
+  React.useEffect(() => {
+    if (
+      PaymentEventData.shouldEmitEvent(
+        ~subscribedEvents=subscribedEvents->Option.getOr([]),
+        ~eventType=Offers,
+      ) &&
+      offerDetails->Option.isSome
+    ) {
+      Utils.messageParentWindow(createAppliedOffersPayload(~offerDetails))
+    }
+    None
+  }, (offerDetails, subscribedEvents))
 }

--- a/src/Hooks/UseCardEligibility.res
+++ b/src/Hooks/UseCardEligibility.res
@@ -2,6 +2,7 @@ type eligibilityState = {
   cardEligibilityError: option<string>,
   updateCardEligibilityError: option<string> => unit,
   eligibilitySurchargeDetails: option<EligibilityHelpers.eligibilitySurchargeDetails>,
+  eligibilityOfferDetails: option<EligibilityHelpers.eligibilityOfferDetails>,
   isEligibilityPending: bool,
   triggerOnCardNumberChange: (~cardNumber: string, ~isCardSupportedAndValid: bool) => unit,
   resetEligibilityState: unit => unit,
@@ -15,6 +16,7 @@ let useCardEligibility = (~logger, ~runEligibility=true): eligibilityState => {
   let customPodUri = Jotai.useAtomValue(customPodUri)
   let (cardEligibilityError, setCardEligibilityError) = React.useState(_ => None)
   let (eligibilitySurchargeDetails, setEligibilitySurchargeDetails) = React.useState(_ => None)
+  let (eligibilityOfferDetails, setEligibilityOfferDetails) = React.useState(_ => None)
   let (isEligibilityPending, setIsEligibilityPending) = React.useState(_ => false)
   let eligibilityControllerRef = React.useRef(None)
   let {
@@ -41,9 +43,9 @@ let useCardEligibility = (~logger, ~runEligibility=true): eligibilityState => {
       ~bodyArr=PaymentBody.cardPaymentMethodEligibilityBody(~cardNumber),
       ~sdkAuthorization,
       ~endpoint,
-      ~shouldBlockConfirm=paymentMethodListValue.should_block_confirm,
       ~setIsEligibilityPending,
       ~setEligibilitySurchargeDetails,
+      ~setEligibilityOfferDetails,
       ~setEligibilityError=Some(setCardEligibilityError),
       ~errorLogMessage="Card payment eligibility check failed",
       ~fetchEligibility={
@@ -74,14 +76,17 @@ let useCardEligibility = (~logger, ~runEligibility=true): eligibilityState => {
   let resetEligibilityState = () => {
     setCardEligibilityError(_ => None)
     setEligibilitySurchargeDetails(_ => None)
+    setEligibilityOfferDetails(_ => None)
     setIsEligibilityPending(_ => false)
   }
 
   let triggerOnCardNumberChange = (~cardNumber, ~isCardSupportedAndValid) => {
-    if runEligibility && paymentMethodListValue.sdk_next_action === Some("eligibility_check") {
+    let shouldRunEligibility = paymentMethodListValue.sdk_next_action === Some("eligibility_check")
+    if runEligibility && shouldRunEligibility {
       cancelEligibilityDebounce()
       setCardEligibilityError(_ => None)
       setEligibilitySurchargeDetails(_ => None)
+      setEligibilityOfferDetails(_ => None)
       if !isCardSupportedAndValid {
         eligibilityControllerRef.current->Option.forEach(c => Fetch.AbortController.abort(c))
         eligibilityControllerRef.current = None
@@ -98,6 +103,7 @@ let useCardEligibility = (~logger, ~runEligibility=true): eligibilityState => {
     cardEligibilityError,
     updateCardEligibilityError: error => setCardEligibilityError(_ => error),
     eligibilitySurchargeDetails,
+    eligibilityOfferDetails,
     isEligibilityPending,
     triggerOnCardNumberChange,
     resetEligibilityState,

--- a/src/LocaleStrings/ArabicLocale.res
+++ b/src/LocaleStrings/ArabicLocale.res
@@ -270,4 +270,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "عرض أقل",
   refreshingText: "جارٍ التحديث...",
   paymentDetailsBeingCheckedText: "جارٍ التحقق من تفاصيل الدفع. يرجى الانتظار",
+  eligibleOffersText: "العروض المتاحة",
+  checkingEligibleOffersText: "جارٍ التحقق من العروض المتاحة",
+  cardOfferText: "عرض البطاقة",
+  offerAppliedText: "تم التطبيق",
 }

--- a/src/LocaleStrings/CatalanLocale.res
+++ b/src/LocaleStrings/CatalanLocale.res
@@ -269,4 +269,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostra menys",
   refreshingText: "Actualitzant...",
   paymentDetailsBeingCheckedText: "S'estan comprovant els detalls del pagament. Si us plau, espereu",
+  eligibleOffersText: "Ofertes disponibles",
+  checkingEligibleOffersText: "Comprovant les ofertes disponibles",
+  cardOfferText: "Oferta de targeta",
+  offerAppliedText: "Aplicada",
 }

--- a/src/LocaleStrings/ChineseLocale.res
+++ b/src/LocaleStrings/ChineseLocale.res
@@ -267,4 +267,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "收起",
   refreshingText: "刷新中...",
   paymentDetailsBeingCheckedText: "正在检查付款详情，请稍候",
+  eligibleOffersText: "可用优惠",
+  checkingEligibleOffersText: "正在查询可用优惠",
+  cardOfferText: "银行卡优惠",
+  offerAppliedText: "已应用",
 }

--- a/src/LocaleStrings/DeutschLocale.res
+++ b/src/LocaleStrings/DeutschLocale.res
@@ -268,4 +268,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Weniger anzeigen",
   refreshingText: "Aktualisierung...",
   paymentDetailsBeingCheckedText: "Zahlungsdetails werden geprüft. Bitte warten",
+  eligibleOffersText: "Verfügbare Angebote",
+  checkingEligibleOffersText: "Verfügbare Angebote werden geprüft",
+  cardOfferText: "Kartenangebot",
+  offerAppliedText: "Angewendet",
 }

--- a/src/LocaleStrings/DutchLocale.res
+++ b/src/LocaleStrings/DutchLocale.res
@@ -267,4 +267,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Minder tonen",
   refreshingText: "Vernieuwen...",
   paymentDetailsBeingCheckedText: "Betalingsgegevens worden gecontroleerd. Een moment geduld",
+  eligibleOffersText: "Beschikbare aanbiedingen",
+  checkingEligibleOffersText: "Beschikbare aanbiedingen controleren",
+  cardOfferText: "Kaartaanbieding",
+  offerAppliedText: "Toegepast",
 }

--- a/src/LocaleStrings/EnglishGBLocale.res
+++ b/src/LocaleStrings/EnglishGBLocale.res
@@ -267,4 +267,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Show less",
   refreshingText: "Refreshing...",
   paymentDetailsBeingCheckedText: "Payment details are being checked. Please wait",
+  eligibleOffersText: "Eligible offers",
+  checkingEligibleOffersText: "Checking eligible offers",
+  cardOfferText: "Card offer",
+  offerAppliedText: "Applied",
 }

--- a/src/LocaleStrings/EnglishLocale.res
+++ b/src/LocaleStrings/EnglishLocale.res
@@ -267,4 +267,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Show less",
   refreshingText: "Refreshing...",
   paymentDetailsBeingCheckedText: "Payment details are being checked. Please wait",
+  eligibleOffersText: "Eligible offers",
+  checkingEligibleOffersText: "Checking eligible offers",
+  cardOfferText: "Card offer",
+  offerAppliedText: "Applied",
 }

--- a/src/LocaleStrings/FrenchBelgiumLocale.res
+++ b/src/LocaleStrings/FrenchBelgiumLocale.res
@@ -269,4 +269,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Afficher moins",
   refreshingText: "Actualisation...",
   paymentDetailsBeingCheckedText: "Les détails du paiement sont en cours de vérification. Veuillez patienter",
+  eligibleOffersText: "Offres éligibles",
+  checkingEligibleOffersText: "Vérification des offres éligibles",
+  cardOfferText: "Offre carte",
+  offerAppliedText: "Appliquée",
 }

--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -269,4 +269,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Afficher moins",
   refreshingText: "Actualisation...",
   paymentDetailsBeingCheckedText: "Les détails du paiement sont en cours de vérification. Veuillez patienter",
+  eligibleOffersText: "Offres éligibles",
+  checkingEligibleOffersText: "Vérification des offres éligibles",
+  cardOfferText: "Offre carte",
+  offerAppliedText: "Appliquée",
 }

--- a/src/LocaleStrings/HebrewLocale.res
+++ b/src/LocaleStrings/HebrewLocale.res
@@ -268,4 +268,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "הצג פחות",
   refreshingText: "מרענן...",
   paymentDetailsBeingCheckedText: "פרטי התשלום נבדקים. אנא המתן",
+  eligibleOffersText: "הצעות זכאיות",
+  checkingEligibleOffersText: "בודק הצעות זכאיות",
+  cardOfferText: "הצעת כרטיס",
+  offerAppliedText: "הוחלה",
 }

--- a/src/LocaleStrings/ItalianLocale.res
+++ b/src/LocaleStrings/ItalianLocale.res
@@ -269,4 +269,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostra meno",
   refreshingText: "Aggiornamento...",
   paymentDetailsBeingCheckedText: "I dettagli del pagamento sono in fase di verifica. Attendere prego",
+  eligibleOffersText: "Offerte disponibili",
+  checkingEligibleOffersText: "Verifica delle offerte disponibili",
+  cardOfferText: "Offerta carta",
+  offerAppliedText: "Applicata",
 }

--- a/src/LocaleStrings/JapaneseLocale.res
+++ b/src/LocaleStrings/JapaneseLocale.res
@@ -268,4 +268,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "表示を減らす",
   refreshingText: "更新中...",
   paymentDetailsBeingCheckedText: "お支払い情報を確認中です。しばらくお待ちください",
+  eligibleOffersText: "利用可能な特典",
+  checkingEligibleOffersText: "利用可能な特典を確認中",
+  cardOfferText: "カード特典",
+  offerAppliedText: "適用済み",
 }

--- a/src/LocaleStrings/LocaleStringTypes.res
+++ b/src/LocaleStrings/LocaleStringTypes.res
@@ -255,6 +255,10 @@ type localeStrings = {
   showLess: string,
   refreshingText: string,
   paymentDetailsBeingCheckedText: string,
+  eligibleOffersText: string,
+  checkingEligibleOffersText: string,
+  cardOfferText: string,
+  offerAppliedText: string,
 }
 
 type constantStrings = {

--- a/src/LocaleStrings/PolishLocale.res
+++ b/src/LocaleStrings/PolishLocale.res
@@ -268,4 +268,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Pokaż mniej",
   refreshingText: "Odświeżanie...",
   paymentDetailsBeingCheckedText: "Trwa weryfikacja szczegółów płatności. Proszę czekać",
+  eligibleOffersText: "Dostępne oferty",
+  checkingEligibleOffersText: "Sprawdzanie dostępnych ofert",
+  cardOfferText: "Oferta kartowa",
+  offerAppliedText: "Zastosowano",
 }

--- a/src/LocaleStrings/PortugueseLocale.res
+++ b/src/LocaleStrings/PortugueseLocale.res
@@ -268,4 +268,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostrar menos",
   refreshingText: "Atualizando...",
   paymentDetailsBeingCheckedText: "Os detalhes do pagamento estão sendo verificados. Por favor, aguarde",
+  eligibleOffersText: "Ofertas elegíveis",
+  checkingEligibleOffersText: "Verificando ofertas elegíveis",
+  cardOfferText: "Oferta de cartão",
+  offerAppliedText: "Aplicada",
 }

--- a/src/LocaleStrings/RussianLocale.res
+++ b/src/LocaleStrings/RussianLocale.res
@@ -276,4 +276,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Показать меньше",
   refreshingText: "Обновление...",
   paymentDetailsBeingCheckedText: "Данные платежа проверяются. Пожалуйста, подождите",
+  eligibleOffersText: "Доступные предложения",
+  checkingEligibleOffersText: "Проверяем доступные предложения",
+  cardOfferText: "Предложение по карте",
+  offerAppliedText: "Применено",
 }

--- a/src/LocaleStrings/SpanishLocale.res
+++ b/src/LocaleStrings/SpanishLocale.res
@@ -268,4 +268,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Mostrar menos",
   refreshingText: "Actualizando...",
   paymentDetailsBeingCheckedText: "Se están verificando los detalles del pago. Por favor, espere",
+  eligibleOffersText: "Ofertas disponibles",
+  checkingEligibleOffersText: "Comprobando ofertas disponibles",
+  cardOfferText: "Oferta de tarjeta",
+  offerAppliedText: "Aplicada",
 }

--- a/src/LocaleStrings/SwedishLocale.res
+++ b/src/LocaleStrings/SwedishLocale.res
@@ -267,4 +267,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "Visa mindre",
   refreshingText: "Uppdaterar...",
   paymentDetailsBeingCheckedText: "Betalningsinformation kontrolleras. Vänligen vänta",
+  eligibleOffersText: "Tillgängliga erbjudanden",
+  checkingEligibleOffersText: "Kontrollerar tillgängliga erbjudanden",
+  cardOfferText: "Korterbjudande",
+  offerAppliedText: "Tillämpat",
 }

--- a/src/LocaleStrings/TraditionalChineseLocale.res
+++ b/src/LocaleStrings/TraditionalChineseLocale.res
@@ -267,4 +267,8 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   showLess: "收起",
   refreshingText: "重新整理中...",
   paymentDetailsBeingCheckedText: "正在檢查付款詳情，請稍候",
+  eligibleOffersText: "可用優惠",
+  checkingEligibleOffersText: "正在查詢可用優惠",
+  cardOfferText: "卡優惠",
+  offerAppliedText: "已套用",
 }

--- a/src/MidnightTheme.res
+++ b/src/MidnightTheme.res
@@ -23,7 +23,7 @@ let midnight = {
   fontSizeXs: "10px",
   fontSize2Xs: "8px",
   fontSize3Xs: "6px",
-  colorSuccess: "",
+  colorSuccess: "#16875B",
   colorWarning: "",
   colorPrimaryText: "#000000",
   colorBackgroundText: "#ffffffe0",

--- a/src/NoTheme.res
+++ b/src/NoTheme.res
@@ -24,7 +24,7 @@ let noThemeValues = {
   fontSizeXs: "",
   fontSize2Xs: "",
   fontSize3Xs: "",
-  colorSuccess: "",
+  colorSuccess: "#16875B",
   colorWarning: "",
   colorPrimaryText: "",
   colorBackgroundText: "",

--- a/src/Payment.res
+++ b/src/Payment.res
@@ -30,7 +30,15 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     // legacy hook enabled for the standalone card-number/expiry/CVC elements.
     ~runEligibility=paymentType !== Card,
   )
-  let {isCardValid, setCardError, cardNumber, cardBrand, cardEligibilityError} = cardProps
+  let {
+    isCardValid,
+    setCardError,
+    cardNumber,
+    cardBrand,
+    cardEligibilityError,
+    eligibilityOfferDetails,
+    isEligibilityPending,
+  } = cardProps
   let {isExpiryValid, setExpiryError, cardExpiry} = expiryProps
   let {isCVCValid, setCvcError, cvcNumber} = cvcProps
   let {isZipValid} = zipProps
@@ -44,14 +52,25 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     switch (isCardValid, isExpiryValid, isCVCValid) {
     | (Some(cardValid), Some(expiryValid), Some(cvcValid)) =>
       CardUtils.emitIsFormReadyForSubmission(
-        cardValid && expiryValid && cvcValid && areRequiredFieldsValid,
+        cardValid && expiryValid && cvcValid && areRequiredFieldsValid && !isEligibilityPending,
       )
     | _ => ()
     }
     None
-  }, (isCardValid, isExpiryValid, isCVCValid, areRequiredFieldsValid))
+  }, (isCardValid, isExpiryValid, isCVCValid, areRequiredFieldsValid, isEligibilityPending))
   let submitAPICall = (body, confirmParam) => {
-    intent(~bodyArr=body, ~confirmParam, ~handleUserError=false, ~manualRetry=isManualRetryEnabled)
+    let offerDetailsBody =
+      eligibilityOfferDetails
+      ->Option.map(offerDetails =>
+        PaymentBody.offerDetailsBody(~offerQuoteIds=offerDetails.offerQuoteIds)
+      )
+      ->Option.getOr([])
+    intent(
+      ~bodyArr=body->Array.concat(offerDetailsBody),
+      ~confirmParam,
+      ~handleUserError=false,
+      ~manualRetry=isManualRetryEnabled,
+    )
   }
 
   let submitValue = (_ev, confirmParam) => {
@@ -60,12 +79,14 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
       isCardValid->Option.getOr(false) &&
       isExpiryValid->Option.getOr(false) &&
       isCVCValid->Option.getOr(false) &&
-      cardEligibilityError->Option.isNone
+      cardEligibilityError->Option.isNone &&
+      !isEligibilityPending
     | CardNumberElement =>
       isCardValid->Option.getOr(false) &&
       checkCardCVC(getCardElementValue(iframeId, "card-cvc"), cardBrand) &&
       checkCardExpiry(getCardElementValue(iframeId, "card-expiry")) &&
-      cardEligibilityError->Option.isNone
+      cardEligibilityError->Option.isNone &&
+      !isEligibilityPending
     | _ => true
     }
     let cardNetwork = [
@@ -115,6 +136,8 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
         )
         setCardError(_ => msg)
         setUserError(msg)
+      } else if isEligibilityPending {
+        setUserError(localeString.paymentDetailsBeingCheckedText)
       }
       if cardExpiry === "" {
         setExpiryError(_ => localeString.cardExpiryDateEmptyText)
@@ -149,6 +172,8 @@ let make = (~paymentMode, ~integrateError, ~logger) => {
     isExpiryValid,
     isCardValid,
     cardEligibilityError,
+    eligibilityOfferDetails,
+    isEligibilityPending,
     sdkAuthorization,
   ))
 

--- a/src/Payments/CardsSDK.res
+++ b/src/Payments/CardsSDK.res
@@ -29,10 +29,14 @@ let make = (~cvcOnly=false) => {
     None
   }, [cvcOnly])
 
+  // Eligibility can only be checked against raw card data (the eligibility
+  // API needs the actual card number), so it is only ever run for the
+  // RawEmit card-collection mode — never for Tokenise (Hyperswitch vault or
+  // VGS), where this component only ever sees vaulted/tokenised card data.
   let {cardProps, expiryProps, cvcProps} = CommonCardProps.useCardForm(
     ~logger=loggerState,
     ~paymentType=cardFlowType,
-    ~runEligibility=cardCollectionMode !== RawEmit,
+    ~runEligibility=cardCollectionMode === RawEmit,
     ~logControlEvents=cardCollectionMode !== RawEmit,
     ~enableExternalCardSupport=cardCollectionMode === RawEmit && !cvcOnly,
     ~cardBrandOverride=cvcOnly ? savedCardBrand : "",

--- a/src/Payments/HyperswitchVaultCardCollector.res
+++ b/src/Payments/HyperswitchVaultCardCollector.res
@@ -13,18 +13,9 @@ let make = (
   let {themeObj, localeString} = Jotai.useAtomValue(JotaiAtoms.configAtom)
   let loggerState = Jotai.useAtomValue(JotaiAtoms.loggerAtom)
   let vaultCredentials = Jotai.useAtomValue(JotaiAtoms.vaultCredentials)
-  let paymentMethodListValue = Jotai.useAtomValue(PaymentUtils.paymentMethodListValue)
   let {parentURL} = Jotai.useAtomValue(JotaiAtoms.keys)
 
-  let {
-    isCardValid,
-    isCardSupported,
-    cardNumber,
-    setCardError,
-    cardBrand,
-    eligibilitySurchargeDetails,
-    isEligibilityPending,
-  } = cardProps
+  let {isCardValid, isCardSupported, cardNumber, setCardError, cardBrand} = cardProps
   let {isExpiryValid, cardExpiry, setExpiryError} = expiryProps
   let {isCVCValid, cvcNumber, setCvcError} = cvcProps
 
@@ -119,11 +110,6 @@ let make = (
     <div className="flex flex-col" style={gridGap: themeObj.spacingGridColumn}>
       <div className="flex flex-col w-full" style={gridGap: themeObj.spacingGridColumn}>
         <CardFields cardProps expiryProps cvcProps />
-        <EligibilityNotice
-          eligibilitySurchargeDetails
-          eligibilityError=None
-          isEligibilityPending={isEligibilityPending && paymentMethodListValue.should_block_confirm}
-        />
       </div>
     </div>
   </div>

--- a/src/Payments/ParentCardComponent.res
+++ b/src/Payments/ParentCardComponent.res
@@ -200,6 +200,7 @@ let make = (
   let {
     cardEligibilityError,
     eligibilitySurchargeDetails,
+    eligibilityOfferDetails,
     isEligibilityPending,
     triggerOnCardNumberChange,
     resetEligibilityState: _,
@@ -207,6 +208,13 @@ let make = (
     ~logger=loggerState,
     ~runEligibility=isRawNewCardFlow && !isBancontact,
   )
+
+  let selectedOfferQuoteIds =
+    eligibilityOfferDetails
+    ->Option.map((offerDetails: EligibilityHelpers.eligibilityOfferDetails) =>
+      offerDetails.offerQuoteIds
+    )
+    ->Option.getOr([])
 
   React.useEffect(() => {
     if isRawNewCardFlow && !isBancontact {
@@ -359,6 +367,7 @@ let make = (
     ~enabled=!isSavedCardFlow,
   )
   SubscriptionEventHooks.useEmitSurchargeInfo(~surchargeDetails=eligibilitySurchargeDetails)
+  SubscriptionEventHooks.useEmitAppliedOffersInfo(~offerDetails=eligibilityOfferDetails)
 
   React.useEffect(() => {
     if !isSavedCardFlow {
@@ -645,9 +654,11 @@ let make = (
     let installmentBody = includeInstallments
       ? selectedInstallmentPlan->PaymentBody.installmentBody
       : []
+    let offerDetailsBody = PaymentBody.offerDetailsBody(~offerQuoteIds=selectedOfferQuoteIds)
     let finalBody =
       bodyWithAcceptance
       ->Array.concat(installmentBody)
+      ->Array.concat(offerDetailsBody)
       ->mergeAndFlattenToTuples(requiredFieldsBody)
     if save {
       saveCard(~bodyArr=finalBody, ~confirmParam=confirmParams, ~handleUserError=true)
@@ -815,7 +826,7 @@ let make = (
           isNicknameValid &&
           isInstallmentValid &&
           cardEligibilityError->Option.isNone &&
-          !isEligibilityPending
+          !(paymentMethodListValue.should_block_confirm && isEligibilityPending)
         let innerMessage = json->getDictFromJson
         innerMessage->Dict.set("isOuterValid", outerValid->JSON.Encode.bool)
 
@@ -989,6 +1000,7 @@ let make = (
     isPMMFlow,
     isBancontact,
     cardEligibilityError,
+    selectedOfferQuoteIds,
     isEligibilityPending,
     paymentMethodListValue.should_block_confirm,
     clickToPayCardBrand,
@@ -1037,13 +1049,14 @@ let make = (
               setShowInstallments
               installmentsError
               setInstallmentsError
+              eligibilityOfferDetails
+              isEligibilityPending
             />
             <RenderIf condition=isRawMode>
               <EligibilityNotice
                 eligibilitySurchargeDetails
                 eligibilityError=None
-                isEligibilityPending={isEligibilityPending &&
-                paymentMethodListValue.should_block_confirm}
+                isEligibilityPending
               />
             </RenderIf>
             <RenderIf condition={cardBrand !== "" || isRawMode}>

--- a/src/SoftTheme.res
+++ b/src/SoftTheme.res
@@ -24,7 +24,7 @@ let soft = {
   fontSizeXs: "10px",
   fontSize2Xs: "8px",
   fontSize3Xs: "6px",
-  colorSuccess: "",
+  colorSuccess: "#16875B",
   colorWarning: "",
   colorPrimaryText: "#000000",
   colorBackgroundText: "#ffffffe0",

--- a/src/Types/SubscriptionEventTypes.res
+++ b/src/Types/SubscriptionEventTypes.res
@@ -1,11 +1,12 @@
 open ErrorUtils
 open PaymentEventTypes
 
-let validSubscriptionEvents = ["surchargeInfo"]
+let validSubscriptionEvents = ["surchargeInfo", "appliedOffersInfo"]
 
 let stringToEvent = (str, key) =>
   switch str {
   | "surchargeInfo" => Surcharge
+  | "appliedOffersInfo" => Offers
   | _ => {
       str->unknownPropValueWarning(validSubscriptionEvents, key)
       UnknownEvent
@@ -132,6 +133,42 @@ let createSurchargePayload = (
   [
     ("elementType", "payment"->JSON.Encode.string),
     ("eventName", "surchargeInfo"->JSON.Encode.string),
+    ("payload", payload),
+  ]
+}
+
+let createAppliedOffersPayload = (
+  ~offerDetails: option<EligibilityHelpers.eligibilityOfferDetails>,
+) => {
+  let event = switch offerDetails {
+  | Some(details) =>
+    // Only a single auto-applied offer is expected in `eligible_offers`; emit
+    // just that applied offer to the merchant (as a one-element array) rather
+    // than the full eligible-offers/uplifted-quote-ids lists.
+    let appliedOffers =
+      details.eligibleOffers
+      ->Array.get(0)
+      ->Option.map(offer => [
+        (
+          {
+            offerQuoteId: offer.offerQuoteId,
+            offerAmount: offer.offerAmount,
+            currency: offer.currency,
+            code: offer.code,
+            title: offer.title,
+            description: offer.description,
+          }: PaymentEventData.eligibleOffer
+        ),
+      ])
+      ->Option.getOr([])
+    PaymentEventData.buildOffersEvent(~offers=appliedOffers)
+  | None => PaymentEventData.buildOffersEvent()
+  }
+  let payload = PaymentEventData.offersEventToJson(event)
+
+  [
+    ("elementType", "payment"->JSON.Encode.string),
+    ("eventName", "appliedOffersInfo"->JSON.Encode.string),
     ("payload", payload),
   ]
 }

--- a/src/Utilities/EligibilityHelpers.res
+++ b/src/Utilities/EligibilityHelpers.res
@@ -13,6 +13,27 @@ type eligibilitySurchargeDetails = {
   displayTotalSurchargeAmount: float,
 }
 
+type eligibilityAmountDetails = {
+  totalAmount: int,
+  netAmount: int,
+  currency: string,
+}
+
+type eligibleOffer = {
+  offerQuoteId: string,
+  offerAmount: int,
+  currency: string,
+  code: string,
+  title: string,
+  description: string,
+}
+
+type eligibilityOfferDetails = {
+  offerQuoteIds: array<string>,
+  eligibleOffers: array<eligibleOffer>,
+  amountDetails: option<eligibilityAmountDetails>,
+}
+
 let parseSdkNextActionError = json => {
   let dict = json->getDictFromJson
   let nextAction = dict->getDictFromDict("sdk_next_action")->Dict.get("next_action")
@@ -65,16 +86,53 @@ let parseEligibilitySurchargeDetails = dict => {
   })
 }
 
+let parseEligibilityAmountDetails = dict =>
+  dict
+  ->getOptionalDict("amount_details")
+  ->Option.map(amountDetailsDict => {
+    totalAmount: getInt(amountDetailsDict, "total_amount", 0),
+    netAmount: getInt(amountDetailsDict, "net_amount", 0),
+    currency: amountDetailsDict->getString("currency", ""),
+  })
+
+let parseEligibilityOfferDetails = dict => {
+  let amountDetails = dict->parseEligibilityAmountDetails
+  dict
+  ->getOptionalDict("offer_details")
+  ->Option.flatMap(offerDetailsDict => {
+    let offerQuoteIds =
+      offerDetailsDict
+      ->getStrArray("uplifted_offer_quote_ids")
+      ->Array.filter(offerQuoteId => offerQuoteId !== "")
+    let eligibleOffers =
+      offerDetailsDict
+      ->getArrayOfObjectsFromDict("eligible_offers")
+      ->Array.map(offerDict => {
+        offerQuoteId: offerDict->getString("offer_quote_id", ""),
+        offerAmount: getInt(offerDict, "offer_amount", 0),
+        currency: offerDict->getString("currency", ""),
+        code: offerDict->getString("code", ""),
+        title: offerDict->getString("title", ""),
+        description: offerDict->getString("description", ""),
+      })
+      ->Array.filter(offer => offer.offerQuoteId !== "")
+
+    eligibleOffers->Array.length > 0 ? Some({offerQuoteIds, eligibleOffers, amountDetails}) : None
+  })
+}
+
 type eligibilityResponse = {
   eligibilityError: option<string>,
   surchargeDetails: option<eligibilitySurchargeDetails>,
+  offerDetails: option<eligibilityOfferDetails>,
 }
 
 let parseEligibilityResponse = json => {
   let dict = json->getDictFromJson
   let eligibilityError = json->parseSdkNextActionError
   let surchargeDetails = dict->parseEligibilitySurchargeDetails
-  {eligibilityError, surchargeDetails}
+  let offerDetails = dict->parseEligibilityOfferDetails
+  {eligibilityError, surchargeDetails, offerDetails}
 }
 
 let performEligibilityCheck = async (
@@ -86,19 +144,20 @@ let performEligibilityCheck = async (
   ~sdkAuthorization,
   ~endpoint,
   ~signal: Fetch.AbortSignal.t,
-  ~shouldBlockConfirm: bool,
   ~setIsEligibilityPending: (bool => bool) => unit,
   ~setEligibilitySurchargeDetails: (
     option<eligibilitySurchargeDetails> => option<eligibilitySurchargeDetails>
+  ) => unit,
+  ~setEligibilityOfferDetails: (
+    option<eligibilityOfferDetails> => option<eligibilityOfferDetails>
   ) => unit,
   ~setEligibilityError: option<(option<string> => option<string>) => unit>,
   ~errorLogMessage: string,
   ~fetchEligibility,
 ) => {
   setEligibilitySurchargeDetails(_ => None)
-  if shouldBlockConfirm {
-    setIsEligibilityPending(_ => true)
-  }
+  setEligibilityOfferDetails(_ => None)
+  setIsEligibilityPending(_ => true)
   try {
     let json = await fetchEligibility(
       ~clientSecret,
@@ -110,9 +169,10 @@ let performEligibilityCheck = async (
       ~endpoint,
       ~signal,
     )
-    let {eligibilityError, surchargeDetails} = parseEligibilityResponse(json)
+    let {eligibilityError, surchargeDetails, offerDetails} = parseEligibilityResponse(json)
     setEligibilityError->Option.forEach(setter => setter(_ => eligibilityError))
     setEligibilitySurchargeDetails(_ => surchargeDetails)
+    setEligibilityOfferDetails(_ => offerDetails)
     setIsEligibilityPending(_ => false)
   } catch {
   | exn =>
@@ -139,9 +199,9 @@ let startEligibilityCheck = async (
   ~bodyArr,
   ~sdkAuthorization,
   ~endpoint,
-  ~shouldBlockConfirm: bool,
   ~setIsEligibilityPending,
   ~setEligibilitySurchargeDetails,
+  ~setEligibilityOfferDetails,
   ~setEligibilityError,
   ~errorLogMessage: string,
   ~fetchEligibility,
@@ -162,14 +222,14 @@ let startEligibilityCheck = async (
       ~sdkAuthorization,
       ~endpoint,
       ~signal,
-      ~shouldBlockConfirm,
       ~setIsEligibilityPending,
       ~setEligibilitySurchargeDetails,
+      ~setEligibilityOfferDetails,
       ~setEligibilityError,
       ~errorLogMessage,
       ~fetchEligibility,
     )
-  | None => ()
+  | None => setIsEligibilityPending(_ => false)
   }
 }
 

--- a/src/Utilities/PaymentBody.res
+++ b/src/Utilities/PaymentBody.res
@@ -66,6 +66,18 @@ let cardPaymentBody = (
   ]
 }
 
+let offerDetailsBody = (~offerQuoteIds) =>
+  offerQuoteIds->Array.length === 0
+    ? []
+    : [
+        (
+          "offer_details",
+          [
+            ("offer_quote_ids", offerQuoteIds->Array.map(JSON.Encode.string)->JSON.Encode.array),
+          ]->Utils.getJsonFromArrayOfJson,
+        ),
+      ]
+
 let installmentBody = (plan: option<PaymentMethodsRecord.installmentPlan>) =>
   switch plan {
   | Some(plan) => [

--- a/src/hyper-loader/LoaderPaymentElement.res
+++ b/src/hyper-loader/LoaderPaymentElement.res
@@ -268,11 +268,6 @@ let make = (
           "surchargeInfo",
           `onSurchargeInfo-${componentType}-${elementInstanceId}`,
         )
-      | Offers =>
-        addSubscriptionEventListener(
-          "appliedOffersInfo",
-          `onAppliedOffersInfo-${componentType}-${elementInstanceId}`,
-        )
       | _ => ()
       }
     }

--- a/src/hyper-loader/LoaderPaymentElement.res
+++ b/src/hyper-loader/LoaderPaymentElement.res
@@ -268,6 +268,11 @@ let make = (
           "surchargeInfo",
           `onSurchargeInfo-${componentType}-${elementInstanceId}`,
         )
+      | Offers =>
+        addSubscriptionEventListener(
+          "appliedOffersInfo",
+          `onAppliedOffersInfo-${componentType}-${elementInstanceId}`,
+        )
       | _ => ()
       }
     }

--- a/src/hyper-loader/Types.res
+++ b/src/hyper-loader/Types.res
@@ -237,6 +237,7 @@ type eventType =
   | PaymentMethodStatus
   | BillingAddress
   | Surcharge
+  | Offers
   | None
 
 let eventTypeMapper = event => {
@@ -251,6 +252,7 @@ let eventTypeMapper = event => {
   | "confirmTriggered" => ConfirmPayment
   | "oneClickConfirmTriggered" => OneClickConfirmPayment
   | "surchargeInfo" => Surcharge
+  | "appliedOffersInfo" => Offers
   | _ => None
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added a card-payment eligibility check that runs against the raw card number as the user types it, surfacing two outcomes before confirm:

- **Surcharge**: an additional-fee notice when the entered card incurs a surcharge.
- **Offers**: an auto-applied, read-only discount/cashback offer for the entered card, shown alongside the installment options.

Both outcomes are also emitted as merchant-facing subscription events (`surchargeInfo`, `appliedOffersInfo`) so integrators can react to them.

Since the eligibility check can only be evaluated against the raw card number, it is scoped to run only for the raw card-collection flow (i.e. when `vaulting_action` is `Skip`), not for tokenised/vaulted card flows.

This depends on the companion `offersEvent` payload added in `juspay/hyperswitch-sdk-utils` (see linked PR).

Fixes #1728

## How did you test it?

Manually tested via the local demo app:
- Verified the eligibility check triggers for the raw new-card flow and surfaces the surcharge and offer notices correctly.
- Verified the offer notice UI renders correctly, matching the installment-options UI in styling and dimensions.

https://github.com/user-attachments/assets/f93e21e2-419c-4397-afdd-6e775a976fe9



## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible