### PR TITLE
fix: update French CVC label text

### DIFF
--- a/src/LocaleStrings/FrenchLocale.res
+++ b/src/LocaleStrings/FrenchLocale.res
@@ -11,7 +11,7 @@ let localeStrings: LocaleStringTypes.localeStrings = {
   poweredBy: `Propulsé par Hyperswitch`,
   validThruText: `Expiration`,
   sortCodeText: `Code de tri`,
-  cvcTextLabel: `Code CVC`,
+  cvcTextLabel: `CVC`,
   line1Label: `Adresse - Ligne 1`,
   line1Placeholder: `Adresse de rue`,
   line1EmptyText: `La ligne d'adresse 1 ne peut pas être vide`,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

I have changed french translation for cvcTextLabel from `Code CVC` to `CVC`.

## How did you test it?

before:
<img width="742" height="742" alt="image" src="https://github.com/user-attachments/assets/35730cfb-fb61-4716-b3b2-8018031856dc" />

<img width="887" height="844" alt="image" src="https://github.com/user-attachments/assets/175bfacb-0bec-4aff-9e5b-cf87cb20ff83" />

after:
<img width="640" height="730" alt="image" src="https://github.com/user-attachments/assets/2c238685-68a9-423c-9994-10dcc35e481d" />
<img width="713" height="619" alt="image" src="https://github.com/user-attachments/assets/da0fc0e9-b550-4033-8253-10526b486310" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
