### PR TITLE
fix: cypress cors issue

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -49,8 +49,8 @@ const devServer = {
   ],
   headers: {
     "Cache-Control": "must-revalidate",
+    "Access-Control-Allow-Origin": "*"
   },
-  allowedHosts: "all",
 };
 
 module.exports = merge(common(), {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -50,6 +50,7 @@ const devServer = {
   headers: {
     "Cache-Control": "must-revalidate",
   },
+  allowedHosts: "all",
 };
 
 module.exports = merge(common(), {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Cypress tests were failing with the following error:

`utils.js:75 GET http://localhost:9050/HyperLoader.js net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin 200 (OK)`

The application was running on `localhost:9060` and was trying to load `HyperLoader.js` from `localhost:9050`, which was being blocked due to the different origins.

To fix this, I added `allowedHosts: "all"`.


## How did you test it?

tested it using github ci/cd

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
