### PR TITLE
fix: styling for cvc widget

### DIFF
--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -483,6 +483,9 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
                 defaultRules: DefaultTheme.defaultRules,
               })
             }->ignore
+            if dict->getDictIsSome("options") {
+              updateOptions(dict)
+            }
           }
         } else if dict->getDictIsSome("paymentElementsUpdate") {
           updateOptions(dict)

--- a/src/Utilities/Utils.res
+++ b/src/Utilities/Utils.res
@@ -1697,7 +1697,7 @@ let expressCheckoutComponents = [
 let spmComponents = ["paymentMethodCollect"]->Array.concat(expressCheckoutComponents)
 
 let componentsForPaymentElementCreate =
-  ["payment", "paymentMethodCollect", "paymentMethodsManagement", "cardCvc"]->Array.concat(
+  ["payment", "paymentMethodCollect", "paymentMethodsManagement"]->Array.concat(
     expressCheckoutComponents,
   )
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
#1763 
<!-- Describe your changes in detail -->
**Issue:** The `appearance` object was not being applied to the standalone CVC widget (`elements.create('cardCvc')`) — the iframe always rendered with the default theme, ignoring merchant-provided appearance/theme/locale/fonts.

**Root cause:** The standalone CVC widget's mount message carried `paymentElementCreate=true`. Since `cardCvc` is an `otherElements` type, `LoaderController` routed the mount message into the `updateOptions()`-only branch and skipped `setConfigs()` — the only place where `paymentOptions.appearance` is mapped into `configAtom` and the theme stylesheet is generated. So the CVC iframe never received the merchant's appearance.
At the same time, we can't simply drop the `updateOptions()` path for the CVC widget — it needs its `create()` options (element `style`, `cvcIcon`, `placeholder`, `subscriptionEvents`) parsed at mount.

**What we did:**

1. **`src/Utilities/Utils.res`** — removed `"cardCvc"` from `componentsForPaymentElementCreate`. The CVC widget now mounts with `paymentElementCreate=false`, which routes it to the `paymentOptions` branch of `LoaderController` where `setConfigs()` runs and appearance/theme/locale/fonts are applied.

2. **`src/LoaderController.res`** — in that `paymentElementCreate=false` branch, added a guarded `updateOptions(dict)` call so card-field iframes also get their `create()` options parsed at mount. The guard checks that an `options` key is present in the message — this is needed because some mount/refresh flows post `paymentElementCreate=false` carrying only `paymentOptions` (no `options` key), and running `updateOptions` there would reset their element options state to defaults.

**Result:** the standalone CVC widget now gets **both** — appearance applied via `setConfigs()` and element options applied via `updateOptions()` — and other card-field types (`card`, `cardNumber`, `cardExpiry`) also pick up their mount-time options the same way. Other flows (vault/card-form group fields, payment element, wallets) are untouched.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

https://github.com/user-attachments/assets/0b097acb-4614-458c-825d-27c990c8a028

https://github.com/user-attachments/assets/d0cb790b-ded2-41ef-a945-f25ef6871551

https://github.com/user-attachments/assets/dd4bd09e-33c5-455b-8f22-9ed53b556813


https://github.com/user-attachments/assets/b3b7e6b2-d6c6-4b30-99d6-1d908913271a




- Ran `npm run re:build` — compiles cleanly with no new warnings/errors.
- Manually verified the standalone CVC widget (`elements.create('cardCvc')`) renders with the merchant-provided `appearance` (theme, variables, rules) and that `create()` options (e.g. `style`, `cvcIcon`, `placeholder`) take effect.
- Manually verified the saved-card / vault CVC recollect flows still mount and pass options correctly (their refresh messages don't carry `options`, so element state is not reset).

## Checklist

<!-- Put an `x` in the boxes that apply -->
- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible