### PR TITLE
feat: sdk props via superposition

### DIFF
--- a/src/LoaderController.res
+++ b/src/LoaderController.res
@@ -9,10 +9,15 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
   let (keys, setKeys) = Jotai.useAtom(keys)
   let (paymentMethodList, setPaymentMethodList) = Jotai.useAtom(paymentMethodList)
   let setSdkConfigs = Jotai.useSetAtom(sdkConfigs)
+  let sdkConfigsValue = Jotai.useAtomValue(PaymentUtils.sdkConfigsValue)
   let setSdkConfigsValue = Jotai.useSetAtom(PaymentUtils.sdkConfigsValue)
   let setSessions = Jotai.useSetAtom(sessions)
   let (options, setOptions) = Jotai.useAtom(elementOptions)
   let (optionsPayment, setOptionsPayment) = Jotai.useAtom(optionAtom)
+  let getSdkPropsDefaults = SdkPropsConfigurationService.useSdkPropsDefaults(
+    ~rawConfigs=sdkConfigsValue.raw_configs,
+  )
+  let merchantOptionsRef: React.ref<option<Dict.t<JSON.t>>> = React.useRef(None)
   let setPaymentManagementList = Jotai.useSetAtom(paymentManagementList)
   let setSessionId = Jotai.useSetAtom(sessionId)
   let setBlockConfirm = Jotai.useSetAtom(isConfirmBlocked)
@@ -102,8 +107,28 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
     }
   }
 
-  let updateOptions = dict => {
-    let optionsDict = dict->getDictFromObj("options")
+  let (profileId, processorMerchantId, organizationId) = SdkConfigParser.getProfileContext(
+    sdkConfigsValue.context_used,
+  )
+
+  let sdkPropsContext: SuperpositionTypes.sdkPropsContext = {
+    platform: "web",
+    profile_id: ?profileId,
+    processor_merchant_id: ?processorMerchantId,
+    organization_id: ?organizationId,
+  }
+
+  let applyOptions = optionsDict => {
+    let superpositionDefaults = getSdkPropsDefaults(sdkPropsContext)
+    let mergeFor = allowedKeys =>
+      CommonUtils.mergeDict(
+        superpositionDefaults
+        ->Dict.toArray
+        ->Array.filter(((key, _)) => allowedKeys->Array.includes(key))
+        ->Dict.fromArray,
+        optionsDict,
+      )
+
     setOptionsJson(_ => optionsDict->JSON.Encode.object)
 
     if isPaymentMethodsSDKSurface {
@@ -152,7 +177,7 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
     switch optionsDict->Dict.get("subscriptionEvents") {
     | Some(_) => {
         let subscriptionEvents = SubscriptionEventTypes.getSubscriptionEvents(
-          optionsDict,
+          mergeFor(["subscriptionEvents"]),
           "subscriptionEvents",
         )
         setOptionsPayment(prev => {...prev, subscriptionEvents})
@@ -165,7 +190,9 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
     | CardExpiryElement
     | CardCVCElement
     | Card =>
-      setOptions(_ => ElementType.itemToObjMapper(optionsDict, logger))
+      setOptions(_ =>
+        ElementType.itemToObjMapper(mergeFor(ElementType.allowedCardElementOptions), logger)
+      )
     | PaymentMethodCollectElement => {
         let paymentMethodCollectOptions = PaymentMethodCollectUtils.itemToObjMapper(optionsDict)
         setPaymentMethodCollectOptions(_ => paymentMethodCollectOptions)
@@ -180,12 +207,21 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
     | PaymentMethodsManagement
     | PaymentMethodsSDK
     | Payment => {
-        let paymentOptions = PaymentType.itemToObjMapper(optionsDict, logger)
+        let paymentOptions = PaymentType.itemToObjMapper(
+          mergeFor(PaymentType.allowedPaymentElementOptions),
+          logger,
+        )
         setOptionsPayment(prev => {...paymentOptions, subscriptionEvents: prev.subscriptionEvents})
         optionsCallback(paymentOptions)
       }
     | _ => ()
     }
+  }
+
+  let updateOptions = dict => {
+    let optionsDict = dict->getDictFromObj("options")
+    merchantOptionsRef.current = Some(optionsDict)
+    applyOptions(optionsDict)
   }
 
   let setConfigs = async (dict, themeValues: ThemeImporter.themeDataModule) => {
@@ -303,6 +339,15 @@ let make = (~children, ~paymentMode, ~setIntegrateErrorError, ~logger, ~initTime
     }
     None
   }, [config])
+
+  React.useEffect(() => {
+    let hasSdkProps = getSdkPropsDefaults(sdkPropsContext)->Dict.keysToArray->Array.length > 0
+    switch merchantOptionsRef.current {
+    | Some(optionsDict) if hasSdkProps => applyOptions(optionsDict)
+    | _ => ()
+    }
+    None
+  }, [getSdkPropsDefaults])
 
   React.useEffect(() => {
     open Promise

--- a/src/Types/ElementType.res
+++ b/src/Types/ElementType.res
@@ -226,23 +226,21 @@ let getStyle = (dict, str, logger) => {
   })
   ->Option.getOr(defaultStyle)
 }
+let allowedCardElementOptions = [
+  "classes",
+  "style",
+  "value",
+  "hidePostalCode",
+  "iconStyle",
+  "hideIcon",
+  "showIcon",
+  "disabled",
+  "placeholder",
+  "showError",
+]
+
 let itemToObjMapper = (dict, logger) => {
-  unknownKeysWarning(
-    [
-      "classes",
-      "style",
-      "value",
-      "hidePostalCode",
-      "iconStyle",
-      "hideIcon",
-      "showIcon",
-      "disabled",
-      "placeholder",
-      "showError",
-    ],
-    dict,
-    "options",
-  )
+  unknownKeysWarning(allowedCardElementOptions, dict, "options")
 
   {
     classes: getClasses("classes", dict, logger),

--- a/src/Types/PaymentType.res
+++ b/src/Types/PaymentType.res
@@ -1691,6 +1691,10 @@ let allowedPaymentElementOptions = [
   "alwaysSendCustomerAcceptance",
   "redirectionInfo",
   "appearance",
+  "billingAddress",
+  "customMethodNames",
+  "payButtonStyle",
+  "subscriptionEvents",
 ]
 
 let fieldsToExcludeFromMasking = ["layout", "wallets", "paymentMethodsConfig", "terms"]


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Merge SDK prop defaults from Superposition (checkout_sdk.* config) into merchant-supplied options, so merchants inherit remotely-configured defaults (subscription events, card elements, payment options) without setting them explicitly — merchant values still take precedence.
- Re-applies pending merchant options once superposition defaults resolve, in case they arrive after initial config load.
- Shared-codebase PR: https://github.com/juspay/hyperswitch-sdk-utils/pull/94


## How did you test it?

- Added an override based on OMP for `"checkout_sdk.layout.type": "accordion"`. Since the default was `"tabs"`, observed a change in appearance. (Local instance testing)

- [PENDING] testing on deployed BE instance with `checkout_sdk` configs whitelisted in `raw_configs` of `/sdk/configs` api.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
