### PR TITLE
fix(card): send customer acceptance in PMM flow

### DIFF
--- a/src/Payments/ParentCardComponent.res
+++ b/src/Payments/ParentCardComponent.res
@@ -662,7 +662,7 @@ let make = (
   ) => {
     let onSessionBody = [("customer_acceptance", PaymentBody.customerAcceptanceBody)]
     let bodyWithAcceptance =
-      includeAcceptance && isCustomerAcceptanceRequired
+      includeAcceptance && (isPMMFlow || isCustomerAcceptanceRequired)
         ? baseBody->Array.concat(onSessionBody)
         : baseBody
     let installmentBody = includeInstallments


### PR DESCRIPTION
## Type of Change

  <!-- Put an `x` in the boxes that apply -->

  - [x] Bugfix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates
  - [ ] Documentation
  - [ ] CI/CD

  ## Description

  Fixes #1741.

  Payment Methods Management card confirmations reused the generic customer acceptance condition. Since the PMM flow does not have a save-card checkbox, this condition could resolve to `false`, causing `/
  payment-method-sessions/{id}/confirm` requests to omit `customer_acceptance`.

  This change ensures PMM card confirmation requests always include online customer acceptance. Existing acceptance behavior for other card flows remains unchanged.

  ## How did you test it?

  - Ran `npm run re:build` successfully.
  - Ran `npm run build` successfully.
  - Ran `npm run test:hooks` successfully.
  - Ran `git diff --check` successfully.
  - Traced the PMM raw-card confirmation path and reviewed the final diff.
  - Confirmed that non-PMM card flows retain their existing acceptance condition.

  The project does not currently provide a credential-free PMM integration test, so a live payment-method-session confirmation was not executed.

  ## Checklist

  <!-- Put an `x` in the boxes that apply -->

  - [x] I ran `npm run re:build`
  - [x] I reviewed submitted code
  - [ ] I added unit tests for my changes where possible