### PR TITLE
fix(cvc): fall back to short "CVC" label for French locale in narrow space

### DIFF
--- a/src/CardCVCElement.res
+++ b/src/CardCVCElement.res
@@ -51,6 +51,47 @@ let make = (
       ? "!border-l-0"
       : ""
 
+  let isFrenchCvc = localeString.locale == "fr"
+  let cvcFieldContainerRef = React.useRef(Nullable.null)
+  let (useShortCvcLabel, setUseShortCvcLabel) = React.useState(_ => false)
+
+  UseResizeObserver.useResizeObserver(
+    ~elementRef=cvcFieldContainerRef,
+    ~enabled={isFrenchCvc && !isSavedCardCvcFlow},
+    ~refreshKey=localeString.cvcTextLabel,
+    ~onResize=() =>
+      switch cvcFieldContainerRef.current->Nullable.toOption {
+      | Some(container) =>
+        let available = container->Window.Element.clientWidth
+        switch container->Window.Element.querySelector(".Label")->Nullable.toOption {
+        | Some(label) =>
+          let style = label->Window.Element.getComputedStyle
+          let font =
+            style.font->String.length > 0
+              ? style.font
+              : `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`
+          let canvas = Window.createElement("canvas")
+          switch canvas->Window.Element.getContext("2d")->Nullable.toOption {
+          | Some(ctx) =>
+            ctx->Window.Element.setFont(font)
+            let required = (ctx->Window.Element.measureText(localeString.cvcTextLabel)).width
+            if available > 0 {
+              setUseShortCvcLabel(_ => required > Int.toFloat(available - 24))
+            }
+          | None => ()
+          }
+        | None => ()
+        }
+      | None => ()
+      },
+  )
+
+  let cvcFieldName = isSavedCardCvcFlow
+    ? ""
+    : useShortCvcLabel
+    ? "CVC"
+    : localeString.cvcTextLabel
+
   // Single submit handler for both modes:
   //   • saved-card flow: SavedMethods forwards doSubmit (carrying the selected
   //     payment_token). Validation happens here; non-vault flows return the raw CVC,
@@ -285,7 +326,8 @@ let make = (
   }, [isSavedCardCvcFlow])
 
   <PaymentInputField
-    fieldName={isSavedCardCvcFlow ? "" : localeString.cvcTextLabel}
+    fieldName=cvcFieldName
+    fieldContainerRef=cvcFieldContainerRef
     isValid=isCVCValid
     setIsValid=setIsCVCValid
     value=cvcNumber

--- a/src/Components/PaymentInputField.res
+++ b/src/Components/PaymentInputField.res
@@ -27,6 +27,7 @@ let make = (
   ~paymentType=?,
   ~isDisabled=false,
   ~autocomplete="on",
+  ~fieldContainerRef=?,
 ) => {
   let {themeObj, config} = Jotai.useAtomValue(configAtom)
   let {innerLayout} = config.appearance
@@ -94,7 +95,10 @@ let make = (
   let inputLogoClass = getClassName("InputLogo")
   let inputClassStyles = innerLayout === Spaced ? "Input" : "Input-Compressed"
 
-  <div className="flex flex-col w-full" style={color: themeObj.colorText}>
+  <div
+    className="flex flex-col w-full"
+    style={color: themeObj.colorText}
+    ref=?{fieldContainerRef->Option.map(ReactDOM.Ref.domRef)}>
     <RenderIf
       condition={!isLabelHidden &&
       fieldName->String.length > 0 &&

--- a/src/Hooks/UseResizeObserver.res
+++ b/src/Hooks/UseResizeObserver.res
@@ -1,0 +1,24 @@
+let useResizeObserver = (
+  ~elementRef: React.ref<Nullable.t<Dom.element>>,
+  ~enabled=true,
+  ~refreshKey="",
+  ~onResize: unit => unit,
+) => {
+  let onResizeRef = React.useRef(onResize)
+  onResizeRef.current = onResize
+
+  React.useEffect(() => {
+    if enabled {
+      let observer = ResizeObserver.newResizerObserver(_ => onResizeRef.current())
+      switch elementRef.current->Nullable.toOption {
+      | Some(el) =>
+        onResizeRef.current()
+        observer.observe(el)
+      | None => ()
+      }
+      Some(() => observer.disconnect())
+    } else {
+      None
+    }
+  }, (enabled, refreshKey))
+}

--- a/src/Window.res
+++ b/src/Window.res
@@ -179,6 +179,22 @@ module LocalStorage = {
 module Element = {
   @get external isConnected: Dom.element => bool = "isConnected"
   @get external clientWidth: Dom.element => int = "clientWidth"
+  @send external querySelector: (Dom.element, string) => Nullable.t<Dom.element> = "querySelector"
+
+  type canvasContext
+  type textMetrics = {width: float}
+  @send external getContext: (Dom.element, string) => Nullable.t<canvasContext> = "getContext"
+  @set external setFont: (canvasContext, string) => unit = "font"
+  @send external measureText: (canvasContext, string) => textMetrics = "measureText"
+
+  type computedStyle = {
+    font: string,
+    fontWeight: string,
+    fontSize: string,
+    fontFamily: string,
+  }
+  @val @scope("window")
+  external getComputedStyle: Dom.element => computedStyle = "getComputedStyle"
   @get external nullableContentWindow: Dom.element => Nullable.t<Dom.element> = "contentWindow"
   @get external nullableContentDocument: Dom.element => Nullable.t<document> = "contentDocument"
   @get external document: Dom.element => Nullable.t<document> = "document"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

Closes #1735

The full French CVC label (**"Code CVC"**) was getting clipped in narrow containers, because it is longer than the English abbreviation (**"CVC"**). This adds a French-only fallback: when the field is too narrow to fit **"Code CVC"**, the widget shows the short **"CVC"** label instead, and restores the full label when the field is widened again.

### Approach

- **French-only.** The fallback is scoped to the French (`fr`) locale, because it is the only locale that ships a long CVC label — every other locale already renders a short label (e.g. `fr-BE` already uses `CVC`). Detection is `localeString.locale == "fr"`, the normalized locale code from the resolved locale file, so it reliably matches `fr`, `fr-FR`, `FR`, and `auto` → French. **No per-locale string or shared-type changes are required.**
- **ResizeObserver-driven.** A new reusable `useResizeObserver` hook (`src/Hooks/UseResizeObserver.res`) observes the CVC field container, so the label choice stays correct across the element's mount, its internal layout changes, and any real container resize (and reverts to the full label when there is room again). The observer only runs when `isFrenchCvc && !isSavedCardCvcFlow`. The existing `ResizeObserver` type/binding in `src/ResizeObserver.res` is reused unchanged (the hook calls `ResizeObserver.newResizerObserver`), so its current consumers are untouched.
- **Canvas measurement.** The label's natural width is measured with Canvas `measureText` using the label's computed font. This is necessary because the default floating label is absolutely positioned and wraps, so `scrollWidth` cannot detect the horizontal overflow; it is also cheaper than DOM measurement (no reflow, no hidden node). The natural width is compared against the container's `clientWidth` with a small buffer (`clientWidth - 24`).
- **`PaymentInputField` stays generic.** It gains a single optional `~fieldContainerRef` prop and has no CVC/locale knowledge; the CVC-specific logic lives entirely in `CardCVCElement`.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

https://github.com/user-attachments/assets/94aeb372-f1bc-4f9f-952b-cf022db974b3


Manually verified in the demo app against a standalone `CardCVCElement` rendered in a resizable container, using the local SDK build (Playwright-driven):

- `?locale=fr`, narrow field (≈52px) → label shows **"CVC"** and stays stable (no flicker back to "Code CVC" across the element's remount/layout transitions).
- `?locale=fr`, wide field (≈292px) → label shows **"Code CVC"**; shrinking it back to ≈52px → falls back to **"CVC"** (bidirectional).
- `?locale=en` → unaffected (no French fallback engaged).
- `npm run re:build` passes.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
