### PR TITLE
feat: added extended bin event

### DIFF
--- a/src/Payments/CardIframeProtocol.res
+++ b/src/Payments/CardIframeProtocol.res
@@ -90,6 +90,7 @@ let decodeCardInfo = (json: JSON.t): PaymentEventData.cardInfo => {
   let dict = json->getDictFromJson
   {
     bin: jsonOptionString(dict, "bin"),
+    extendedBin: jsonOptionString(dict, "extendedBin"),
     last4: jsonOptionString(dict, "last4"),
     brand: jsonOptionString(dict, "brand"),
     expiryMonth: jsonOptionString(dict, "expiryMonth"),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Companion to the `hyperswitch-sdk-utils` PR that adds `extendedBin` (first 8
digits of the PAN) to `cardInfo`. Merchants subscribed to `cardDetailsChange`
now receive:

```json
{
  "bin": "424242",
  "extendedBin": "42424242",
  "last4": "4242",
  ...
}
```

Two parts:

1. **Submodule pointer bump** — picks up the `cardInfo` type, builders and
   encoder changes from `hyperswitch-sdk-utils`.
2. **`src/Payments/CardIframeProtocol.res`** — `decodeCardInfo` learns the new
   key.

The decoder change is required, not cosmetic. The raw card number only exists
inside the card iframe, so `cardInfo` is built there, serialized via
`cardInfoToJson`, `postMessage`'d to the parent, and re-decoded by
`decodeCardInfo`. Without this line the record literal would not compile — and
had it compiled, the field would have been silently dropped in transit and never
reached the merchant.

These two parts must land together: the pointer bump alone fails to compile
because `decodeCardInfo` would be missing a field, and the decoder change alone
fails because the field would not exist on the type yet.

`bin` is unchanged and the JSON is purely additive, so existing integrations are
unaffected.

### Security note

`extendedBin` + `last4` exposes 12 PAN digits. Within PCI DSS 4.0 masking rules,
which permit first-8/last-4 now that 8-digit BINs are standard — flagging it for
a conscious sign-off, since on a 13-digit legacy PAN it leaves one digit unknown.

## How did you test it?

<img width="508" height="326" alt="Screenshot 2026-09-08 at 10 56 53 AM" src="https://github.com/user-attachments/assets/366cba1f-7b22-4c8c-96b1-b0e36de0d41e" />


## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible